### PR TITLE
Ignore touch bad file descriptor, but still have incorrect exit code

### DIFF
--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -53,7 +53,17 @@ export abstract class WasmCommandRunner implements ICommandRunner {
       thisProgram: cmdName,
       arguments: args,
       print: (text: string) => stdout.write(`${text}\n`),
-      printErr: (text: string) => stderr.write(`${text}\n`),
+      printErr: (text: string) => {
+        if (
+          cmdName === 'touch' &&
+          text === `touch: failed to close '${args[1]}': Bad file descriptor`
+        ) {
+          // Temporarily ignore bad file descriptor error in touch command until have proper fix.
+          // Command will still return an exit code of 1.
+          return;
+        }
+        stderr.write(`${text}\n`);
+      },
       quit: (moduleExitCode: number, toThrow: any) => {
         if (exitCode === undefined) {
           exitCode = moduleExitCode;

--- a/test/tests/command/touch.test.ts
+++ b/test/tests/command/touch.test.ts
@@ -1,0 +1,39 @@
+import { expect } from '@playwright/test';
+import { test } from '../utils';
+
+test.describe('touch command', () => {
+  test('should create file', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { shell, output } = await globalThis.cockle.shell_setup_empty();
+      await shell.inputLine('ls abc');
+      const ret = [output.text];
+
+      await shell.inputLine('touch abc');
+      output.clear();
+      await shell.inputLine('env | grep ^?=');
+      ret.push(output.text);
+      output.clear();
+
+      await shell.inputLine('ls abc');
+      ret.push(output.text);
+      output.clear();
+
+      await shell.inputLine('touch abc');
+      output.clear();
+      await shell.inputLine('env | grep ^?=');
+      ret.push(output.text);
+      output.clear();
+
+      await shell.inputLine('ls abc');
+      ret.push(output.text);
+      return ret;
+    });
+    expect(output[0]).toMatch("ls: cannot access 'abc': No such file or directory");
+    // Note exitCode is 1 when it should be 0, but we are expecting 1 due to bad file descriptor
+    // workaround. When that is fully fixed, change expected exitCode to be 0.
+    expect(output[1]).toMatch(/\r\n\?=1\r\n/);
+    expect(output[2]).toMatch(/^ls abc\r\nabc\r\n/);
+    expect(output[3]).toMatch(/\r\n\?=1\r\n/);
+    expect(output[4]).toMatch(/^ls abc\r\nabc\r\n/);
+  });
+});


### PR DESCRIPTION
Temporary workaround for issue #17 that filters out the error. The exit code is still incorrect. This will be fixed properly at a later date.