### PR TITLE
Support command-line editing

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -5,10 +5,10 @@
 const ESC = '\x1B[';
 
 export const ansi = {
-  cursorUp: (count = 1) => ESC + count + 'A',
-  cursorDown: (count = 1) => ESC + count + 'B',
-  cursorRight: (count = 1) => ESC + count + 'C',
-  cursorLeft: (count = 1) => ESC + count + 'D',
+  cursorUp: (count = 1) => (count > 0 ? ESC + count + 'A' : ''),
+  cursorDown: (count = 1) => (count > 0 ? ESC + count + 'B' : ''),
+  cursorRight: (count = 1) => (count > 0 ? ESC + count + 'C' : ''),
+  cursorLeft: (count = 1) => (count > 0 ? ESC + count + 'D' : ''),
 
   eraseEndLine: ESC + 'K',
   eraseStartLine: ESC + '1K',

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -29,6 +29,7 @@ export class Shell {
     this._enableBufferedStdinCallback = options.enableBufferedStdinCallback;
     this._stdinCallback = options.stdinCallback;
     this._currentLine = '';
+    this._cursorIndex = 0;
     this._aliases = new Aliases();
     this._environment = new Environment();
     this._history = new History();
@@ -55,20 +56,26 @@ export class Shell {
       await this.output('\r\n');
       const cmdText = this._currentLine.trimStart();
       this._currentLine = '';
+      this._cursorIndex = 0;
       await this._runCommands(cmdText);
       await this.output(this._environment.getPrompt());
     } else if (code === 127) {
       // Backspace
-      if (this._currentLine.length > 0) {
-        this._currentLine = this._currentLine.slice(0, -1);
-        await this.output(ansi.cursorLeft() + ansi.eraseEndLine);
+      if (this._cursorIndex > 0) {
+        const suffix = this._currentLine.slice(this._cursorIndex);
+        this._currentLine = this._currentLine.slice(0, this._cursorIndex - 1) + suffix;
+        this._cursorIndex--;
+        await this.output(
+          ansi.cursorLeft(1) + suffix + ansi.eraseEndLine + ansi.cursorLeft(suffix.length)
+        );
       }
     } else if (code === 9) {
       // Tab \t
-      await this._tabComplete(this._currentLine);
+      await this._tabComplete();
     } else if (code === 27) {
       // Escape following by 1+ more characters
       const remainder = char.slice(1);
+      console.log('Escape code', char);
       if (
         remainder === '[A' || // Up arrow
         remainder === '[1A' ||
@@ -77,14 +84,76 @@ export class Shell {
       ) {
         const cmdText = this._history.scrollCurrent(remainder.endsWith('B'));
         this._currentLine = cmdText !== null ? cmdText : '';
+        this._cursorIndex = this._currentLine.length;
         // Re-output whole line.
         this.output(ansi.eraseStartLine + `\r${this._environment.getPrompt()}${this._currentLine}`);
+      } else if (remainder === '[D' || remainder === '[1D') {
+        // Left arrow
+        if (this._cursorIndex > 0) {
+          this._cursorIndex--;
+          await this.output(ansi.cursorLeft());
+        }
+      } else if (remainder === '[C' || remainder === '[1C') {
+        // Right arrow
+        if (this._cursorIndex < this._currentLine.length) {
+          this._cursorIndex++;
+          await this.output(ansi.cursorRight());
+        }
+      } else if (remainder === '[3~') {
+        // Delete
+        if (this._cursorIndex < this._currentLine.length) {
+          const suffix = this._currentLine.slice(this._cursorIndex + 1);
+          this._currentLine = this._currentLine.slice(0, this._cursorIndex) + suffix;
+          await this.output(ansi.eraseEndLine + suffix + ansi.cursorLeft(suffix.length));
+        }
+      } else if (remainder === '[H' || remainder === '[1;2H') {
+        // Home
+        if (this._cursorIndex > 0) {
+          await this.output(ansi.cursorLeft(this._cursorIndex));
+          this._cursorIndex = 0;
+        }
+      } else if (remainder === '[F' || remainder === '[1;2F') {
+        // End
+        const { length } = this._currentLine;
+        if (this._cursorIndex < length) {
+          await this.output(ansi.cursorRight(length - this._cursorIndex));
+          this._cursorIndex = length;
+        }
+      } else if (remainder === '[1;2D' || remainder === '[1;5D') {
+        // Start of previous word
+        if (this._cursorIndex > 0) {
+          const index =
+            this._currentLine.slice(0, this._cursorIndex).trimEnd().lastIndexOf(' ') + 1;
+          this.output(ansi.cursorLeft(this._cursorIndex - index));
+          this._cursorIndex = index;
+        }
+      } else if (remainder === '[1;2C' || remainder === '[1;5C') {
+        // End of next word
+        const { length } = this._currentLine;
+        if (this._cursorIndex < length - 1) {
+          const end = this._currentLine.slice(this._cursorIndex);
+          const trimmed = end.trimStart();
+          const i = trimmed.indexOf(' ');
+          const index = i < 0 ? length : this._cursorIndex + end.length - trimmed.length + i;
+          this.output(ansi.cursorRight(index - this._cursorIndex));
+          this._cursorIndex = index;
+        }
       }
     } else if (code === 4) {
       // EOT, usually = Ctrl-D
     } else {
-      this._currentLine += char;
-      await this.output(char);
+      // Add char to command line at cursor position.
+      if (this._cursorIndex === this._currentLine.length) {
+        // Append char.
+        this._currentLine += char;
+        await this.output(char);
+      } else {
+        // Insert char.
+        const suffix = this._currentLine.slice(this._cursorIndex);
+        this._currentLine = this._currentLine.slice(0, this._cursorIndex) + char + suffix;
+        await this.output(ansi.eraseEndLine + char + suffix + ansi.cursorLeft(suffix.length));
+      }
+      this._cursorIndex++;
     }
   }
 
@@ -241,18 +310,19 @@ export class Shell {
     return exitCode;
   }
 
-  private async _tabComplete(text: string): Promise<void> {
+  private async _tabComplete(): Promise<void> {
+    const text = this._currentLine.slice(0, this._cursorIndex);
     if (text.endsWith(' ') && text.trim().length > 0) {
       return;
     }
 
+    const suffix = this._currentLine.slice(this._cursorIndex);
     const parsed = parse(text, false);
     const [lastToken, isCommand] =
       parsed.length > 0 ? parsed[parsed.length - 1].lastToken() : [null, true];
     let lookup = lastToken?.value ?? '';
 
     let possibles: string[] = [];
-    //let prefix = '';
     if (isCommand) {
       const commandMatches = CommandRegistry.instance().match(lookup);
       const aliasMatches = this._aliases.match(lookup);
@@ -301,30 +371,29 @@ export class Shell {
       }
     }
 
-    if (possibles.length === 0) {
-      return;
-    } else if (possibles.length === 1) {
+    if (possibles.length === 1) {
       let extra = possibles[0].slice(lookup.length);
       if (!extra.endsWith('/')) {
         extra += ' ';
       }
-      this._currentLine += extra;
-      await this.output(extra);
-      return;
-    }
-
-    // Multiple possibles.
-    const startsWith = longestStartsWith(possibles, lookup.length);
-    if (startsWith.length > lookup.length) {
-      // Complete up to the longest common startsWith.
-      const extra = startsWith.slice(lookup.length);
-      this._currentLine += extra;
-      await this.output(extra);
-    } else {
-      // Write all the possibles in columns across the terminal.
-      const lines = toColumns(possibles, this._environment.getNumber('COLUMNS') ?? 0);
-      const output = `\r\n${lines.join('\r\n')}\r\n${this._environment.getPrompt()}${this._currentLine}`;
-      await this.output(output);
+      this._currentLine = this._currentLine.slice(0, this._cursorIndex) + extra + suffix;
+      this._cursorIndex += extra.length;
+      await this.output(extra + suffix + ansi.cursorLeft(suffix.length));
+    } else if (possibles.length > 1) {
+      // Multiple possibles.
+      const startsWith = longestStartsWith(possibles, lookup.length);
+      if (startsWith.length > lookup.length) {
+        // Complete up to the longest common startsWith.
+        const extra = startsWith.slice(lookup.length);
+        this._currentLine = this._currentLine.slice(0, this._cursorIndex) + extra + suffix;
+        this._cursorIndex += extra.length;
+        await this.output(extra + suffix + ansi.cursorLeft(suffix.length));
+      } else {
+        // Write all the possibles in columns across the terminal.
+        const lines = toColumns(possibles, this._environment.getNumber('COLUMNS') ?? 0);
+        const output = `\r\n${lines.join('\r\n')}\r\n${this._environment.getPrompt()}${this._currentLine}`;
+        await this.output(output + ansi.cursorLeft(suffix.length));
+      }
     }
   }
 
@@ -333,6 +402,7 @@ export class Shell {
   private readonly _stdinCallback?: IStdinCallback;
 
   private _currentLine: string;
+  private _cursorIndex: number;
   private _aliases: Aliases;
   private _environment: Environment;
   private _history: History;


### PR DESCRIPTION
This adds support for editing within the input command line:

1. Left and right arrows to move cursor one character at a time.
2. Insert new character at cursor position rather that always at the end.
3. Delete at cursor position to accompany backspace which is already implemented.
4. Home and End to move cursor to start and end of command line.
5. Shift/alt left and right arrows to move back and forward a word (separated by whitespace) at a time.
6. Tab completion at the cursor location whilst keeping the remainder of the command line.

I have been a bit permissive about what keystrokes correspond to these, to ensure that this works on both of my test machines (linux and macos). In time we may need to tighten this up and make some OS-specific. This will need multi-platform testing, both manual and automated.