### PR TITLE
Support separate WASM/JS files and remove use of callMain

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
     "private": true,
     "scripts": {
         "build": "npm run build:wasm && rspack build",
-        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.{js,wasm} assets/",
+        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.js assets/ && cp node_modules/@jupyterlite/cockle/src/wasm/*.wasm assets/",
         "serve": "rspack serve"
     },
     "devDependencies": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
     "private": true,
     "scripts": {
         "build": "npm run build:wasm && rspack build",
-        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.js assets/",
+        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.{js,wasm} assets/",
         "serve": "rspack serve"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
         "url": "https://github.com/jupyterlite/cockle/issues"
     },
     "files": [
-        "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+        "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,wasm,woff2,ttf}",
         "src/**/*.ts"
     ],
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "scripts": {
         "fetch:wasm:create-env": "micromamba create -p $(pwd)/cockle_wasm_env -y cockle_fs grep coreutils --platform=emscripten-wasm32 -c https://repo.mamba.pm/emscripten-forge -c https://repo.mamba.pm/conda-forge",
-        "fetch:wasm:copy": "mkdir -p src/wasm && cp -r $(pwd)/cockle_wasm_env/bin/*.js src/wasm",
+        "fetch:wasm:copy": "mkdir -p src/wasm && cp -r $(pwd)/cockle_wasm_env/bin/*.{js,wasm} src/wasm/",
         "fetch:wasm": "npm run fetch:wasm:create-env && npm run fetch:wasm:copy",
         "build": "tsc",
         "eslint": "npm run eslint:check -- --fix",
@@ -53,6 +53,7 @@
         "dist",
         "coverage",
         "**/*.d.ts",
+        "**/*.wasm",
         "**/package-lock.json"
     ],
     "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "types": "lib/index.d.ts",
     "scripts": {
         "fetch:wasm:create-env": "micromamba create -p $(pwd)/cockle_wasm_env -y cockle_fs grep coreutils --platform=emscripten-wasm32 -c https://repo.mamba.pm/emscripten-forge -c https://repo.mamba.pm/conda-forge",
-        "fetch:wasm:copy": "mkdir -p src/wasm && cp -r $(pwd)/cockle_wasm_env/bin/*.{js,wasm} src/wasm/",
+        "fetch:wasm:copy": "mkdir -p src/wasm && cp $(pwd)/cockle_wasm_env/bin/*.js src/wasm/ && cp $(pwd)/cockle_wasm_env/bin/*.wasm src/wasm/",
         "fetch:wasm": "npm run fetch:wasm:create-env && npm run fetch:wasm:copy",
         "build": "tsc",
         "eslint": "npm run eslint:check -- --fix",

--- a/src/error_exit_code.ts
+++ b/src/error_exit_code.ts
@@ -26,9 +26,3 @@ export class ImproperUseError extends ErrorExitCode {
     super(ExitCode.IMPROPER_USE, message);
   }
 }
-
-export class RunCommandError extends ErrorExitCode {
-  constructor(commandName: string, message: string) {
-    super(ExitCode.CANNOT_RUN_COMMAND, `'${commandName}': ${message}`);
-  }
-}

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -69,7 +69,6 @@ export class ShellImpl implements IShell {
     } else if (code === 27) {
       // Escape following by 1+ more characters
       const remainder = char.slice(1);
-      console.log('Escape code', char);
       if (
         remainder === '[A' || // Up arrow
         remainder === '[1A' ||

--- a/test/package.json
+++ b/test/package.json
@@ -9,7 +9,7 @@
     "private": true,
     "scripts": {
         "build": "npm run build:wasm && rspack build",
-        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.js assets",
+        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.{js,wasm} assets/",
         "serve": "rspack serve",
         "test": "playwright test",
         "test:ui": "playwright test --ui",

--- a/test/package.json
+++ b/test/package.json
@@ -9,7 +9,7 @@
     "private": true,
     "scripts": {
         "build": "npm run build:wasm && rspack build",
-        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.{js,wasm} assets/",
+        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.js assets/ && cp node_modules/@jupyterlite/cockle/src/wasm/*.wasm assets/",
         "serve": "rspack serve",
         "test": "playwright test",
         "test:ui": "playwright test --ui",

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -2,10 +2,9 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   reporter: [['html', { open: 'never' }]],
   use: {
     baseURL: 'http://localhost:8000',

--- a/test/rspack.config.js
+++ b/test/rspack.config.js
@@ -17,7 +17,7 @@ module.exports = {
     ]
   },
   resolve: {
-    extensions: ['.tsx', '.ts', '.js']
+    extensions: ['.tsx', '.ts', '.js', '.wasm']
   },
   output: {
     filename: 'bundle.js',

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -34,6 +34,7 @@ async function _shell_setup_common(options: IOptions, level: number): Promise<IS
   const shell = new Shell({
     color: options.color ?? false,
     outputCallback: output.callback,
+    wasmBaseUrl: 'http://localhost:8000/',
     initialDirectories,
     initialFiles
   });


### PR DESCRIPTION

With the merging of emscripten-forge/recipes#1278 there are now the following packages on Emscripten-forge with separate JS and WASM files:

- `cockle_fs` build 2
- `coreutils` build 4
- `grep` build 4

This PR uses these new WASM files, most of the changes for this are trivial as the work has already been done and `importScripts` automagically works for the `.wasm` files provided they are served from the same directory as the `.js` files.

The other changes are to deal with not having to call `callMain` anymore, the calls happens automatically when a JS/WASM `Module` is instantiated.

I have changed the playwright test settings to run a single test at a time as without it there were some problems with multiple tests trying to load JS/WASM files at the same time. It is probably just my limited understanding of playwright, but as the tests only take ~15 seconds to run this is fine for now and can be revisited later.

After this I plan to release version 0.0.6 and bring the JupyterLite terminal extension up to date to use it. 