### PR TITLE
Remove @jupyterlab/services as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "0.0.7",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@jupyterlab/services": "^7.2.5",
                 "@jupyterlite/contents": "^0.4.1",
                 "comlink": "^4.4.1"
             },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "prettier:check": "prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml}\""
     },
     "dependencies": {
-        "@jupyterlab/services": "^7.2.5",
         "@jupyterlite/contents": "^0.4.1",
         "comlink": "^4.4.1"
     },


### PR DESCRIPTION
Remove `@jupyterlab/services` as a dependency. It hasn't been needed since we switched from using `Contents.IManager` to `DriveFS` for the filesystem integration with JupyterLite.