### PR TITLE
Load WASM/JS modules dynamically using importScripts

### DIFF
--- a/src/commands/coreutils_command_runner.ts
+++ b/src/commands/coreutils_command_runner.ts
@@ -1,7 +1,15 @@
-import * as CoreutilsModule from '../wasm/coreutils';
 import { WasmCommandRunner } from './wasm_command_runner';
+import { WasmLoader } from '../wasm_loader';
 
 export class CoreutilsCommandRunner extends WasmCommandRunner {
+  constructor(wasmLoader: WasmLoader) {
+    super(wasmLoader);
+  }
+
+  moduleName(): string {
+    return 'coreutils';
+  }
+
   names(): string[] {
     return [
       'basename',
@@ -49,9 +57,5 @@ export class CoreutilsCommandRunner extends WasmCommandRunner {
       'vdir',
       'wc'
     ];
-  }
-
-  protected _getWasmModule(): any {
-    return CoreutilsModule.default;
   }
 }

--- a/src/commands/grep_command_runner.ts
+++ b/src/commands/grep_command_runner.ts
@@ -1,12 +1,16 @@
-import * as GrepModule from '../wasm/grep';
 import { WasmCommandRunner } from './wasm_command_runner';
+import { WasmLoader } from '../wasm_loader';
 
 export class GrepCommandRunner extends WasmCommandRunner {
-  names(): string[] {
-    return ['grep'];
+  constructor(wasmLoader: WasmLoader) {
+    super(wasmLoader);
   }
 
-  protected _getWasmModule(): any {
-    return GrepModule.default;
+  moduleName(): string {
+    return 'grep';
+  }
+
+  names(): string[] {
+    return ['grep'];
   }
 }

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -5,6 +5,7 @@ import { ProxyMarked, Remote } from 'comlink';
 interface IOptionsCommon {
   color?: boolean;
   mountpoint?: string;
+  wasmBaseUrl?: string;
   driveFsBaseUrl?: string;
   // Initial directories and files to create, for testing purposes.
   initialDirectories?: string[];

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -17,10 +17,19 @@ export class Shell implements IShell {
     this._worker = new Worker(new URL('./shell_worker.js', import.meta.url), { type: 'module' });
 
     this._remote = wrap(this._worker);
-    const { color, mountpoint, driveFsBaseUrl, initialDirectories, initialFiles } = options;
+    const { color, mountpoint, wasmBaseUrl, driveFsBaseUrl, initialDirectories, initialFiles } =
+      options;
     const { sharedArrayBuffer } = this._bufferedStdin;
     await this._remote.initialize(
-      { color, mountpoint, driveFsBaseUrl, sharedArrayBuffer, initialDirectories, initialFiles },
+      {
+        color,
+        mountpoint,
+        wasmBaseUrl,
+        driveFsBaseUrl,
+        sharedArrayBuffer,
+        initialDirectories,
+        initialFiles
+      },
       proxy(options.outputCallback),
       proxy(this.enableBufferedStdinCallback.bind(this))
     );

--- a/src/shell_worker.ts
+++ b/src/shell_worker.ts
@@ -17,10 +17,12 @@ export class ShellWorker implements IShell {
     this._outputCallback = outputCallback;
     this._enableBufferedStdinCallback = enableBufferedStdinCallback;
 
-    const { color, mountpoint, driveFsBaseUrl, initialDirectories, initialFiles } = options;
+    const { color, mountpoint, wasmBaseUrl, driveFsBaseUrl, initialDirectories, initialFiles } =
+      options;
     this._shellImpl = new ShellImpl({
       color,
       mountpoint,
+      wasmBaseUrl,
       driveFsBaseUrl,
       initialDirectories,
       initialFiles,

--- a/src/wasm_loader.ts
+++ b/src/wasm_loader.ts
@@ -1,0 +1,25 @@
+/**
+ * Loader of WASM modules. Once loaded, a module is cached so that it is faster to subsequently.
+ * Must be run in a WebWorker.
+ */
+export class WasmLoader {
+  constructor(wasmBaseUrl?: string) {
+    this._wasmBaseUrl = wasmBaseUrl ?? '';
+  }
+
+  public getModule(name: string): any {
+    let module = this._cache.get(name);
+    if (module === undefined) {
+      // Maybe should use @jupyterlab/coreutils.URLExt to combine URL components.
+      const url = this._wasmBaseUrl + name + '.js';
+      console.log('Importing JS/WASM from ' + url);
+      importScripts(url);
+      module = (self as any).Module;
+      this._cache.set(name, module);
+    }
+    return module;
+  }
+
+  private _wasmBaseUrl: string;
+  private _cache = new Map<string, any>();
+}

--- a/test/package.json
+++ b/test/package.json
@@ -8,7 +8,8 @@
     "types": "lib/index.d.ts",
     "private": true,
     "scripts": {
-        "build": "rspack build",
+        "build": "npm run build:wasm && rspack build",
+        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.js assets",
         "serve": "rspack serve",
         "test": "playwright test",
         "test:ui": "playwright test --ui",

--- a/test/serve/index.ts
+++ b/test/serve/index.ts
@@ -10,8 +10,7 @@ async function setup() {
     tokenize
   };
 
-  // @ts-expect-error Assigning to globalThis.
-  globalThis.cockle = cockle;
+  (globalThis as any).cockle = cockle;
 }
 
 setup();

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -40,8 +40,7 @@ async function _shell_setup_common(options: IOptions, level: number): Promise<IS
 
   // Monkey patch an inputLine function to enter a sequence of characters and append a '\r'.
   // Cannot be used for multi-character ANSI escape codes.
-  // @ts-expect-error Function not in interface.
-  shell.inputLine = async (line: string) => {
+  (shell as any).inputLine = async (line: string) => {
     for (const char of line) {
       await shell.input(char);
     }


### PR DESCRIPTION
Up until now we have been importing the JavaScript-with-embedded-WebAssembly modules statically at build time just like any other TypeScript/JavaScript code. This PR changes this to dynamically import such code on demand using the WebWorker `importScripts` function. There are two benefits:

1. It will support (with a little more work) separate JS and WASM files. This will be in a follow-up PR.
2. It will be possible (with a larger amount of more work) to register the WASM commands available at runtime, probably when constructing a `Shell` object, to support arbitrary terminal functionality written by ourselves or any user.

To dynamically import such modules they have to be available at some URL. At this stage I have implemented a really simple solution to this in the test suite and cockle-playground (Jupyter terminal extension to follow) of copying the JS/WASM files from the cockle npm package into the webpack/rspack statically-served `assets` directory.

The imported JS/WASM modules are cached to make subsequent command calls faster. The first time `coreutils` is used it takes on my dev machine ~150 ms to import compared to the ~60 ms previously. But subsequent calls only take ~15 ms compared to the ~30 ms previously. `grep` is faster as it is a much smaller module with just a single command, taking ~60 ms to load the first time and <10 ms subsequently. If these times get worse and feel like they are too long then we can always pre-emptively warm up the cache at the start. Also note that the browser caches the JS/WASM files and if you have a copy of `coreutils` already cached in the browser it only takes ~60 ms to import the first time.