### PR TITLE
Separate module for ANSI escape sequences

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -1,0 +1,19 @@
+/**
+ * ANSI escape sequences.
+ */
+
+const ESC = '\x1B[';
+
+export const ansi = {
+  cursorUp: (count = 1) => ESC + count + 'A',
+  cursorDown: (count = 1) => ESC + count + 'B',
+  cursorRight: (count = 1) => ESC + count + 'C',
+  cursorLeft: (count = 1) => ESC + count + 'D',
+
+  eraseEndLine: ESC + 'K',
+  eraseStartLine: ESC + '1K',
+
+  styleReset: ESC + '1;0m',
+  styleBoldRed: ESC + '1;31m',
+  styleBoldGreen: ESC + '1;32m'
+};

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,3 +1,5 @@
+import { ansi } from './ansi';
+
 /**
  * Collection of environment variables that are known to a shell and are passed in and out of
  * commands.
@@ -5,7 +7,7 @@
 export class Environment extends Map<string, string> {
   constructor() {
     super();
-    this.set('PS1', '\x1b[1;32mjs-shell:$\x1b[1;0m ');
+    this.set('PS1', ansi.styleBoldGreen + 'js-shell:' + ansi.styleReset + ' ');
     this.set('TERM', 'xterm-256color');
   }
 


### PR DESCRIPTION
Fixes #18.

This moves all ANSI escape sequences into their own module `ansi.ts` and gives them sensible names. Although the original plan was to use an external module for this, only a few codes are needed at this stage so this will suffice.