### PR TITLE
History maxSize and ignore duplicates and leading whitespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1301,9 +1301,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -2045,9 +2045,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.828",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.828.tgz",
-      "integrity": "sha512-QOIJiWpQJDHAVO4P58pwb133Cwee0nbvy/MV1CwzZVGpkH1RX33N3vsaWRCpR6bF63AAq366neZrRTu7Qlsbbw==",
+      "version": "1.4.829",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.829.tgz",
+      "integrity": "sha512-5qp1N2POAfW0u1qGAxXEtz6P7bO1m6gpZr5hdf5ve6lxpLM7MpiM4jIPz7xcrNlClQMafbyUDDWjlIQZ1Mw0Rw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2649,9 +2649,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3207,9 +3207,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3572,9 +3572,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3697,9 +3697,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.17.tgz",
+      "integrity": "sha512-Ww6ZlOiEQfPfXM45v17oabk77Z7mg5bOt7AjDyzy7RjK9OrLrLC8dyZQoAPEOtFX9SaNf1Tdvr5gRJWdTJj7GA==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -4438,9 +4438,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"

--- a/src/history.ts
+++ b/src/history.ts
@@ -7,10 +7,13 @@ export class History {
   add(command: string) {
     this._current = null
 
-    if (!command.trim()) {
-      // Do nothing with command that is all whitespace.
+    if (!command.trim() ||
+        (this._ignoreInitialWhitespace && command.startsWith(" ")) ||
+        (this._ignoreDuplicates && command == this.at(-1))) {
+      // Do not store.
       return
     }
+
     if (this._history.length >= this._maxSize) {
       this._history.shift()
     }
@@ -20,6 +23,11 @@ export class History {
   // Supports negative indexing from end.
   at(index: number): string | null {
     return this._history.at(index) ?? null
+  }
+
+  clear() {
+    this._current = null
+    this._history = []
   }
 
   scrollCurrent(next: boolean): string | null {
@@ -40,6 +48,14 @@ export class History {
     return this._current === null ? null : this.at(this._current)
   }
 
+  setMaxSize(maxSize: number) {
+    this._maxSize = Math.max(maxSize, 0)
+    if (this._history.length > this._maxSize) {
+      this._current = null
+      this._history = this._history.slice(this._maxSize)
+    }
+  }
+
   async write(output: IOutput): Promise<void> {
     for (let i = 0; i < this._history.length; i++) {
       const index = String(i).padStart(5, ' ')
@@ -49,7 +65,7 @@ export class History {
 
   private _history: string[] = []
   private _current: number | null = null
-
-  // Smnall number for debug purposes. Should probably get this from an env var.
-  private _maxSize: number = 5
+  private _ignoreInitialWhitespace: boolean = true
+  private _ignoreDuplicates: boolean = true
+  private _maxSize: number = 1000
 }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -168,7 +168,7 @@ export class Shell {
     commandNode: CommandNode,
     input: IInput,
     output: IOutput,
-): Promise<void> {
+  ): Promise<void> {
     const name = commandNode.name.value
     const runner = CommandRegistry.instance().get(name)
     if (runner === null) {

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -1,7 +1,5 @@
 import { shell_setup_empty } from "./shell_setup"
 
-// Not accessing the history object directly, here using the Shell.
-
 describe("history", () => {
   it("should be stored", async () => {
     const { shell, output } = await shell_setup_empty()
@@ -16,8 +14,9 @@ describe("history", () => {
   })
 
   it("should limit storage to max size", async () => {
-    // TODO: Max size initially hard-coded as 5, will change to use env var.
     const { shell, output } = await shell_setup_empty()
+    const { history } = shell
+    history.setMaxSize(5)
 
     await shell._runCommands("cat")
     await shell._runCommands("echo")
@@ -31,7 +30,48 @@ describe("history", () => {
         "    0  echo\r\n    1  ls\r\n    2  uname\r\n    3  uniq\r\n    4  history\r\n")
   })
 
-  it("should rerun previous command using !index syntax", async () => {
+  it("should clip history when reduce max size", async () => {
+    const { shell, output } = await shell_setup_empty()
+    const { history } = shell
+    history.setMaxSize(5)
+
+    await shell._runCommands("cat")
+    await shell._runCommands("echo")
+    await shell._runCommands("ls")
+    await shell._runCommands("uname")
+    await shell._runCommands("uniq")
+    output.clear()
+
+    history.setMaxSize(3)
+
+    await shell._runCommands("history")
+    expect(output.text).toEqual("    0  uname\r\n    1  uniq\r\n    2  history\r\n")
+  })
+
+  it("should ignore duplicates", async () => {
+    const { shell, output } = await shell_setup_empty()
+
+    await shell._runCommands("cat")
+    await shell._runCommands("cat")
+    output.clear()
+
+    await shell._runCommands("history")
+    expect(output.text).toEqual(
+        "    0  cat\r\n    1  history\r\n")
+  })
+
+  it("should ignore commands starting with whitespace", async () => {
+    const { shell, output } = await shell_setup_empty()
+
+    await shell._runCommands(" ls")
+    output.clear()
+
+    await shell._runCommands("history")
+    expect(output.text).toEqual(
+        "    0  history\r\n")
+  })
+
+  it("should rerun previous command using !index syntax, negative and positive", async () => {
     const { shell, output } = await shell_setup_empty()
 
     await shell._runCommands("cat")
@@ -39,11 +79,58 @@ describe("history", () => {
     await shell._runCommands("ls")
     output.clear()
 
+    await shell._runCommands("!-2")
+    expect(output.text).toEqual("hello\r\n")
+    output.clear()
+
     await shell._runCommands("!1")
     expect(output.text).toEqual("hello\r\n")
   })
 
-  // Need ! out of bounds
+  it("should handle !index out of bounds", async () => {
+    const { shell, output } = await shell_setup_empty()
+    const { history } = shell
 
-  // Need up and down to be tested.
+    await shell._runCommands("ls")
+    output.clear()
+
+    await shell._runCommands("!1")
+    expect(output.text).toMatch(/!1: event not found/)
+  })
+
+  it("should scroll up and down", async () => {
+    const { shell, output } = await shell_setup_empty()
+
+    await shell._runCommands("cat")
+    await shell._runCommands("echo hello")
+    await shell._runCommands("ls")
+    output.clear()
+
+    const upArrow = "\x1B[A"
+    const downArrow = "\x1B[B"
+
+    await shell.input(upArrow)
+    await shell.input(upArrow)
+    expect(output.text).toMatch(/echo hello$/)
+    output.clear()
+
+    await shell.input(upArrow)
+    expect(output.text).toMatch(/cat$/)
+    output.clear()
+
+    await shell.input(upArrow)
+    expect(output.text).toMatch(/cat$/)
+    output.clear()
+
+    await shell.input(downArrow)
+    expect(output.text).toMatch(/echo hello$/)
+    output.clear()
+
+    await shell.input(downArrow)
+    expect(output.text).toMatch(/ls$/)
+    output.clear()
+
+    await shell.input(downArrow)
+    expect(output.text).toMatch(/ $/)
+  })
 })


### PR DESCRIPTION
Added more to shell history:

1. Programmatically set `maxSize` (will probably be env var eventually).
2. Ignore duplicate commands.
3. Ignore commands with leading whitespace.

And more comprehensive testing.