### PR TITLE
Rename package to `@jupyterlite/cockle`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
 Copyright (c) 2024, Ian Thomas.
+Copyright (c) 2024, JupyterLite Contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@ianthomas23/cockle",
+  "name": "@jupyterlite/cockle",
   "version": "0.0.2",
   "description": "In browser bash-like shell",
-  "homepage": "https://github.com/ianthomas23/cockle",
+  "homepage": "https://github.com/jupyterlite/cockle",
   "license": "BSD-3-Clause",
   "author": "Ian Thomas",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ianthomas23/cockle.git"
+    "url": "git+https://github.com/jupyterlite/cockle.git"
   },
   "bugs": {
-    "url": "https://github.com/ianthomas23/cockle/issues"
+    "url": "https://github.com/jupyterlite/cockle/issues"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Follow-up to the move to the `jupyterlite` organization.