### PR TITLE
Add releaser workflows

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,30 @@
+name: Check Release
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["*"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Check Release
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
+        with:
+
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: jupyterlite_terminal-releaser-dist-${{ github.run_number }}
+          path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Upload Distributions
         uses: actions/upload-artifact@v4
         with:
-          name: jupyterlite_terminal-releaser-dist-${{ github.run_number }}
+          name: jupyterlite-terminal-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,13 @@
+name: Enforce PR label
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: enforce-triage-label
+        uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -1,0 +1,48 @@
+name: 'Step 1: Prep Release'
+on:
+  workflow_dispatch:
+    inputs:
+      version_spec:
+        description: 'New Version Specifier'
+        default: 'next'
+        required: false
+      branch:
+        description: 'The branch to target'
+        required: false
+      post_version_spec:
+        description: 'Post Version Specifier'
+        required: false
+      silent:
+        description: "Set a placeholder in the changelog and don't publish the release."
+        required: false
+        type: boolean
+      since:
+        description: 'Use PRs with activity since this date or git reference'
+        required: false
+      since_last_stable:
+        description: 'Use PRs with activity since the last stable git tag'
+        required: false
+        type: boolean
+jobs:
+  prep_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Prep Release
+        id: prep-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version_spec: ${{ github.event.inputs.version_spec }}
+          # silent: ${{ github.event.inputs.silent }}
+          post_version_spec: ${{ github.event.inputs.post_version_spec }}
+          branch: ${{ github.event.inputs.branch }}
+          since: ${{ github.event.inputs.since }}
+          since_last_stable: ${{ github.event.inputs.since_last_stable }}
+
+      - name: '** Next Step **'
+        run: |
+          echo "Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,58 @@
+name: 'Step 2: Publish Release'
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The target branch'
+        required: false
+      release_url:
+        description: 'The URL of the draft GitHub release'
+        required: false
+      steps_to_skip:
+        description: 'Comma separated list of steps to skip'
+        required: false
+
+jobs:
+  publish_release:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Populate Release
+        id: populate-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ github.event.inputs.branch }}
+          release_url: ${{ github.event.inputs.release_url }}
+          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
+
+      - name: Finalize Release
+        id: finalize-release
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          release_url: ${{ steps.populate-release.outputs.release_url }}
+
+      - name: '** Next Step **'
+        if: ${{ success() }}
+        run: |
+          echo "Verify the final release"
+          echo ${{ steps.finalize-release.outputs.release_url }}
+
+      - name: '** Failure Message **'
+        if: ${{ failure() }}
+        run: |
+          echo "Failed to Publish the Draft Release Url:"
+          echo ${{ steps.populate-release.outputs.release_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-dist/
+lib/
 node_modules/
 tsconfig.tsbuildinfo
 .coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+<!-- <START NEW CHANGELOG ENTRY> -->
+
+<!-- <END NEW CHANGELOG ENTRY> -->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# cockle
+
 In-browser bash-like shell implemented in TypeScript.
 
 Intended for use in [JupyterLite](https://github.com/jupyterlite/jupyterlite).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+# Releasing `cockle`
+
+## Automated Releases with `jupyter_releaser`
+
+The recommended way to make a release is to use
+[`jupyter_releaser`](https://jupyter-releaser.readthedocs.io/en/latest/get_started/making_release_from_repo.html).

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "typescript": "^5.4.5"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/jupyterlite/cockle/issues"
   },
   "files": [
-    "dist/",
+    "lib/",
     "src/**/*.ts"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepare": "npm install && npm run build",
+    "prepack": "npm run build",
     "test": "jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/jupyterlite/cockle/issues"
   },
   "files": [
-    "lib/",
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "src/**/*.ts"
   ],
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepare": "npm run build",
+    "prepare": "npm install && npm run build",
     "test": "jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "test": "jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepack": "npm run build",
+    "prepack": "npm install && npm run build",
     "test": "jest"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "preserveWatchOutput": true,
     "resolveJsonModule": true,
-    "outDir": "dist",
+    "outDir": "lib",
     "rootDir": "src",
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
To streamline the release of the package to `npm`, using the same process as other packages in the `jupyterlite` organization.

- [x] Add GitHub actions workflows
- [x] Add `enforce-label` workflow to make sure the categories are set and the changelog is correctly generated
- [x] Create the `release` environment with `APP_PRIVATE_KEY` and `APP_ID`
- [x] Add empty `CHANGELOG.md`
- [x] Add `RELEASE.md`