### PR TITLE
Update releaser artifact name

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Upload Distributions
         uses: actions/upload-artifact@v4
         with:
-          name: jupyterlite-terminal-releaser-dist-${{ github.run_number }}
+          name: jupyterlite-cockle-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist


### PR DESCRIPTION
So it uses a name related to this repo, which is less confusing when downloading and extracting the artifact locally.