### PR TITLE
Echo buffered stdin (whilst running a command) back to stdout

### DIFF
--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -19,8 +19,19 @@ export abstract class WasmCommandRunner implements ICommandRunner {
     // Functions for monkey-patching.
     function getChar(tty: any) {
       const utf16codes = stdin.readChar();
-      // What to do with length other than 1?
       const utf16 = utf16codes[0];
+
+      if (stdin.isTerminal()) {
+        if (utf16 === 10) {
+          context.stdout.write('\n');
+          context.stdout.flush();
+        } else if (utf16 > 31 && utf16 !== 127) {
+          context.stdout.write(String.fromCharCode(...utf16codes));
+          context.stdout.flush();
+        }
+      }
+
+      // What to do with length other than 1?
       if (utf16 === 4) {
         // EOT
         return null;

--- a/src/io/input.ts
+++ b/src/io/input.ts
@@ -1,4 +1,6 @@
 export interface IInput {
+  isTerminal(): boolean;
+
   /**
    * Read and return a single character as a sequence of ASCII character codes. Note this might be
    * more than one actual character such as \n or escape code for up arrow, etc. No further input is

--- a/src/io/input_all.ts
+++ b/src/io/input_all.ts
@@ -1,6 +1,10 @@
 import { IInput } from './input';
 
 export abstract class InputAll implements IInput {
+  isTerminal(): boolean {
+    return false;
+  }
+
   /**
    * Read and return the entire contents of this input. No special character is required to indicate
    * the end of the input, it is just the end of the string. Should only be called once per object.

--- a/src/io/terminal_input.ts
+++ b/src/io/terminal_input.ts
@@ -4,6 +4,10 @@ import { IStdinCallback } from '../callback';
 export class TerminalInput implements IInput {
   constructor(readonly stdinCallback?: IStdinCallback) {}
 
+  isTerminal(): boolean {
+    return true;
+  }
+
   readChar(): number[] {
     if (this._finished || this.stdinCallback === undefined) {
       return [4]; // EOT

--- a/test/tests/shell.test.ts
+++ b/test/tests/shell.test.ts
@@ -60,7 +60,7 @@ test.describe('Shell', () => {
         ]);
         return output.text;
       });
-      expect(output).toMatch(/^wc\r\n {6}1 {7}3 {7}5\r\n/);
+      expect(output).toMatch(/^wc\r\na b\r\nc {6}1 {7}3 {7}5\r\n/);
     });
 
     test('should support terminal stdin more than once', async ({ page }) => {
@@ -81,8 +81,8 @@ test.describe('Shell', () => {
         const ret1 = output.text;
         return [ret0, ret1];
       });
-      expect(output[0]).toMatch(/^wc\r\n {6}1 {7}3 {7}5\r\n/);
-      expect(output[1]).toMatch(/^wc\r\n {6}0 {7}2 {7}4\r\n/);
+      expect(output[0]).toMatch(/^wc\r\na b\r\nc {6}1 {7}3 {7}5\r\n/);
+      expect(output[1]).toMatch(/^wc\r\nde f {6}0 {7}2 {7}4\r\n/);
     });
 
     test('should support quotes', async ({ page }) => {


### PR DESCRIPTION
Whilst running a command that accepts stdin, such as `wc` or `cat` without any arguments, stdin should be echoed back to stdout a character at a time. This PR does this in the `getChar()` that is monkey-patched into the command's WASM wrapper. It only does so if stdout is the terminal, if it is a file for example then it is not echoed. Perhaps the code should alternatively go in `TerminalInput`, but then that would need access to the current `TerminalOutput` too.

It is not fully correct for the situation of `cat` accepting multiple lines of input, as here all the output is written at once at the end of the command. What should actually happen is that the command should write each line after it receives a carriage return. I think this occurs because the WASM commands are not set up to perform line buffering. There are a number of similar issues around input/output handling of the WASM commands that will be dealt with in due course.