### PR TITLE
Support terminal handling of columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/services": "^7.1.6",
-        "@jupyterlite/contents": "^0.3.0"
+        "@jupyterlite/contents": "^0.4.0-beta.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.45.1",
@@ -50,30 +50,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
-      "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.9.tgz",
+      "integrity": "sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
-      "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
+      "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.24.7",
-        "@babel/helper-module-transforms": "^7.24.7",
-        "@babel/helpers": "^7.24.7",
-        "@babel/parser": "^7.24.7",
+        "@babel/generator": "^7.24.9",
+        "@babel/helper-compilation-targets": "^7.24.8",
+        "@babel/helper-module-transforms": "^7.24.9",
+        "@babel/helpers": "^7.24.8",
+        "@babel/parser": "^7.24.8",
         "@babel/template": "^7.24.7",
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/traverse": "^7.24.8",
+        "@babel/types": "^7.24.9",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -89,12 +89,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
-      "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+      "version": "7.24.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
+      "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.24.7",
+        "@babel/types": "^7.24.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -104,14 +104,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
-      "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
+      "integrity": "sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.24.8",
+        "@babel/helper-validator-option": "^7.24.8",
+        "browserslist": "^4.23.1",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-      "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz",
+      "integrity": "sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.24.7",
@@ -189,9 +189,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
-      "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -241,22 +241,22 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-      "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
-      "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
+      "integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
+      "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -552,19 +552,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
-      "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
+      "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
+        "@babel/generator": "^7.24.8",
         "@babel/helper-environment-visitor": "^7.24.7",
         "@babel/helper-function-name": "^7.24.7",
         "@babel/helper-hoist-variables": "^7.24.7",
         "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/parser": "^7.24.8",
+        "@babel/types": "^7.24.8",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -573,12 +573,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
+      "integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-string-parser": "^7.24.8",
         "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
@@ -928,9 +928,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -944,9 +944,9 @@
       }
     },
     "node_modules/@jupyter/ydoc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@jupyter/ydoc/-/ydoc-2.0.1.tgz",
-      "integrity": "sha512-HyJPi7dHEWqxBqfjU+QqY/ks5RpDPYFl8QtbBYQ56WRN6nOvI/QOnDUCTTRU9p+X38IDqM+Rym+SLVn0qLppzg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@jupyter/ydoc/-/ydoc-2.1.1.tgz",
+      "integrity": "sha512-NeEwqXQ2j1OyLq4uezeQmsMiI+Qo5k7dYIMqNByOM7dJp6sHeP0jQ96w7BEc9E4SmrxwcOT4cLvcJWJE8Xun4g==",
       "dependencies": {
         "@jupyterlab/nbformat": "^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0",
         "@lumino/coreutils": "^1.11.0 || ^2.0.0",
@@ -957,9 +957,9 @@
       }
     },
     "node_modules/@jupyterlab/coreutils": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-6.2.0.tgz",
-      "integrity": "sha512-utWs8ZPs3J5l+t1LVd/tRbw0kmSX/qMzelH98vmBLPEc+UNbNGiLOLsHLMq+nyAdNz8bZyXJKviUsLbc6tnT/Q==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-6.2.3.tgz",
+      "integrity": "sha512-tGABmtHpBxgRPBg66SbuN54aVmgYYmfFqUoTURBbhu8ifbzX4FXhzzq23At36+jspQam/9U/cFnqBNBh8d40pQ==",
       "dependencies": {
         "@lumino/coreutils": "^2.1.2",
         "@lumino/disposable": "^2.1.2",
@@ -970,23 +970,23 @@
       }
     },
     "node_modules/@jupyterlab/nbformat": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-4.2.0.tgz",
-      "integrity": "sha512-kHnF4+6BOIM4IPn6Mk5cXxoH/e+NLA1dvcTzA9u8a9btE8djZ8cbJ36gHmadus+FwXi77Egikt3JESniGihKag==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-4.2.3.tgz",
+      "integrity": "sha512-eNn5F4JGw6Gq8xB1AaJ29hKQFgDvcjv9KZQeSp9joCYvedmc0LHivELCO+GticUjN5Y0+qgS4ZvnOARAqcIyvQ==",
       "dependencies": {
         "@lumino/coreutils": "^2.1.2"
       }
     },
     "node_modules/@jupyterlab/services": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-7.2.0.tgz",
-      "integrity": "sha512-Kk7bjE83oADJ2qIZ8oma1HkwmnW6MecxBe8HXtd7aZSCh3IUeAIu3DnhYtq4+J/HH+mvc1n2e3+fmcr9+iIqrQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-7.2.3.tgz",
+      "integrity": "sha512-Szx0FQ9Lehf/yrMOqVL1E5ZXDL8T97VgQqjfDkZx9xrA0SR7Ib7dMb3/8JF+IzV7eX5ycxT8U+LvPTGj0MOE2w==",
       "dependencies": {
         "@jupyter/ydoc": "^2.0.1",
-        "@jupyterlab/coreutils": "^6.2.0",
-        "@jupyterlab/nbformat": "^4.2.0",
-        "@jupyterlab/settingregistry": "^4.2.0",
-        "@jupyterlab/statedb": "^4.2.0",
+        "@jupyterlab/coreutils": "^6.2.3",
+        "@jupyterlab/nbformat": "^4.2.3",
+        "@jupyterlab/settingregistry": "^4.2.3",
+        "@jupyterlab/statedb": "^4.2.3",
         "@lumino/coreutils": "^2.1.2",
         "@lumino/disposable": "^2.1.2",
         "@lumino/polling": "^2.1.2",
@@ -996,12 +996,12 @@
       }
     },
     "node_modules/@jupyterlab/settingregistry": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-4.2.0.tgz",
-      "integrity": "sha512-PNPiAeVOmZuapjjq6sfUOsAWH+bHy0oYy0yxSh4QT2C3quY9M9s+AGUu4+N1iUNeSpXKNWWARMOc3fUu4zZ1pw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-4.2.3.tgz",
+      "integrity": "sha512-f5rNTd7wk/fn1C0ylD0/jDmMVvxgYYqOfPktaOAeWckS4iQ44XcrqfPUWs8sg66JYBHBFXBD9OkUKiMteQZDZg==",
       "dependencies": {
-        "@jupyterlab/nbformat": "^4.2.0",
-        "@jupyterlab/statedb": "^4.2.0",
+        "@jupyterlab/nbformat": "^4.2.3",
+        "@jupyterlab/statedb": "^4.2.3",
         "@lumino/commands": "^2.3.0",
         "@lumino/coreutils": "^2.1.2",
         "@lumino/disposable": "^2.1.2",
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@jupyterlab/statedb": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-4.2.0.tgz",
-      "integrity": "sha512-F2j7ydYLVSpL58gp7C0FGJPmUI3hpYIXkGkgvEYhV3RuQA7ONeaeSE1CH7Hc8N7WMvs6S7X77TPHoRk/FdzDfg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-4.2.3.tgz",
+      "integrity": "sha512-fHWkhMdz3U5ZCJmxsze39UyJnVaMnbRrHIhKh5nvwAQdg2h4KCP1Yg/EKKbsfmKYMgwE8YA5tCU7OmBuiyzKyg==",
       "dependencies": {
         "@lumino/commands": "^2.3.0",
         "@lumino/coreutils": "^2.1.2",
@@ -1027,163 +1027,114 @@
       }
     },
     "node_modules/@jupyterlite/contents": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/contents/-/contents-0.3.0.tgz",
-      "integrity": "sha512-G75H/oG/3FLhBzWB7iQ/GG34OvscAfwYPLBcnd76zHxzmZ/oRuc5O5WHPlcMDHD8rozj6vMOJj+MKgdx1jInGA==",
+      "version": "0.4.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/contents/-/contents-0.4.0-beta.1.tgz",
+      "integrity": "sha512-x8Z8J3BX7bQD+kVoC4A6F7Sh7YKckNMuxlAxS04wCMRdsHVjJs/E6l366YhZ9/zSa7rQfNxL7aqpNjTQcJZyvw==",
       "dependencies": {
-        "@jupyterlab/nbformat": "~4.1.5",
-        "@jupyterlab/services": "~7.1.5",
-        "@jupyterlite/localforage": "^0.3.0",
+        "@jupyterlab/nbformat": "~4.2.2",
+        "@jupyterlab/services": "~7.2.2",
+        "@jupyterlite/localforage": "^0.4.0-beta.1",
         "@lumino/coreutils": "^2.1.2",
         "@types/emscripten": "^1.39.6",
         "localforage": "^1.9.0",
         "mime": "^3.0.0"
       }
     },
-    "node_modules/@jupyterlite/contents/node_modules/@jupyter/ydoc": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@jupyter/ydoc/-/ydoc-1.1.1.tgz",
-      "integrity": "sha512-fXx9CbUwUlXBsJo83tBQL3T0MgWT4YYz2ozcSFj0ymZSohAnI1uo7N9CPpVe4/nmc9uG1lFdlXC4XQBevi2jSA==",
-      "dependencies": {
-        "@jupyterlab/nbformat": "^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0",
-        "@lumino/coreutils": "^1.11.0 || ^2.0.0",
-        "@lumino/disposable": "^1.10.0 || ^2.0.0",
-        "@lumino/signaling": "^1.10.0 || ^2.0.0",
-        "y-protocols": "^1.0.5",
-        "yjs": "^13.5.40"
-      }
-    },
-    "node_modules/@jupyterlite/contents/node_modules/@jupyterlab/nbformat": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-4.1.8.tgz",
-      "integrity": "sha512-uwGLaiIEsSox6zZ9WIsHbKaPO4Yovrp9LW6NXSafFhHeNdEaVGJ05C4mZTDAXWGgV+EWEBx5U2PrGmsYiHRLlQ==",
-      "dependencies": {
-        "@lumino/coreutils": "^2.1.2"
-      }
-    },
-    "node_modules/@jupyterlite/contents/node_modules/@jupyterlab/services": {
-      "version": "7.1.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-7.1.8.tgz",
-      "integrity": "sha512-pecYo8oOKCuEl+qur1yrEVTuGF3vxKlRItY2ofmTfBiyHIh8ARcAzlC+Zh55mdsIUU2w2GMrhTlINF5bWC5qZw==",
-      "dependencies": {
-        "@jupyter/ydoc": "^1.1.1",
-        "@jupyterlab/coreutils": "^6.1.8",
-        "@jupyterlab/nbformat": "^4.1.8",
-        "@jupyterlab/settingregistry": "^4.1.8",
-        "@jupyterlab/statedb": "^4.1.8",
-        "@lumino/coreutils": "^2.1.2",
-        "@lumino/disposable": "^2.1.2",
-        "@lumino/polling": "^2.1.2",
-        "@lumino/properties": "^2.0.1",
-        "@lumino/signaling": "^2.1.2",
-        "ws": "^8.11.0"
-      }
-    },
     "node_modules/@jupyterlite/localforage": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/localforage/-/localforage-0.3.0.tgz",
-      "integrity": "sha512-L2wsnLAV2XarWcdMw6hSA94hDo5o8/ASo+s+sVufsPTznxUWMpDpljPjn2QlHjYgKVFicPhywYL+GV3h4T712Q==",
+      "version": "0.4.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/localforage/-/localforage-0.4.0-beta.1.tgz",
+      "integrity": "sha512-yioJFfYkRbGX18M3PzDDMUJctKA3hFg+8MQseCVUn8xFdvbe1hyMNYdR1mPzSyg/s4hMwo/IdAmAY++0CidkNQ==",
       "dependencies": {
-        "@jupyterlab/coreutils": "~6.1.5",
+        "@jupyterlab/coreutils": "~6.2.2",
         "@lumino/coreutils": "^2.1.2",
         "localforage": "^1.9.0",
         "localforage-memoryStorageDriver": "^0.9.2"
       }
     },
-    "node_modules/@jupyterlite/localforage/node_modules/@jupyterlab/coreutils": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-6.1.8.tgz",
-      "integrity": "sha512-DDPHr1qR+UuMs+/z5YMi2/2oQ3YbLrmYdv+zpbj5w1tbglB/fa0muw/xX6RpXzuDog1+z5fZmERQ5RUBtdAS/g==",
-      "dependencies": {
-        "@lumino/coreutils": "^2.1.2",
-        "@lumino/disposable": "^2.1.2",
-        "@lumino/signaling": "^2.1.2",
-        "minimist": "~1.2.0",
-        "path-browserify": "^1.0.0",
-        "url-parse": "~1.5.4"
-      }
-    },
     "node_modules/@lumino/algorithm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-2.0.1.tgz",
-      "integrity": "sha512-iA+uuvA7DeNFB0/cQpIWNgO1c6z4pOSigifjstLy+rxf1U5ZzxIq+xudnEuTbWgKSTviG02j4cKwCyx1PO6rzA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-2.0.2.tgz",
+      "integrity": "sha512-cI8yJ2+QK1yM5ZRU3Kuaw9fJ/64JEDZEwWWp7+U0cd/mvcZ44BGdJJ29w+tIet1QXxPAvnsUleWyQ5qm4qUouA=="
     },
     "node_modules/@lumino/commands": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-2.3.0.tgz",
-      "integrity": "sha512-qOF9p9W54IWjyXrbd9QKr0d5XIn5ZTh6PBFO4UBGvEJJPO477tDm0f36HUxMMRtdJvp5ArgTj5/Khd3L3BFayg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-2.3.1.tgz",
+      "integrity": "sha512-DpX1kkE4PhILpvK1T4ZnaFb6UP4+YTkdZifvN3nbiomD64O2CTd+wcWIBpZMgy6MMgbVgrE8dzHxHk1EsKxNxw==",
       "dependencies": {
-        "@lumino/algorithm": "^2.0.1",
-        "@lumino/coreutils": "^2.1.2",
-        "@lumino/disposable": "^2.1.2",
-        "@lumino/domutils": "^2.0.1",
-        "@lumino/keyboard": "^2.0.1",
-        "@lumino/signaling": "^2.1.2",
-        "@lumino/virtualdom": "^2.0.1"
+        "@lumino/algorithm": "^2.0.2",
+        "@lumino/coreutils": "^2.2.0",
+        "@lumino/disposable": "^2.1.3",
+        "@lumino/domutils": "^2.0.2",
+        "@lumino/keyboard": "^2.0.2",
+        "@lumino/signaling": "^2.1.3",
+        "@lumino/virtualdom": "^2.0.2"
       }
     },
     "node_modules/@lumino/coreutils": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-2.1.2.tgz",
-      "integrity": "sha512-vyz7WzchTO4HQ8iVAxvSUmb5o/8t3cz1vBo8V4ZIaPGada0Jx0xe3tKQ8bXp4pjHc+AEhMnkCnlUyVYMWbnj4A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-2.2.0.tgz",
+      "integrity": "sha512-x5wnQ/GjWBayJ6vXVaUi6+Q6ETDdcUiH9eSfpRZFbgMQyyM6pi6baKqJBK2CHkCc/YbAEl6ipApTgm3KOJ/I3g==",
+      "dependencies": {
+        "@lumino/algorithm": "^2.0.2"
+      }
     },
     "node_modules/@lumino/disposable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-2.1.2.tgz",
-      "integrity": "sha512-0qmB6zPt9+uj4SVMTfISn0wUOjYHahtKotwxDD5flfcscj2gsXaFCXO4Oqot1zcsZbg8uJmTUhEzAvFW0QhFNA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-2.1.3.tgz",
+      "integrity": "sha512-k5KXy/+T3UItiWHY4WwQawnsJnGo3aNtP5CTRKqo4+tbTNuhc3rTSvygJlNKIbEfIZXW2EWYnwfFDozkYx95eA==",
       "dependencies": {
-        "@lumino/signaling": "^2.1.2"
+        "@lumino/signaling": "^2.1.3"
       }
     },
     "node_modules/@lumino/domutils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-2.0.1.tgz",
-      "integrity": "sha512-tbcfhsdKH04AMjSgYAYGD2xE80YcjrqKnfMTeU2NHt4J294Hzxs1GvEmSMk5qJ3Bbgwx6Z4BbQ7apnFg8Gc6cA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-2.0.2.tgz",
+      "integrity": "sha512-2Kp6YHaMNI1rKB0PrALvOsZBHPy2EvVVAvJLWjlCm8MpWOVETjFp0MA9QpMubT9I76aKbaI5s1o1NJyZ8Y99pQ=="
     },
     "node_modules/@lumino/keyboard": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-2.0.1.tgz",
-      "integrity": "sha512-R2mrH9HCEcv/0MSAl7bEUbjCNOnhrg49nXZBEVckg//TEG+sdayCsyrbJNMPcZ07asIPKc6mq3v7DpAmDKqh+w=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-2.0.2.tgz",
+      "integrity": "sha512-icRUpvswDaFjqmAJNbQRb/aTu6Iugo6Y2oC08TiIwhQtLS9W+Ee9VofdqvbPSvCm6DkyP+DCWMuA3KXZ4V4g4g=="
     },
     "node_modules/@lumino/polling": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@lumino/polling/-/polling-2.1.2.tgz",
-      "integrity": "sha512-hv6MT7xuSrw2gW4VIoiz3L366ZdZz4oefht+7HIW/VUB6seSDp0kVyZ4P9P4I4s/LauuzPqru3eWr7QAsFZyGA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@lumino/polling/-/polling-2.1.3.tgz",
+      "integrity": "sha512-WEZk96ddK6eHEhdDkFUAAA40EOLit86QVbqQqnbPmhdGwFogek26Kq9b1U273LJeirv95zXCATOJAkjRyb7D+w==",
       "dependencies": {
-        "@lumino/coreutils": "^2.1.2",
-        "@lumino/disposable": "^2.1.2",
-        "@lumino/signaling": "^2.1.2"
+        "@lumino/coreutils": "^2.2.0",
+        "@lumino/disposable": "^2.1.3",
+        "@lumino/signaling": "^2.1.3"
       }
     },
     "node_modules/@lumino/properties": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-2.0.1.tgz",
-      "integrity": "sha512-RPtHrp8cQqMnTC915lOIdrmsbPDCC7PhPOZb2YY7/Jj6dEdwmGhoMthc2tBEYWoHP+tU/hVm8UR/mEQby22srQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-2.0.2.tgz",
+      "integrity": "sha512-b312oA3Bh97WFK8efXejYmC3DVJmvzJk72LQB7H3fXhfqS5jUWvL7MSnNmgcQvGzl9fIhDWDWjhtSTi0KGYYBg=="
     },
     "node_modules/@lumino/signaling": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-2.1.2.tgz",
-      "integrity": "sha512-KtwKxx+xXkLOX/BdSqtvnsqBTPKDIENFBKeYkMTxstQc3fHRmyTzmaVoeZES+pr1EUy3e8vM4pQFVQpb8VsDdA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-2.1.3.tgz",
+      "integrity": "sha512-9Wd4iMk8F1i6pYjy65bqKuPlzQMicyL9xy1/ccS20kovPcfD074waneL/7BVe+3M8i+fGa3x2qjbWrBzOdTdNw==",
       "dependencies": {
-        "@lumino/algorithm": "^2.0.1",
-        "@lumino/coreutils": "^2.1.2"
+        "@lumino/algorithm": "^2.0.2",
+        "@lumino/coreutils": "^2.2.0"
       }
     },
     "node_modules/@lumino/virtualdom": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-2.0.1.tgz",
-      "integrity": "sha512-WNM+uUZX7vORhlDRN9NmhEE04Tz1plDjtbwsX+i/51pQj2N2r7+gsVPY/gR4w+I5apmC3zG8/BojjJYIwi8ogA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-2.0.2.tgz",
+      "integrity": "sha512-HYZThOtZSoknjdXA102xpy5CiXtTFCVz45EXdWeYLx3NhuEwuAIX93QBBIhupalmtFlRg1yhdDNV40HxJ4kcXg==",
       "dependencies": {
-        "@lumino/algorithm": "^2.0.1"
+        "@lumino/algorithm": "^2.0.2"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
-      "integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.2.tgz",
+      "integrity": "sha512-JxG9eq92ET75EbVi3s+4sYbcG7q72ECeZNbdBlaMkGcNbiDQ4cAi8U2QP5oKkOx+1gpaiL1LDStmzCaEM1Z6fQ==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.45.1"
+        "playwright": "1.45.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1193,9 +1144,9 @@
       }
     },
     "node_modules/@rjsf/utils": {
-      "version": "5.18.3",
-      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.18.3.tgz",
-      "integrity": "sha512-0TzjAKAlqXSCneVnHhcL3gAr4DlIPgwzkFdNEI4A+LFjLFlECPah2o3RhEgvqJnUXFviDGF1dqhkxa/Pr59ajw==",
+      "version": "5.19.3",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.19.3.tgz",
+      "integrity": "sha512-1lG/uMMmnAJE48BHUl4laNY2W2j2gIR2LH4jsxeEMSuFloB06ZuUXLesD03Nz2zQjm66izNmnm5eAmAi3Pa1yQ==",
       "dependencies": {
         "json-schema-merge-allof": "^0.8.1",
         "jsonpointer": "^5.0.1",
@@ -1350,9 +1301,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1365,9 +1316,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.2.tgz",
-      "integrity": "sha512-Btgg89dAnqD4vV7R3hlwOxgqobUQKgx3MmrQRi0yYbs/P0ym8XozIAlkqVilPqHQwXs4e9Tf63rrCgl58BcO4w==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
+      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -1409,9 +1360,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1455,14 +1406,14 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1529,6 +1480,12 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "dev": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1672,9 +1629,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-      "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
+      "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
       "dev": true,
       "funding": [
         {
@@ -1691,10 +1648,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001629",
-        "electron-to-chromium": "^1.4.796",
+        "caniuse-lite": "^1.0.30001640",
+        "electron-to-chromium": "^1.4.820",
         "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.16"
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1749,9 +1706,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001639",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001639.tgz",
-      "integrity": "sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg==",
+      "version": "1.0.30001642",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001642.tgz",
+      "integrity": "sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==",
       "dev": true,
       "funding": [
         {
@@ -2072,10 +2029,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.816",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.816.tgz",
-      "integrity": "sha512-EKH5X5oqC6hLmiS7/vYtZHZFTNdhsYG5NVPRN6Yn0kQHNBlT59+xSM8HBy66P5fxWpKgZbPqb+diC64ng295Jw==",
+      "version": "1.4.828",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.828.tgz",
+      "integrity": "sha512-QOIJiWpQJDHAVO4P58pwb133Cwee0nbvy/MV1CwzZVGpkH1RX33N3vsaWRCpR6bF63AAq366neZrRTu7Qlsbbw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2246,6 +2218,11 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -2253,6 +2230,36 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -2692,6 +2699,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.1.tgz",
+      "integrity": "sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest": {
@@ -3699,9 +3724,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
-      "integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==",
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
+      "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
       "dev": true
     },
     "node_modules/once": {
@@ -3887,12 +3912,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
-      "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.2.tgz",
+      "integrity": "sha512-ReywF2t/0teRvNBpfIgh5e4wnrI/8Su8ssdo5XsQKpjxJj+jspm00jSoz9BTg91TT0c9HRjXO7LBNVrgYj9X0g==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.45.1"
+        "playwright-core": "1.45.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3905,9 +3930,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
-      "integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.2.tgz",
+      "integrity": "sha512-ha175tAWb0dTK0X4orvBIqi3jGEt701SMxMhyujxNrgd8K0Uy5wMSwwcQHtyB4om7INUkfndx02XnQ2p6dvLDw==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -3979,6 +4004,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4364,12 +4390,13 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.1.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.5.tgz",
-      "integrity": "sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==",
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.2.tgz",
+      "integrity": "sha512-sSW7OooaKT34AAngP6k1VS669a0HdLxkQZnlC7T76sckGCokXFnvJ3yRlQZGRTAoV5K19HfSgCiSwWOSIfcYlg==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
+        "ejs": "^3.0.0",
         "fast-json-stable-stringify": "2.x",
         "jest-util": "^29.0.0",
         "json5": "^2.2.3",
@@ -4444,9 +4471,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4472,9 +4499,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "dev": true,
       "funding": [
         {
@@ -4499,14 +4526,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-parse": {
@@ -4680,9 +4699,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4776,9 +4795,9 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.15",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.15.tgz",
-      "integrity": "sha512-moFv4uNYhp8BFxIk3AkpoAnnjts7gwdpiG8RtyFiKbMtxKCS0zVZ5wPaaGpwC3V2N/K8TK8MwtSI3+WO9CHWjQ==",
+      "version": "13.6.18",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.18.tgz",
+      "integrity": "sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==",
       "dependencies": {
         "lib0": "^0.2.86"
       },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^7.1.6",
-    "@jupyterlite/contents": "^0.3.0"
+    "@jupyterlite/contents": "^0.4.0-beta.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.45.1",

--- a/src/commands/coreutils_command_runner.ts
+++ b/src/commands/coreutils_command_runner.ts
@@ -7,7 +7,7 @@ export class CoreutilsCommandRunner extends WasmCommandRunner {
       "basename", "cat", "cp", "cut", "date", "dirname", "echo", "env", "expr", "head", "id",
       "join", "ln", "logname", "ls", "md5sum", "mkdir", "mv", "nl", "pwd", "realpath", "rm",
       "rmdir", "seq", "sha1sum", "sha224sum", "sha256sum", "sha384sum", "sha512sum", "sleep",
-      "sort", "stat", "tail", "touch", "tr", "uname", "uniq", "wc",
+      "sort", "stat", "stty", "tail", "touch", "tr", "tty", "uname", "uniq", "wc",
     ]
   }
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -29,8 +29,21 @@ export class Environment {
     }
   }
 
+  delete(key: string) {
+    this._env.delete(key)
+  }
+
   get(key: string): string | null {
     return this._env.get(key) ?? null
+  }
+
+  getNumber(key: string): number | null {
+    const str = this.get(key)
+    if (str === null) {
+      return null
+    }
+    const number = Number(str)
+    return isNaN(number) ? null : number
   }
 
   getPrompt(): string {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -100,8 +100,19 @@ export class Shell {
   }
 
   async setSize(rows: number, columns: number): Promise<void> {
-    //this._env.set("COLUMNS", columns.toString())
-    //this._env.set("LINES", rows.toString())
+    const { environment } = this
+
+    if (rows >= 1) {
+      environment.set("LINES", rows.toString())
+    } else {
+      environment.delete("LINES")
+    }
+
+    if (columns >= 1) {
+      environment.set("COLUMNS", columns.toString())
+    } else {
+      environment.delete("COLUMNS")
+    }
   }
 
   async start(): Promise<void> {

--- a/src/wasm/coreutils.js
+++ b/src/wasm/coreutils.js
@@ -5678,6 +5678,8 @@ var Module = (() => {
 
     Module['PROXYFS'] = PROXYFS;
 
+    Module['TTY'] = TTY;
+
     var calledRun;
 
     dependenciesFulfilled = function runCaller() {

--- a/src/wasm/grep.js
+++ b/src/wasm/grep.js
@@ -4576,6 +4576,7 @@ Module['FS_createPreloadedFile'] = FS.createPreloadedFile;
 Module['FS'] = FS;
 Module['ENV'] = ENV;
 Module['getEnvStrings'] = getEnvStrings;
+Module['TTY'] = TTY;
 var missingLibrarySymbols = [
   'writeI53ToI64',
   'writeI53ToI64Clamped',
@@ -4832,7 +4833,6 @@ var unexportedSymbols = [
   'FS_stdin_getChar_buffer',
   'FS_stdin_getChar',
   'MEMFS',
-  'TTY',
   'PIPEFS',
   'SOCKFS',
   'tempFixedLengthArray',

--- a/tests/commands/ls.test.ts
+++ b/tests/commands/ls.test.ts
@@ -16,4 +16,44 @@ describe("ls command", () => {
     await shell._runCommands("ls")
     expect(output.text).toEqual("")
   })
+
+  it("should vary with COLUMNS", async () => {
+    const { shell, output, FS } = await shell_setup_simple()
+    FS.writeFile("a", "")
+    FS.writeFile("bb", "")
+    FS.writeFile("ccc", "")
+    FS.writeFile("dddd", "")
+    FS.writeFile("eeeee", "")
+    FS.writeFile("ffffff", "")
+    FS.writeFile("ggggg", "")
+    FS.writeFile("hhhh", "")
+    FS.writeFile("iii", "")
+    FS.writeFile("jj", "")
+    FS.writeFile("k", "")
+
+    await shell.setSize(10, 50)
+    await shell._runCommands("ls")
+    expect(output.text).toEqual(
+      "a   ccc   dirA	 ffffff  file2	hhhh  jj\r\nb" +
+      "b  dddd  eeeee  file1	 ggggg	iii   k\r\n")
+    output.clear()
+
+    await shell.setSize(10, 40)
+    await shell._runCommands("ls")
+    expect(output.text).toEqual(
+      "a    dddd   ffffff  ggggg  jj\r\n" +
+      "bb   dirA   file1   hhhh   k\r\n" +
+      "ccc  eeeee  file2   iii\r\n")
+    output.clear()
+
+    await shell.setSize(10, 20)
+    await shell._runCommands("ls")
+    expect(output.text).toEqual(
+      "a     eeeee   hhhh\r\n" +
+      "bb    ffffff  iii\r\n" +
+      "ccc   file1   jj\r\n" +
+      "dddd  file2   k\r\n" +
+      "dirA  ggggg\r\n"
+    )
+  })
 })

--- a/tests/commands/stty.test.ts
+++ b/tests/commands/stty.test.ts
@@ -1,0 +1,15 @@
+import { shell_setup_empty } from "../shell_setup"
+
+describe("stty command", () => {
+  it("should return default size", async () => {
+    const { shell, output } = await shell_setup_empty()
+
+    await shell._runCommands("stty size")
+    expect(output.text).toEqual("24 80\r\n")
+    output.clear()
+
+    await shell.setSize(10, 43)
+    await shell._runCommands("stty size")
+    expect(output.text).toEqual("10 43\r\n")
+  })
+})

--- a/tests/commands/tty.test.ts
+++ b/tests/commands/tty.test.ts
@@ -1,0 +1,9 @@
+import { shell_setup_empty } from "../shell_setup"
+
+describe("tty command", () => {
+  it("should write to stdout", async () => {
+    const { shell, output } = await shell_setup_empty()
+    await shell._runCommands("tty")
+    expect(output.text).toEqual("/dev/tty\r\n")
+  })
+})

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -87,4 +87,23 @@ describe("Shell", () => {
       expect(output.text).toEqual("unk")
     })
   })
+
+  describe("setSize", () => {
+    it("should set env vars", async () => {
+      const { shell } = await shell_setup_empty()
+      const { environment } = shell
+
+      await shell.setSize(10, 44)
+      expect(environment.getNumber("LINES")).toEqual(10)
+      expect(environment.getNumber("COLUMNS")).toEqual(44)
+
+      await shell.setSize(0, 45)
+      expect(environment.getNumber("LINES")).toBeNull()
+      expect(environment.getNumber("COLUMNS")).toEqual(45)
+
+      await shell.setSize(14, -1)
+      expect(environment.getNumber("LINES")).toEqual(14)
+      expect(environment.getNumber("COLUMNS")).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
This PR adds support for correct terminal handling of number of columns, set using `Shell.setSize`. An example of a command that uses this is `ls`, which by default writes the file and directory list in a number of columns that fit in the terminal width.

The terminal size is stored as environment variables `LINES` and `COLUMNS`. These can be checked using the commands `env` or `stty size`.

In terms of implementation, if `stdin` is not specified when loading the JS/WASM command file then stdin is a valid TTY. To get this to work as we desire two functions are monkey-patched, one which returns the window size (otherwise hard-coded as 24x80) and the other is the `get_char` function by which we pass in stdin characters one at a time.

I have modified both `coreutils.js` and `grep.js` to export `TTY` as this is needed for the monkey-patching. This change will have to be repeated in the emscripten forge recipes.

There is no coloured terminal output yet.