### PR TITLE
Add clear built-in command

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -9,7 +9,10 @@ export const ansi = {
   cursorDown: (count = 1) => (count > 0 ? ESC + count + 'B' : ''),
   cursorRight: (count = 1) => (count > 0 ? ESC + count + 'C' : ''),
   cursorLeft: (count = 1) => (count > 0 ? ESC + count + 'D' : ''),
+  cursorHome: ESC + 'H',
 
+  eraseScreen: ESC + '2J',
+  eraseSavedLines: ESC + '3J',
   eraseEndLine: ESC + 'K',
   eraseStartLine: ESC + '1K',
 

--- a/src/builtin/clear_command.ts
+++ b/src/builtin/clear_command.ts
@@ -1,0 +1,18 @@
+import { BuiltinCommand } from './builtin_command';
+import { ansi } from '../ansi';
+import { Context } from '../context';
+import { ExitCode } from '../exit_code';
+
+export class ClearCommand extends BuiltinCommand {
+  get name(): string {
+    return 'clear';
+  }
+
+  protected async _run(context: Context): Promise<number> {
+    const { stdout } = context;
+    if (stdout.supportsAnsiEscapes()) {
+      await stdout.write(ansi.eraseScreen + ansi.eraseSavedLines + ansi.cursorHome);
+    }
+    return ExitCode.SUCCESS;
+  }
+}

--- a/src/builtin/index.ts
+++ b/src/builtin/index.ts
@@ -3,5 +3,6 @@
 export * from './alias_command';
 export * from './builtin_command';
 export * from './cd_command';
+export * from './clear_command';
 export * from './export_command';
 export * from './history_command';

--- a/src/io/buffered_output.ts
+++ b/src/io/buffered_output.ts
@@ -11,6 +11,10 @@ export abstract class BufferedOutput implements IOutput {
 
   abstract flush(): Promise<void>;
 
+  supportsAnsiEscapes(): boolean {
+    return false;
+  }
+
   async write(text: string): Promise<void> {
     this.data.push(text);
   }

--- a/src/io/console_output.ts
+++ b/src/io/console_output.ts
@@ -3,6 +3,10 @@ import { IOutput } from './output';
 export class ConsoleOutput implements IOutput {
   async flush(): Promise<void> {}
 
+  supportsAnsiEscapes(): boolean {
+    return false;
+  }
+
   async write(text: string): Promise<void> {
     console.log(text);
   }

--- a/src/io/output.ts
+++ b/src/io/output.ts
@@ -1,4 +1,5 @@
 export interface IOutput {
   flush(): Promise<void>;
+  supportsAnsiEscapes(): boolean;
   write(text: string): Promise<void>;
 }

--- a/src/io/terminal_output.ts
+++ b/src/io/terminal_output.ts
@@ -17,6 +17,10 @@ export class TerminalOutput extends BufferedOutput {
     this.clear();
   }
 
+  override supportsAnsiEscapes(): boolean {
+    return true;
+  }
+
   override async write(text: string): Promise<void> {
     if (text.endsWith('\n')) {
       text = text.slice(0, -1) + '\r\n';


### PR DESCRIPTION
Add `clear` built-in command. Does nothing if `stdout` does not support ANSI escape codes, i.e. is not a terminal.