### PR TITLE
Fix packaging of wasm files

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
     "private": true,
     "scripts": {
         "build": "npm run build:wasm && rspack build",
-        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.js assets/ && cp node_modules/@jupyterlite/cockle/src/wasm/*.wasm assets/",
+        "build:wasm": "cp node_modules/@jupyterlite/cockle/lib/wasm/*.js assets/ && cp node_modules/@jupyterlite/cockle/lib/wasm/*.wasm assets/",
         "serve": "rspack serve"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "fetch:wasm:create-env": "micromamba create -p $(pwd)/cockle_wasm_env -y cockle_fs grep coreutils --platform=emscripten-wasm32 -c https://repo.mamba.pm/emscripten-forge -c https://repo.mamba.pm/conda-forge",
         "fetch:wasm:copy": "mkdir -p src/wasm && cp $(pwd)/cockle_wasm_env/bin/*.js src/wasm/ && cp $(pwd)/cockle_wasm_env/bin/*.wasm src/wasm/",
         "fetch:wasm": "npm run fetch:wasm:create-env && npm run fetch:wasm:copy",
-        "build": "tsc",
+        "build": "tsc && cp src/wasm/*.wasm lib/wasm/",
         "eslint": "npm run eslint:check -- --fix",
         "eslint:check": "eslint . --cache --ext .ts,.tsx",
         "lint": "npm run prettier && npm run eslint",

--- a/test/package.json
+++ b/test/package.json
@@ -9,7 +9,7 @@
     "private": true,
     "scripts": {
         "build": "npm run build:wasm && rspack build",
-        "build:wasm": "cp node_modules/@jupyterlite/cockle/src/wasm/*.js assets/ && cp node_modules/@jupyterlite/cockle/src/wasm/*.wasm assets/",
+        "build:wasm": "cp node_modules/@jupyterlite/cockle/lib/wasm/*.js assets/ && cp node_modules/@jupyterlite/cockle/lib/wasm/*.wasm assets/",
         "serve": "rspack serve",
         "test": "playwright test",
         "test:ui": "playwright test --ui",


### PR DESCRIPTION
The just-released version 0.0.6 of cockle doesn't package the WASM files correctly, which is fixed by this PR. When packaging, WASM files are included only in the `lib` not `src` directory as we do not want to ship two copies of each of these potentially large files. This will affect downstream libraries as they will need to extract the WASM files from `lib` not `src`.