### PR TITLE
Use separate TerminalOutput for stderr

### DIFF
--- a/src/commands/builtin_command_runner.ts
+++ b/src/commands/builtin_command_runner.ts
@@ -12,7 +12,7 @@ export class BuiltinCommandRunner implements ICommandRunner {
         await this._alias(context);
         break;
       case 'cd':
-        this._cd(context);
+        await this._cd(context);
         break;
       case 'history':
         await this._history(context);
@@ -28,20 +28,22 @@ export class BuiltinCommandRunner implements ICommandRunner {
     }
   }
 
-  private _cd(context: Context) {
-    const { args } = context;
+  private async _cd(context: Context) {
+    const { args, stderr } = context;
     if (args.length < 1) {
       // Do nothing.
       return;
     } else if (args.length > 1) {
-      throw new Error('cd: too many arguments');
+      await stderr.write('cd: too many arguments\r\n');
+      return;
     }
 
     let path = args[0];
     if (path === '-') {
       const oldPwd = context.environment.get('OLDPWD');
       if (oldPwd === undefined) {
-        throw new Error('cd: OLDPWD not set');
+        await stderr.write('cd: OLDPWD not set\r\n');
+        return;
       }
       path = oldPwd;
     }

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -5,7 +5,7 @@ export abstract class WasmCommandRunner implements ICommandRunner {
   abstract names(): string[];
 
   async run(cmdName: string, context: Context): Promise<void> {
-    const { args, fileSystem, mountpoint, stdin, stdout } = context;
+    const { args, fileSystem, mountpoint, stdin, stdout, stderr } = context;
 
     const start = Date.now();
     if (!this._wasmModule) {
@@ -36,7 +36,7 @@ export abstract class WasmCommandRunner implements ICommandRunner {
       thisProgram: cmdName,
       noInitialRun: true,
       print: (text: string) => stdout.write(`${text}\n`),
-      printErr: (text: string) => stdout.write(`${text}\n`), // Should be stderr
+      printErr: (text: string) => stderr.write(`${text}\n`),
       preRun: (module: any) => {
         if (Object.prototype.hasOwnProperty.call(module, 'FS')) {
           // Use PROXYFS so that command sees the shared FS.

--- a/src/context.ts
+++ b/src/context.ts
@@ -16,10 +16,12 @@ export class Context {
     readonly environment: Environment,
     readonly history: History,
     readonly stdin: IInput,
-    readonly stdout: IOutput
+    readonly stdout: IOutput,
+    readonly stderr: IOutput
   ) {}
 
   async flush(): Promise<void> {
+    await this.stderr.flush();
     await this.stdout.flush();
   }
 }

--- a/src/io/terminal_output.ts
+++ b/src/io/terminal_output.ts
@@ -4,13 +4,16 @@ import { IOutputCallback } from '../callback';
 export class TerminalOutput extends BufferedOutput {
   // Needs to know if supports terminal escape codes.
 
-  constructor(outputCallback: IOutputCallback) {
+  constructor(
+    readonly outputCallback: IOutputCallback,
+    readonly prefix: string | null = null,
+    readonly suffix: string | null = null
+  ) {
     super();
-    this._outputCallback = outputCallback;
   }
 
   override async flush(): Promise<void> {
-    this.data.forEach(async line => await this._outputCallback(line));
+    this.data.forEach(async line => await this.outputCallback(line));
     this.clear();
   }
 
@@ -18,8 +21,12 @@ export class TerminalOutput extends BufferedOutput {
     if (text.endsWith('\n')) {
       text = text.slice(0, -1) + '\r\n';
     }
+    if (this.prefix !== null) {
+      text = this.prefix + text;
+    }
+    if (this.suffix !== null) {
+      text = text + this.suffix;
+    }
     await super.write(text);
   }
-
-  private _outputCallback: IOutputCallback;
 }


### PR DESCRIPTION
Use a separate `TerminalOutput` for stderr, and add the colour ANSI escape codes automatically.