### PR TITLE
Add export command

### DIFF
--- a/src/builtin/export_command.ts
+++ b/src/builtin/export_command.ts
@@ -1,0 +1,32 @@
+import { BuiltinCommand } from './builtin_command';
+import { TrailingStringsOption } from './option';
+import { Options } from './options';
+import { Context } from '../context';
+import { ExitCode } from '../exit_code';
+
+class ExportOptions extends Options {
+  trailingStrings = new TrailingStringsOption(0);
+}
+
+export class ExportCommand extends BuiltinCommand {
+  get name(): string {
+    return 'export';
+  }
+
+  protected async _run(context: Context): Promise<number> {
+    const { args, environment } = context;
+    const options = Options.fromArgs(args, ExportOptions);
+
+    if (options.trailingStrings.isSet) {
+      for (const name of options.trailingStrings.strings) {
+        const index = name.indexOf('=');
+        if (index > 0) {
+          const key = name.slice(0, index);
+          const value = name.slice(index + 1);
+          environment.set(key, value);
+        }
+      }
+    }
+    return ExitCode.SUCCESS;
+  }
+}

--- a/src/builtin/index.ts
+++ b/src/builtin/index.ts
@@ -3,4 +3,5 @@
 export * from './alias_command';
 export * from './builtin_command';
 export * from './cd_command';
+export * from './export_command';
 export * from './history_command';

--- a/src/command_registry.ts
+++ b/src/command_registry.ts
@@ -27,7 +27,7 @@ export class CommandRegistry {
   }
 
   match(start: string): string[] {
-    return [...this._map.keys()].filter(name => name.startsWith(start));
+    return [...this._map.keys()].filter(name => name.startsWith(start)).sort();
   }
 
   /**

--- a/test/tests/command/export.test.ts
+++ b/test/tests/command/export.test.ts
@@ -1,0 +1,25 @@
+import { expect } from '@playwright/test';
+import { shellRunSimpleN, test } from '../utils';
+
+test.describe('export command', () => {
+  test('should export to env', async ({ page }) => {
+    const output = await shellRunSimpleN(page, [
+      'env | grep SOME_NAME',
+      "export SOME_NAME='a b c'",
+      'env | grep SOME_NAME',
+      'export SOME_NAME=other23',
+      'env | grep SOME_NAME',
+      'export SOME_NAME=',
+      'env | grep SOME_NAME'
+    ]);
+    expect(output).toEqual([
+      '',
+      '',
+      'SOME_NAME=a b c\r\n',
+      '',
+      'SOME_NAME=other23\r\n',
+      '',
+      'SOME_NAME=\r\n'
+    ]);
+  });
+});

--- a/test/tests/command_registry.test.ts
+++ b/test/tests/command_registry.test.ts
@@ -27,6 +27,6 @@ test.describe('CommandRegistry', () => {
     });
     expect(output[0]).toEqual([]);
     expect(output[1]).toEqual(['echo']);
-    expect(output[2]).toEqual(['echo', 'env', 'expr']);
+    expect(output[2]).toEqual(['echo', 'env', 'export', 'expr']);
   });
 });

--- a/test/tests/shell.test.ts
+++ b/test/tests/shell.test.ts
@@ -140,7 +140,9 @@ test.describe('Shell', () => {
     });
 
     test('should show tab completion options', async ({ page }) => {
-      expect(await shellInputsSimple(page, ['e', '\t'])).toMatch(/^e\r\necho {2}env {2}expr\r\n/);
+      expect(await shellInputsSimple(page, ['e', '\t'])).toMatch(
+        /^e\r\necho {2}env {2}export {2}expr\r\n/
+      );
     });
 
     test('should do nothing on unknown command', async ({ page }) => {


### PR DESCRIPTION
Add `export` as a new built-in (TypeScript) command, so that it is possible to export new environment variables to the environment that is shared between all commands.

For example:
```bash
export SOME_NAME='some value'
```