### PR TITLE
Support coloured output for ls and grep commands

### DIFF
--- a/src/commands/coreutils_command_runner.ts
+++ b/src/commands/coreutils_command_runner.ts
@@ -4,10 +4,23 @@ import { WasmCommandRunner } from "./wasm_command_runner"
 export class CoreutilsCommandRunner extends WasmCommandRunner {
   names(): string[] {
     return [
-      "basename", "cat", "cp", "cut", "date", "dir", "dircolors", "dirname", "echo", "env", "expr",
-      "head", "id", "join", "ln", "logname", "ls", "md5sum", "mkdir", "mv", "nl", "pwd", "realpath",
-      "rm", "rmdir", "seq", "sha1sum", "sha224sum", "sha256sum", "sha384sum", "sha512sum", "sleep",
-      "sort", "stat", "stty", "tail", "touch", "tr", "tty", "uname", "uniq", "vdir", "wc",
+      "basename",
+      "cat", "chmod", "cp", "cut",
+      "date", "dir", "dircolors", "dirname",
+      "echo", "env", "expr",
+      "head",
+      "id",
+      "join",
+      "ln", "logname", "ls",
+      "md5sum", "mkdir", "mv",
+      "nl",
+      "pwd",
+      "realpath", "rm", "rmdir",
+      "seq", "sha1sum", "sha224sum", "sha256sum", "sha384sum", "sha512sum", "sleep", "sort", "stat", "stty",
+      "tail", "touch", "tr", "tty",
+      "uname", "uniq",
+      "vdir",
+      "wc",
     ]
   }
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -5,7 +5,8 @@
 export class Environment extends Map<string, string> {
   constructor() {
     super()
-    this.set("PS1", "\x1b[1;31mjs-shell:$\x1b[1;0m ")  // red color
+    this.set("PS1", "\x1b[1;32mjs-shell:$\x1b[1;0m ")
+    this.set("TERM", "xterm-256color")
   }
 
   /**

--- a/src/io/file_output.ts
+++ b/src/io/file_output.ts
@@ -19,7 +19,7 @@ export class FileOutput extends BufferedOutput {
       }
     }
 
-    FS.writeFile(this.path, content)
+    FS.writeFile(this.path, content, { mode: 0o664 })
     this.clear()
   }
 }

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -52,7 +52,7 @@ describe("Shell", () => {
     it("should echo input and run ls command after \\r", async () => {
       const { shell, output } = await shell_setup_simple()
       await shell.inputs(["l", "s", "\r"])
-      expect(output.text).toEqual("ls\r\ndirA  file1  file2\r\n\x1b[1;31mjs-shell:$\x1b[1;0m ")
+      expect(output.text).toMatch(/^ls\r\ndirA  file1  file2\r\n/)
     })
   })
 
@@ -78,7 +78,7 @@ describe("Shell", () => {
     it("should show tab completion options", async () => {
       const { shell, output } = await shell_setup_empty()
       await shell.inputs(["e", "\t"])
-      expect(output.text).toEqual("e\r\necho  env  expr\r\n\x1b[1;31mjs-shell:$\x1b[1;0m e")
+      expect(output.text).toMatch(/^e\r\necho  env  expr\r\n/)
     })
 
     it("should do nothing on unknown command", async () => {

--- a/tests/shell_setup.ts
+++ b/tests/shell_setup.ts
@@ -9,27 +9,33 @@ export interface IShellSetup {
   FS: any
 }
 
-export async function shell_setup_empty(): Promise<IShellSetup> {
-  return await _shell_setup_common(0)
+export async function shell_setup_empty(wantColor: boolean = false): Promise<IShellSetup> {
+  return await _shell_setup_common(wantColor, 0)
 }
 
-export async function shell_setup_simple(): Promise<IShellSetup> {
-  return await _shell_setup_common(1)
+export async function shell_setup_simple(wantColor: boolean = false): Promise<IShellSetup> {
+  return await _shell_setup_common(wantColor, 1)
 }
 
-async function _shell_setup_common(level: number): Promise<IShellSetup> {
+async function _shell_setup_common(wantColor: boolean, level: number): Promise<IShellSetup> {
   const output = new MockTerminalOutput(false)
   const shell = new Shell(output.callback)
   const fileSystem = await shell.initFilesystem()
   const { FS } = fileSystem
 
+  if (!wantColor) {
+    // TODO: disable color in the prompt.
+    const { environment } = shell
+    environment.delete("TERM")
+  }
+
   await shell.start()
   output.start()
 
   if (level > 0) {
-    FS.writeFile('file1', 'Contents of the file');
-    FS.writeFile('file2', 'Some other file\nSecond line');
-    FS.mkdir('dirA')
+    FS.writeFile('file1', 'Contents of the file', { mode: 0o664 });
+    FS.writeFile('file2', 'Some other file\nSecond line', { mode: 0o664 });
+    FS.mkdir('dirA', 0o775)
   }
 
   return { shell, output, fileSystem, FS }


### PR DESCRIPTION
Support coloured output for `ls` and `grep` commands. This is actually a surprisingly small change in the code just to set the `TERM` environment variable, now that aliases are set up to use colour in both `ls` and `grep` commands by default. It uses the default `ls` colours which can be checked using `dircolors --print-ls-colors`; these could be overridden by setting an `LS_COLORS` env var.

<img width="389" alt="Screenshot 2024-07-18 at 08 51 01" src="https://github.com/user-attachments/assets/6baf333b-db89-4de6-8805-dbf90ffe2f57">
