### PR TITLE
Pre-install micromamba in release actions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
+      - name: Install micromamba executable
+        uses: mamba-org/setup-micromamba@main
+
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:


### PR DESCRIPTION
Micromamba is needed in release actions to perform the `fetch:wasm` step.