### PR TITLE
Add storage of command history

### DIFF
--- a/src/commands/builtin_command_runner.ts
+++ b/src/commands/builtin_command_runner.ts
@@ -3,7 +3,7 @@ import { Context } from "../context"
 
 export class BuiltinCommandRunner implements ICommandRunner {
   names(): string[] {
-    return ["cd"]
+    return ["cd", "history"]
   }
 
   async run(cmdName: string, context: Context): Promise<void> {
@@ -11,7 +11,10 @@ export class BuiltinCommandRunner implements ICommandRunner {
       case "cd":
         this._cd(context)
         break
-    }
+      case "history":
+        await this._history(context)
+        break
+      }
   }
 
   private _cd(context: Context) {
@@ -37,5 +40,11 @@ export class BuiltinCommandRunner implements ICommandRunner {
     FS.chdir(path)
     context.environment.set("OLDPWD", oldPwd)
     context.environment.set("PWD", FS.cwd())
+  }
+
+  private async _history(context: Context) {
+    // TODO: support flags to clear, etc, history.
+    const { history, stdout } = context
+    await history.write(stdout)
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,5 @@
 import { Environment } from "./environment"
+import { History } from "./history"
 import { IFileSystem } from "./file_system"
 import { IInput, IOutput } from "./io"
 
@@ -10,16 +11,13 @@ export class Context {
     readonly args: string[],
     readonly fileSystem: IFileSystem,
     readonly mountpoint: string,
-    environment: Environment,
+    readonly environment: Environment,
+    readonly history: History,
     readonly stdin: IInput,
     readonly stdout: IOutput,
-  ) {
-    this.environment = environment
-  }
+  ) {}
 
   async flush(): Promise<void> {
     await this.stdout.flush()
   }
-
-  environment: Environment
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,55 @@
+import { IOutput } from "./io/output"
+
+/**
+ * Command history. Also maintains a current index in the history for scrolling through it.
+ */
+export class History {
+  add(command: string) {
+    this._current = null
+
+    if (!command.trim()) {
+      // Do nothing with command that is all whitespace.
+      return
+    }
+    if (this._history.length >= this._maxSize) {
+      this._history.shift()
+    }
+    this._history.push(command)
+  }
+
+  // Supports negative indexing from end.
+  at(index: number): string | null {
+    return this._history.at(index) ?? null
+  }
+
+  scrollCurrent(next: boolean): string | null {
+    if (next) {
+      this._current = (this._current === null) ? null : this._current+1
+    } else {
+      this._current = (this._current === null) ? this._history.length-1 : this._current-1
+    }
+
+    if (this._current !== null) {
+      if (this._current < 0) {
+        this._current = 0
+      } else if (this._current >= this._history.length) {
+        this._current = null
+      }
+    }
+
+    return this._current === null ? null : this.at(this._current)
+  }
+
+  async write(output: IOutput): Promise<void> {
+    for (let i = 0; i < this._history.length; i++) {
+      const index = String(i).padStart(5, ' ')
+      await output.write(`${index}  ${this._history[i]}\n`)
+    }
+  }
+
+  private _history: string[] = []
+  private _current: number | null = null
+
+  // Smnall number for debug purposes. Should probably get this from an env var.
+  private _maxSize: number = 5
+}

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -1,0 +1,49 @@
+import { shell_setup_empty } from "./shell_setup"
+
+// Not accessing the history object directly, here using the Shell.
+
+describe("history", () => {
+  it("should be stored", async () => {
+    const { shell, output } = await shell_setup_empty()
+
+    await shell._runCommands("cat")
+    await shell._runCommands("echo")
+    await shell._runCommands("ls")
+    output.clear()
+
+    await shell._runCommands("history")
+    expect(output.text).toEqual("    0  cat\r\n    1  echo\r\n    2  ls\r\n    3  history\r\n")
+  })
+
+  it("should limit storage to max size", async () => {
+    // TODO: Max size initially hard-coded as 5, will change to use env var.
+    const { shell, output } = await shell_setup_empty()
+
+    await shell._runCommands("cat")
+    await shell._runCommands("echo")
+    await shell._runCommands("ls")
+    await shell._runCommands("uname")
+    await shell._runCommands("uniq")
+    output.clear()
+
+    await shell._runCommands("history")
+    expect(output.text).toEqual(
+        "    0  echo\r\n    1  ls\r\n    2  uname\r\n    3  uniq\r\n    4  history\r\n")
+  })
+
+  it("should rerun previous command using !index syntax", async () => {
+    const { shell, output } = await shell_setup_empty()
+
+    await shell._runCommands("cat")
+    await shell._runCommands("echo hello")
+    await shell._runCommands("ls")
+    output.clear()
+
+    await shell._runCommands("!1")
+    expect(output.text).toEqual("hello\r\n")
+  })
+
+  // Need ! out of bounds
+
+  // Need up and down to be tested.
+})


### PR DESCRIPTION
This adds storage of command history with the following functionality:

- `history` command
- Use of `!` followed by number to rerun a command from the history
- Scrolling up and down in the history using up and down arrows