### PR TITLE
Add support for aliases

### DIFF
--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -7,7 +7,7 @@ export class Aliases extends Map<string, string> {
     this.set("dir", "dir --color=auto")
     this.set("grep", "grep --color=auto")
     this.set("ls", "ls --color=auto")
-    this.set("ll", "ls -F")
+    this.set("ll", "ls -lF")
     this.set("vdir", "vdir --color=auto")
   }
 
@@ -19,8 +19,9 @@ export class Aliases extends Map<string, string> {
         // Avoid infinite recursion.
         break
       }
+      const newAlias = this.get(newKey)
+      alias = (newAlias === undefined) ? newAlias : newAlias + alias!.slice(newKey.length)
       key = newKey
-      alias = this.get(key)
     }
     return alias
   }

--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -1,0 +1,33 @@
+/**
+ * Collection of aliases that are known to a shell.
+ */
+export class Aliases extends Map<string, string> {
+  constructor() {
+    super()
+    this.set("dir", "dir --color=auto")
+    this.set("grep", "grep --color=auto")
+    this.set("ls", "ls --color=auto")
+    this.set("ll", "ls -F")
+    this.set("vdir", "vdir --color=auto")
+  }
+
+  getRecursive(key: string): string | undefined {
+    let alias = this.get(key)
+    while (alias !== undefined) {
+      const newKey = alias.split(" ")[0]
+      if (newKey == key) {
+        // Avoid infinite recursion.
+        break
+      }
+      key = newKey
+      alias = this.get(key)
+    }
+    return alias
+  }
+
+  match(start: string): string[] {
+    return [...this.keys()].filter((name) => {
+      return name.startsWith(start)
+    })
+  }
+}

--- a/src/commands/builtin_command_runner.ts
+++ b/src/commands/builtin_command_runner.ts
@@ -3,11 +3,14 @@ import { Context } from "../context"
 
 export class BuiltinCommandRunner implements ICommandRunner {
   names(): string[] {
-    return ["cd", "history"]
+    return ["alias", "cd", "history"]
   }
 
   async run(cmdName: string, context: Context): Promise<void> {
     switch (cmdName) {
+      case "alias":
+        await this._alias(context)
+        break
       case "cd":
         this._cd(context)
         break
@@ -15,6 +18,14 @@ export class BuiltinCommandRunner implements ICommandRunner {
         await this._history(context)
         break
       }
+  }
+
+  private async _alias(context: Context) {
+    // TODO: support flags to clear, set, etc.
+    const { aliases, stdout } = context
+    for (const [key, value] of aliases.entries()) {
+      await stdout.write(`${key}='${value}'\n`)
+    }
   }
 
   private _cd(context: Context) {
@@ -29,7 +40,7 @@ export class BuiltinCommandRunner implements ICommandRunner {
     let path = args[0]
     if (path == "-") {
       const oldPwd = context.environment.get("OLDPWD")
-      if (oldPwd === null) {
+      if (oldPwd === undefined) {
         throw new Error("cd: OLDPWD not set")
       }
       path = oldPwd

--- a/src/commands/coreutils_command_runner.ts
+++ b/src/commands/coreutils_command_runner.ts
@@ -4,10 +4,10 @@ import { WasmCommandRunner } from "./wasm_command_runner"
 export class CoreutilsCommandRunner extends WasmCommandRunner {
   names(): string[] {
     return [
-      "basename", "cat", "cp", "cut", "date", "dirname", "echo", "env", "expr", "head", "id",
-      "join", "ln", "logname", "ls", "md5sum", "mkdir", "mv", "nl", "pwd", "realpath", "rm",
-      "rmdir", "seq", "sha1sum", "sha224sum", "sha256sum", "sha384sum", "sha512sum", "sleep",
-      "sort", "stat", "stty", "tail", "touch", "tr", "tty", "uname", "uniq", "wc",
+      "basename", "cat", "cp", "cut", "date", "dir", "dircolors", "dirname", "echo", "env", "expr",
+      "head", "id", "join", "ln", "logname", "ls", "md5sum", "mkdir", "mv", "nl", "pwd", "realpath",
+      "rm", "rmdir", "seq", "sha1sum", "sha224sum", "sha256sum", "sha384sum", "sha512sum", "sleep",
+      "sort", "stat", "stty", "tail", "touch", "tr", "tty", "uname", "uniq", "vdir", "wc",
     ]
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,3 +1,4 @@
+import { Aliases } from "./aliases"
 import { Environment } from "./environment"
 import { History } from "./history"
 import { IFileSystem } from "./file_system"
@@ -11,6 +12,7 @@ export class Context {
     readonly args: string[],
     readonly fileSystem: IFileSystem,
     readonly mountpoint: string,
+    readonly aliases: Aliases,
     readonly environment: Environment,
     readonly history: History,
     readonly stdin: IInput,

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -2,9 +2,10 @@
  * Collection of environment variables that are known to a shell and are passed in and out of
  * commands.
  */
-export class Environment {
+export class Environment extends Map<string, string> {
   constructor() {
-    this._env.set("PS1", "\x1b[1;31mjs-shell:$\x1b[1;0m ")  // red color
+    super()
+    this.set("PS1", "\x1b[1;31mjs-shell:$\x1b[1;0m ")  // red color
   }
 
   /**
@@ -15,7 +16,7 @@ export class Environment {
       const split = str.split("=")
       const key = split.shift()
       if (key && !this._ignore.has(key)) {
-        this._env.set(key, split.join("="))
+        this.set(key, split.join("="))
       }
     }
   }
@@ -24,17 +25,9 @@ export class Environment {
    * Copy environment variables into a command before it is run.
    */
   copyIntoCommand(target: { [key: string]: string }) {
-    for (const [key, value] of this._env.entries()) {
+    for (const [key, value] of this.entries()) {
       target[key] = value
     }
-  }
-
-  delete(key: string) {
-    this._env.delete(key)
-  }
-
-  get(key: string): string | null {
-    return this._env.get(key) ?? null
   }
 
   getNumber(key: string): number | null {
@@ -47,14 +40,8 @@ export class Environment {
   }
 
   getPrompt(): string {
-    return this._env.get("PS1") ?? "$ "
+    return this.get("PS1") ?? "$ "
   }
-
-  set(key: string, value: string) {
-    this._env.set(key, value)
-  }
-
-  private _env: Map<string, string> = new Map()
 
   // Keys to ignore when copying back from a command's env vars.
   private _ignore: Set<string> = new Set(["USER", "LOGNAME", "HOME", "LANG", "_"])

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { Aliases } from "./aliases"
 export { Context } from "./context"
 export { IFileSystem } from "./file_system"
 export { IOutputCallback } from "./output_callback"

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,3 +1,4 @@
+import { Aliases } from "./aliases"
 import { Token, tokenize } from "./tokenize"
 
 const endOfCommand = ";&"
@@ -26,8 +27,8 @@ export class RedirectNode extends Node {
 }
 
 
-export function parse(source: string): Node[] {
-  const tokens = tokenize(source)
+export function parse(source: string, aliases?: Aliases): Node[] {
+  const tokens = tokenize(source, aliases)
 
   const ret: Node[] = []
   const stack: CommandNode[] = []

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -1,3 +1,5 @@
+import { Aliases } from "./aliases"
+
 const delimiters = ";&|><"
 const whitespace = " "
 
@@ -7,43 +9,10 @@ export type Token = {
   value: string
 }
 
-export function tokenize(source: string): Token[] {
-  const tokens: Token[] = []
-
-  let offset: number = -1  // Offset of start of current token, -1 if not in token.
-  const n = source.length
-
-  let prevChar: string = ""
-  let prevCharType: CharType = CharType.None
-  for (let i = 0; i < n; i++) {
-    const char = source[i]
-    const charType = _getCharType(char)
-    if (offset >= 0) {  // In token.
-      if (charType == CharType.Whitespace) {
-        // Finish current token.
-        tokens.push({offset, value: source.slice(offset, i)})
-        offset = -1
-      } else if (charType != prevCharType || (charType == CharType.Delimiter && char != prevChar)) {
-        // Finish current token and start new one.
-        tokens.push({offset, value: source.slice(offset, i)})
-        offset = i
-      }
-    } else {  // Not in token.
-      if (charType != CharType.Whitespace) {
-        // Start new token.
-        offset = i
-      }
-    }
-    prevChar = char
-    prevCharType = charType
-  }
-
-  if (offset >= 0) {
-    // Finish last token.
-    tokens.push({offset, value: source.slice(offset, n)})
-  }
-
-  return tokens
+export function tokenize(source: string, aliases?: Aliases): Token[] {
+  const tokenizer = new Tokenizer(source, aliases)
+  tokenizer.run()
+  return tokenizer.tokens
 }
 
 enum CharType {
@@ -53,12 +22,99 @@ enum CharType {
   Other,
 }
 
-function _getCharType(char: string): CharType {
-  if (whitespace.includes(char)) {
-    return CharType.Whitespace
-  } else if (delimiters.includes(char)) {
-    return CharType.Delimiter
-  } else {
-    return CharType.Other
-  }
+class State {
+  prevChar: string = ""
+  prevCharType: CharType = CharType.None
+  index: number = -1  // Index into source string.
+  offset: number = -1  // Offset of start of current token, -1 if not in token.
+  aliasOffset: number = -1
 }
+
+class Tokenizer {
+  constructor(source: string, readonly aliases?: Aliases) {
+    this._source = source
+    this._tokens = []
+    this._state = new State()
+  }
+
+  run() {
+    while (this._state.index <= this._source.length) {
+      this._next()
+    }
+  }
+
+  get tokens(): Token[] {
+    return this._tokens
+  }
+
+  private _addToken(offset: number, value: string): boolean {
+    if (this.aliases !== undefined && offset != this._state.aliasOffset) {
+      const isCommand = (
+        this._tokens.length == 0 ||
+        ";&|".includes(this._tokens.at(-1)!.value.at(-1)!)
+      )
+
+      if (isCommand) {
+        const alias = this.aliases.getRecursive(value)
+        if (alias !== undefined) {
+          // Replace token with its alias and set state to beginning of it to re-tokenize.
+          const n = value.length
+          this._state.offset = -1
+          this._state.index = offset - 1
+          this._state.aliasOffset = offset  // Do not attempt to alias this token again.
+          this._source = this._source.slice(0, offset) + alias + this._source.slice(offset + n)
+          this._state.prevChar = ""
+          this._state.prevCharType = CharType.None
+          return false
+        }
+      }
+    }
+
+    this._tokens.push({ offset, value })
+    return true
+  }
+
+  private _getCharType(char: string): CharType {
+    if (whitespace.includes(char)) {
+      return CharType.Whitespace
+    } else if (delimiters.includes(char)) {
+      return CharType.Delimiter
+    } else {
+      return CharType.Other
+    }
+  }
+
+  private _next() {
+    const i = ++this._state.index
+
+    const char = i < this._source.length ? this._source[i] : " "
+    const charType = this._getCharType(char)
+    if (this._state.offset >= 0) {  // In token.
+      if (charType == CharType.Whitespace) {
+        // Finish current token.
+        if (this._addToken(this._state.offset, this._source.slice(this._state.offset, i))) {
+          this._state.offset = -1
+        }
+      } else if (charType != this._state.prevCharType ||
+                 (charType == CharType.Delimiter && char != this._state.prevChar)) {
+        // Finish current token and start new one.
+        if (this._addToken(this._state.offset, this._source.slice(this._state.offset, i))) {
+          this._state.offset = i
+        }
+      }
+    } else {  // Not in token.
+      if (charType != CharType.Whitespace) {
+        // Start new token.
+        this._state.offset = i
+      }
+    }
+    this._state.prevChar = char
+    this._state.prevCharType = charType
+  }
+
+  private _source: string
+  private _tokens: Token[]
+  private _state: State
+}
+
+

--- a/tests/aliases.test.ts
+++ b/tests/aliases.test.ts
@@ -31,7 +31,7 @@ describe("aliases", () => {
     it("should lookup ll", async () => {
       const { shell } = await shell_setup_empty()
       const { aliases } = shell
-      expect(aliases.getRecursive("ll")).toEqual("ls --color=auto")
+      expect(aliases.getRecursive("ll")).toEqual("ls --color=auto -lF")
     })
 
     it("should lookup grep", async () => {

--- a/tests/aliases.test.ts
+++ b/tests/aliases.test.ts
@@ -1,0 +1,57 @@
+import { shell_setup_empty } from "./shell_setup"
+
+describe("aliases", () => {
+  describe("get", () => {
+    it("should return alias string", async () => {
+      const { shell } = await shell_setup_empty()
+      const { aliases } = shell
+      expect(aliases.get("grep")).toEqual("grep --color=auto")
+    })
+
+    it("should return undefined for unknown key", async () => {
+      const { shell } = await shell_setup_empty()
+      const { aliases } = shell
+      expect(aliases.get("unknown")).toBeUndefined()
+    })
+  })
+
+  describe("getRecursive", () => {
+    it("should returned undefined for unknown key", async () => {
+      const { shell } = await shell_setup_empty()
+      const { aliases } = shell
+      expect(aliases.getRecursive("unknown")).toBeUndefined()
+    })
+
+    it("should lookup ls", async () => {
+      const { shell } = await shell_setup_empty()
+      const { aliases } = shell
+      expect(aliases.getRecursive("ls")).toEqual("ls --color=auto")
+    })
+
+    it("should lookup ll", async () => {
+      const { shell } = await shell_setup_empty()
+      const { aliases } = shell
+      expect(aliases.getRecursive("ll")).toEqual("ls --color=auto")
+    })
+
+    it("should lookup grep", async () => {
+      const { shell } = await shell_setup_empty()
+      const { aliases } = shell
+      expect(aliases.getRecursive("grep")).toEqual("grep --color=auto")
+    })
+  })
+
+  describe("match", () => {
+    it("should match multiple possibilities", async () => {
+      const { shell } = await shell_setup_empty()
+      const { aliases } = shell
+      expect(aliases.match("l")).toEqual(["ls", "ll"])
+    })
+
+    it("should match zero possibilities", async () => {
+      const { shell } = await shell_setup_empty()
+      const { aliases } = shell
+      expect(aliases.match("z")).toEqual([])
+    })
+  })
+})

--- a/tests/commands/alias.test.ts
+++ b/tests/commands/alias.test.ts
@@ -1,0 +1,16 @@
+import { shell_setup_empty } from "../shell_setup"
+
+describe("alias command", () => {
+  it("should write to stdout", async () => {
+    const { shell, output } = await shell_setup_empty()
+
+    await shell._runCommands("alias")
+    expect(output.text).toEqual(
+      "dir='dir --color=auto'\r\n" +
+      "grep='grep --color=auto'\r\n" +
+      "ls='ls --color=auto'\r\n" +
+      "ll='ls -F'\r\n" +
+      "vdir='vdir --color=auto'\r\n"
+    )
+  })
+})

--- a/tests/commands/alias.test.ts
+++ b/tests/commands/alias.test.ts
@@ -9,7 +9,7 @@ describe("alias command", () => {
       "dir='dir --color=auto'\r\n" +
       "grep='grep --color=auto'\r\n" +
       "ls='ls --color=auto'\r\n" +
-      "ll='ls -F'\r\n" +
+      "ll='ls -lF'\r\n" +
       "vdir='vdir --color=auto'\r\n"
     )
   })

--- a/tests/commands/cd.test.ts
+++ b/tests/commands/cd.test.ts
@@ -38,7 +38,7 @@ describe("cd command", () => {
     const { shell } = await shell_setup_simple()
     const { environment } = shell
 
-    expect(environment.get("OLDPWD")).toBeNull()
+    expect(environment.get("OLDPWD")).toBeUndefined()
     await shell._runCommands("cd dirA")
     expect(environment.get("PWD")).toEqual("/drive/dirA")
     expect(environment.get("OLDPWD")).toEqual("/drive")

--- a/tests/commands/env.test.ts
+++ b/tests/commands/env.test.ts
@@ -4,10 +4,10 @@ describe("env command", () => {
   it("should write to stdout", async () => {
     const { shell, output } = await shell_setup_simple()
     const { environment } = shell
-    expect(environment.get("MYENV")).toBeNull()
+    expect(environment.get("MYENV")).toBeUndefined()
 
     await shell._runCommands("env MYENV=23")
-    expect(environment.get("MYENV")).toBeNull()
+    expect(environment.get("MYENV")).toBeUndefined()
     expect(output.text.trim().split("\r\n").at(-1)).toEqual("MYENV=23")
   })
 })

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -88,10 +88,16 @@ describe("parse", () => {
   it("should use aliases", () => {
     const aliases = new Aliases()
     expect(parse("ll", aliases)).toEqual([
-      new CommandNode({offset: 0, value: "ls"}, [{offset: 3, value: "--color=auto"}])
+      new CommandNode(
+        {offset: 0, value: "ls"},
+        [{offset: 3, value: "--color=auto"}, {offset: 16, value: "-lF"}],
+      )
     ])
     expect(parse(" ll;", aliases)).toEqual([
-      new CommandNode({offset: 1, value: "ls"}, [{offset: 4, value: "--color=auto"}])
+      new CommandNode(
+        {offset: 1, value: "ls"},
+        [{offset: 4, value: "--color=auto"}, {offset: 17, value: "-lF"}],
+      )
     ])
   })
 })

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -1,3 +1,4 @@
+import { Aliases } from "../src/aliases"
 import { CommandNode, PipeNode, RedirectNode, parse } from "../src/parse"
 
 describe("parse", () => {
@@ -81,6 +82,16 @@ describe("parse", () => {
         {offset: 0, value: "wc"},
         [{offset: 3, value: "-l"}],
         [new RedirectNode({offset: 6, value: "<"}, {offset: 8, value: "file"})])
+    ])
+  })
+
+  it("should use aliases", () => {
+    const aliases = new Aliases()
+    expect(parse("ll", aliases)).toEqual([
+      new CommandNode({offset: 0, value: "ls"}, [{offset: 3, value: "--color=auto"}])
+    ])
+    expect(parse(" ll;", aliases)).toEqual([
+      new CommandNode({offset: 1, value: "ls"}, [{offset: 4, value: "--color=auto"}])
     ])
   })
 })

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -86,6 +86,12 @@ describe("Shell", () => {
       await shell.inputs(["u", "n", "k", "\t"])
       expect(output.text).toEqual("unk")
     })
+
+    it("should include aliases", async () => {
+      const { shell, output } = await shell_setup_empty()
+      await shell.inputs(["l", "\t"])
+      expect(output.text).toMatch(/^l\r\nln  logname  ls  ll/)
+    })
   })
 
   describe("setSize", () => {

--- a/tests/tokenize.test.ts
+++ b/tests/tokenize.test.ts
@@ -1,4 +1,4 @@
-import { tokenize } from "../src"
+import { Aliases, tokenize } from "../src"
 
 describe("Tokenize", () => {
   it("should support no tokens", () => {
@@ -87,6 +87,27 @@ describe("Tokenize", () => {
     expect(tokenize("wc -l < somefile")).toEqual([
       {offset: 0, value: "wc"}, {offset: 3, value: "-l"}, {offset: 6, value: "<"},
       {offset: 8, value: "somefile"},
+    ])
+  })
+
+  it("should use aliases", () => {
+    const aliases = new Aliases()
+    expect(tokenize("ll", aliases)).toEqual([
+      {offset: 0, value: "ls"}, {offset: 3, value: "--color=auto"},
+    ])
+    expect(tokenize("ll;", aliases)).toEqual([
+      {offset: 0, value: "ls"}, {offset: 3, value: "--color=auto"}, {offset: 15, value: ";"},
+    ])
+    expect(tokenize(" ll ", aliases)).toEqual([
+      {offset: 1, value: "ls"}, {offset: 4, value: "--color=auto"},
+    ])
+    expect(tokenize("cat; ll", aliases)).toEqual([
+      {offset: 0, value: "cat"}, {offset: 3, value: ";"}, {offset: 5, value: "ls"},
+      {offset: 8, value: "--color=auto"}
+    ])
+    expect(tokenize("ll; cat", aliases)).toEqual([
+      {offset: 0, value: "ls"}, {offset: 3, value: "--color=auto"}, {offset: 15, value: ";"},
+      {offset: 17, value: "cat"},
     ])
   })
 })

--- a/tests/tokenize.test.ts
+++ b/tests/tokenize.test.ts
@@ -93,21 +93,22 @@ describe("Tokenize", () => {
   it("should use aliases", () => {
     const aliases = new Aliases()
     expect(tokenize("ll", aliases)).toEqual([
-      {offset: 0, value: "ls"}, {offset: 3, value: "--color=auto"},
+      {offset: 0, value: "ls"}, {offset: 3, value: "--color=auto"}, {offset: 16, value: "-lF"}
     ])
     expect(tokenize("ll;", aliases)).toEqual([
-      {offset: 0, value: "ls"}, {offset: 3, value: "--color=auto"}, {offset: 15, value: ";"},
+      {offset: 0, value: "ls"}, {offset: 3, value: "--color=auto"}, {offset: 16, value: "-lF"},
+      {offset: 19, value: ";"},
     ])
     expect(tokenize(" ll ", aliases)).toEqual([
-      {offset: 1, value: "ls"}, {offset: 4, value: "--color=auto"},
+      {offset: 1, value: "ls"}, {offset: 4, value: "--color=auto"}, {offset: 17, value: "-lF"},
     ])
     expect(tokenize("cat; ll", aliases)).toEqual([
       {offset: 0, value: "cat"}, {offset: 3, value: ";"}, {offset: 5, value: "ls"},
-      {offset: 8, value: "--color=auto"}
+      {offset: 8, value: "--color=auto"}, {offset: 21, value: "-lF"},
     ])
     expect(tokenize("ll; cat", aliases)).toEqual([
-      {offset: 0, value: "ls"}, {offset: 3, value: "--color=auto"}, {offset: 15, value: ";"},
-      {offset: 17, value: "cat"},
+      {offset: 0, value: "ls"}, {offset: 3, value: "--color=auto"}, {offset: 16, value: "-lF"},
+      {offset: 19, value: ";"}, {offset: 21, value: "cat"},
     ])
   })
 })


### PR DESCRIPTION
Add initial support for aliases. It is not yet possible to set a new alias from a `Shell` as this will require parsing of quote-delimited strings, but there are hard-coded aliases in the `Aliases` constructor. The primary motivation here is to set some default use of colour in various commands for the upcoming coloured output PR.

The aliases work when running commands and for tab completion, and the `alias` command writes the current aliases to stdout.