### PR TITLE
Support repeat use of BufferedStdin

### DIFF
--- a/src/shell_worker.ts
+++ b/src/shell_worker.ts
@@ -27,10 +27,26 @@ export class ShellWorker implements IShell {
       initialDirectories,
       initialFiles,
       outputCallback: this._outputCallback,
-      enableBufferedStdinCallback: this._enableBufferedStdinCallback!,
+      enableBufferedStdinCallback: this.enableBufferedStdin.bind(this),
       stdinCallback: this._bufferedStdin.get.bind(this._bufferedStdin)
     });
     await this._shellImpl.initialize();
+  }
+
+  async enableBufferedStdin(enable: boolean): Promise<void> {
+    // Enable/disable webworker's buffered stdin.
+    if (this._bufferedStdin) {
+      if (enable) {
+        await this._bufferedStdin.enable();
+      } else {
+        await this._bufferedStdin.disable();
+      }
+    }
+
+    // Enable/disable main worker's buffered stdin.
+    if (this._enableBufferedStdinCallback) {
+      this._enableBufferedStdinCallback(enable);
+    }
   }
 
   async input(char: string): Promise<void> {

--- a/test/serve/index.ts
+++ b/test/serve/index.ts
@@ -1,4 +1,5 @@
 import { Aliases, parse, tokenize } from '@jupyterlite/cockle';
+import { terminalInput } from './input_setup';
 import { shell_setup_empty, shell_setup_simple } from './shell_setup';
 
 async function setup() {
@@ -7,6 +8,7 @@ async function setup() {
     parse,
     shell_setup_empty,
     shell_setup_simple,
+    terminalInput,
     tokenize
   };
 

--- a/test/serve/input_setup.ts
+++ b/test/serve/input_setup.ts
@@ -9,7 +9,7 @@ import { Shell } from '@jupyterlite/cockle';
 export async function terminalInput(
   shell: Shell,
   chars: string[],
-  initialDelayMs: number = 10
+  initialDelayMs: number = 100
 ): Promise<void> {
   if (initialDelayMs > 0) {
     await new Promise(f => setTimeout(f, initialDelayMs));

--- a/test/serve/input_setup.ts
+++ b/test/serve/input_setup.ts
@@ -1,0 +1,21 @@
+import { Shell } from '@jupyterlite/cockle';
+
+/**
+ * Helper to provide terminal input whilst a command is running.
+ * Pass EOT (ASCII code 4) to finish.
+ * There is an optional delay in milliseconds to wait before starting the terminal input to allow
+ * the command to start.
+ */
+export async function terminalInput(
+  shell: Shell,
+  chars: string[],
+  initialDelayMs: number = 10
+): Promise<void> {
+  if (initialDelayMs > 0) {
+    await new Promise(f => setTimeout(f, initialDelayMs));
+  }
+
+  for (const char of chars) {
+    await shell.input(char);
+  }
+}


### PR DESCRIPTION
Support repeat use of `BufferedStdin`, fixes #48. The fix itself is quite simple, we weren't fully clearing the buffered stdin on the web worker side by calling `_clear()`.

Also included here is the testing framework to test use of buffered terminal stdin whilst a command is running. This runs two `async` tasks concurrently, the first is the command to run and the second is the terminal stdin to provide whilst the command is running. The latter starts with a short delay so that the command is actually running, otherwise the terminal stdin is just appended to the end of the command input string.

