### PR TITLE
Fix empty listing

### DIFF
--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -28,9 +28,11 @@ export class LsCommand extends Command<LsOptions> {
 
     }
 
-    const width = context.env_number("COLUMNS")
-    const output = _toColumns(filenames, width)
-    await context.stdout.write(output)  // How to deal with newlines?
+    if (filenames.length > 0) {
+      const width = context.env_number("COLUMNS")
+      const output = _toColumns(filenames, width)
+      await context.stdout.write(output)  // How to deal with newlines?
+    }
     return 0
   }
 }

--- a/tests/commands/ls.test.ts
+++ b/tests/commands/ls.test.ts
@@ -1,8 +1,11 @@
+import { ContentsManagerMock } from "@jupyterlab/services/lib/testutils"
+
 import { file_system_setup } from "../file_system_setup"
 
 import { CommandRegistry } from "../../src/command_registry"
 import { Context } from "../../src/context"
 import { ConsoleOutput } from "../../src/io/console_output"
+import { JupyterFileSystem } from "../../src/jupyter_file_system"
 
 describe("ls command", () => {
   it.each(["jupyter"])
@@ -36,6 +39,22 @@ describe("ls command", () => {
     expect(exit_code).toBe(0)
 
     expect(spy).toHaveBeenCalledWith("file2\r\n")
+    spy.mockRestore()
+  })
+
+  it("should handle empty listing", async () => {
+    const fs = new JupyterFileSystem(new ContentsManagerMock())
+    const stdout = new ConsoleOutput()
+    const context = new Context([], fs, stdout)
+
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    const cmd = CommandRegistry.instance().create("ls")
+    expect(cmd).not.toBeNull()
+    const exit_code = await cmd!.run(context)
+    expect(exit_code).toBe(0)
+
+    expect(spy).toHaveBeenCalledTimes(0)
     spy.mockRestore()
   })
 })


### PR DESCRIPTION
Fix `ls` of empty directory returning nothing rather than showing an obscure `map` error.