### PR TITLE
Improvements to command/alias tab completion

### DIFF
--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -9,8 +9,8 @@ export type Token = {
   value: string;
 };
 
-export function tokenize(source: string, aliases?: Aliases): Token[] {
-  const tokenizer = new Tokenizer(source, aliases);
+export function tokenize(source: string, throwErrors: boolean = true, aliases?: Aliases): Token[] {
+  const tokenizer = new Tokenizer(source, throwErrors, aliases);
   tokenizer.run();
   return tokenizer.tokens;
 }
@@ -27,6 +27,7 @@ enum CharType {
 class Tokenizer {
   constructor(
     source: string,
+    readonly throwErrors: boolean,
     readonly aliases?: Aliases
   ) {
     this._source = source;
@@ -38,8 +39,10 @@ class Tokenizer {
       this._next();
     }
 
-    if (this._endQuote !== '') {
-      throw new Error('Tokenize error, expected end quote ' + this._endQuote);
+    if (this.throwErrors) {
+      if (this._endQuote !== '') {
+        throw new Error('Tokenize error, expected end quote ' + this._endQuote);
+      }
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,57 @@
+/**
+ * Find the longest string that starts all of the supplied strings.
+ * startIndex is the index to start at, if you already know that the first startIndex characters
+ * are identical.
+ */
+export function longestStartsWith(strings: string[], startIndex: number = 0): string {
+  if (strings.length < 1) {
+    return '';
+  }
+  const minLength = Math.min(...strings.map(str => str.length));
+  const toMatch = strings[0];
+  let index = startIndex;
+  while (index < minLength && strings.every(str => str[index] === toMatch[index])) {
+    index++;
+  }
+  return toMatch.slice(0, index);
+}
+
+/**
+ * Arrange an array of strings into columns that fit within a columnWidth.
+ * Each column is the same width.
+ * Return an array of lines.
+ */
+export function toColumns(strings: string[], columnWidth: number): string[] {
+  if (strings.length < 1) {
+    return [];
+  }
+
+  if (columnWidth < 1) {
+    // If don't know number of columns, use a single line which will be too long.
+    return [strings.join('  ')];
+  }
+
+  const nstrings = strings.length;
+  const gap = 2;
+  const maxLength = Math.max(...strings.map(str => str.length));
+  const ncols = Math.min(Math.floor(columnWidth / (maxLength + gap)), nstrings);
+  const nrows = Math.ceil(nstrings / ncols);
+
+  const lines = [];
+  for (let row = 0; row < nrows; ++row) {
+    let line = '';
+    for (let col = 0; col < ncols; ++col) {
+      const index = col * nrows + row;
+      if (index >= nstrings) {
+        continue;
+      }
+      const str = strings[index];
+      line += str;
+      if (index + nrows < nstrings) {
+        line += ' '.repeat(maxLength + gap - str.length);
+      }
+    }
+    lines.push(line);
+  }
+  return lines;
+}

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -88,13 +88,13 @@ describe('parse', () => {
 
   it('should use aliases', () => {
     const aliases = new Aliases();
-    expect(parse('ll', aliases)).toEqual([
+    expect(parse('ll', true, aliases)).toEqual([
       new CommandNode({ offset: 0, value: 'ls' }, [
         { offset: 3, value: '--color=auto' },
         { offset: 16, value: '-lF' }
       ])
     ]);
-    expect(parse(' ll;', aliases)).toEqual([
+    expect(parse(' ll;', true, aliases)).toEqual([
       new CommandNode({ offset: 1, value: 'ls' }, [
         { offset: 4, value: '--color=auto' },
         { offset: 17, value: '-lF' }

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -76,7 +76,7 @@ describe('Shell', () => {
     });
   });
 
-  describe('input tab complete', () => {
+  describe('input tab complete commands', () => {
     it('should complete ec', async () => {
       const { shell, output } = await shell_setup_empty();
       await shell.inputs(['e', 'c', '\t']);
@@ -107,10 +107,32 @@ describe('Shell', () => {
       expect(output.text).toEqual('unk');
     });
 
+    it('should arrange in columns', async () => {
+      const { shell, output } = await shell_setup_empty();
+      await shell.setSize(40, 10);
+      await shell.inputs(['t', '\t']);
+      expect(output.text).toMatch(/^t\r\ntail\r\ntouch\r\ntr\r\ntty\r\n/);
+      output.clear();
+
+      await shell.setSize(40, 20);
+      await shell.inputs(['\t']);
+      expect(output.text).toMatch(/^\r\ntail   tr\r\ntouch  tty\r\n/);
+    });
+
+    it('should add common startsWith', async () => {
+      const { shell, output } = await shell_setup_empty();
+      await shell.inputs(['s', 'h', '\t']);
+      expect(output.text).toEqual('sha');
+      output.clear();
+
+      await shell.inputs(['\t']);
+      expect(output.text).toMatch(/sha1sum  sha224sum  sha256sum  sha384sum  sha512sum/);
+    });
+
     it('should include aliases', async () => {
       const { shell, output } = await shell_setup_empty();
       await shell.inputs(['l', '\t']);
-      expect(output.text).toMatch(/^l\r\nln  logname  ls  ll/);
+      expect(output.text).toMatch(/^l\r\nll  ln  logname  ls/);
     });
   });
 

--- a/tests/tokenize.test.ts
+++ b/tests/tokenize.test.ts
@@ -131,30 +131,30 @@ describe('Tokenize', () => {
 
   it('should use aliases', () => {
     const aliases = new Aliases();
-    expect(tokenize('ll', aliases)).toEqual([
+    expect(tokenize('ll', true, aliases)).toEqual([
       { offset: 0, value: 'ls' },
       { offset: 3, value: '--color=auto' },
       { offset: 16, value: '-lF' }
     ]);
-    expect(tokenize('ll;', aliases)).toEqual([
+    expect(tokenize('ll;', true, aliases)).toEqual([
       { offset: 0, value: 'ls' },
       { offset: 3, value: '--color=auto' },
       { offset: 16, value: '-lF' },
       { offset: 19, value: ';' }
     ]);
-    expect(tokenize(' ll ', aliases)).toEqual([
+    expect(tokenize(' ll ', true, aliases)).toEqual([
       { offset: 1, value: 'ls' },
       { offset: 4, value: '--color=auto' },
       { offset: 17, value: '-lF' }
     ]);
-    expect(tokenize('cat; ll', aliases)).toEqual([
+    expect(tokenize('cat; ll', true, aliases)).toEqual([
       { offset: 0, value: 'cat' },
       { offset: 3, value: ';' },
       { offset: 5, value: 'ls' },
       { offset: 8, value: '--color=auto' },
       { offset: 21, value: '-lF' }
     ]);
-    expect(tokenize('ll; cat', aliases)).toEqual([
+    expect(tokenize('ll; cat', true, aliases)).toEqual([
       { offset: 0, value: 'ls' },
       { offset: 3, value: '--color=auto' },
       { offset: 16, value: '-lF' },


### PR DESCRIPTION
We already had some tab completion of commands and aliases, this improves the situation with:

1. Parses the string from the command line to correctly identify if we are trying to complete a command or not, such as when following a pipe, etc.
2. Prints the possible matches in columns.
3. Prints all of the commands and aliases if you tab complete an empty string.
4. If all of the possible matches start with the same text that is longer than the entered command, updates the entered command to this start text.

Still need to add tab completion of filenames.