### PR TITLE
Prevent use of color in command output to file

### DIFF
--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -82,7 +82,7 @@ export abstract class WasmCommandRunner implements ICommandRunner {
 
         if (Object.prototype.hasOwnProperty.call(module, 'ENV')) {
           // Copy environment variables into command.
-          context.environment.copyIntoCommand(module.ENV);
+          context.environment.copyIntoCommand(module.ENV, stdout.supportsAnsiEscapes());
         }
 
         if (Object.prototype.hasOwnProperty.call(module, 'TTY')) {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -31,9 +31,11 @@ export class Environment extends Map<string, string> {
   /**
    * Copy environment variables into a command before it is run.
    */
-  copyIntoCommand(target: { [key: string]: string }) {
+  copyIntoCommand(target: { [key: string]: string }, supportsAnsiEscapes: boolean) {
     for (const [key, value] of this.entries()) {
-      target[key] = value;
+      if (supportsAnsiEscapes || key !== 'TERM') {
+        target[key] = value;
+      }
     }
   }
 

--- a/test/tests/shell.test.ts
+++ b/test/tests/shell.test.ts
@@ -40,6 +40,20 @@ test.describe('Shell', () => {
       expect(output[5]).toMatch('\r\n 2  2 14 out\r\n');
     });
 
+    test('should output redirect to file without ansi escapes', async ({ page }) => {
+      // grep to terminal is colored
+      const output_direct = await shellLineSimple(page, 'grep of file1', { color: true });
+      const start = '\x1B[01;31m\x1B[K';
+      const end = '\x1B[m\x1B[K';
+      expect(output_direct).toMatch(`\r\nContents ${start}of${end} the file\r\n`);
+
+      // grep to file is not colored
+      const output_file = await shellLineSimpleN(page, ['grep of file1 > output', 'cat output'], {
+        color: false
+      });
+      expect(output_file[1]).toMatch(/^cat output\r\nContents of the file\r\n/);
+    });
+
     test('should input redirect from file', async ({ page }) => {
       expect(await shellLineSimple(page, 'wc < file2')).toMatch('      1       5      27\r\n');
     });


### PR DESCRIPTION
When outputting commands that are colored, such as `grep`, to file, no color should be used. This is achieved here by not setting the `TERM` environment variable for the command.

Behaviour before this PR:
<img width="365" alt="Screenshot 2024-09-23 at 08 34 32" src="https://github.com/user-attachments/assets/6cddaab5-fad6-4ad7-9ad8-9ff391660512">

and after:
<img width="365" alt="Screenshot 2024-09-23 at 08 35 28" src="https://github.com/user-attachments/assets/6ab8b34e-0cca-4d3b-ac82-f317cb92def0">