### PR TITLE
Add new cockle-config command that prints cockle version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/package-lock.json
 *.wasm
 cockle_wasm_env/
 demo/package-lock.json
+src/version.ts

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
         "coverage",
         "**/*.d.ts",
         "**/*.wasm",
-        "**/package-lock.json"
+        "**/package-lock.json",
+        "src/version.ts"
     ],
     "eslintConfig": {
         "extends": [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "eslint:check": "eslint . --cache --ext .ts,.tsx",
         "lint": "npm run prettier && npm run eslint",
         "lint:check": "npm run prettier:check && npm run eslint:check",
+        "prebuild": "node -p \"'export const COCKLE_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
         "prepack": "npm install && npm run fetch:wasm && npm run build",
         "prettier": "prettier --list-different --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml}\"",
         "prettier:check": "prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml}\""

--- a/src/builtin/cockle_config_command.ts
+++ b/src/builtin/cockle_config_command.ts
@@ -1,0 +1,16 @@
+import { BuiltinCommand } from './builtin_command';
+import { Context } from '../context';
+import { ExitCode } from '../exit_code';
+import { COCKLE_VERSION } from '../version';
+
+export class CockleConfigCommand extends BuiltinCommand {
+  get name(): string {
+    return 'cockle-config';
+  }
+
+  protected async _run(context: Context): Promise<number> {
+    const { stdout } = context;
+    stdout.write(`cockle ${COCKLE_VERSION}\n`);
+    return ExitCode.SUCCESS;
+  }
+}

--- a/src/builtin/index.ts
+++ b/src/builtin/index.ts
@@ -4,5 +4,6 @@ export * from './alias_command';
 export * from './builtin_command';
 export * from './cd_command';
 export * from './clear_command';
+export * from './cockle_config_command';
 export * from './export_command';
 export * from './history_command';


### PR DESCRIPTION
Add a new `cockle-config` command that shows the cockle version being run. Eventually this will also include information about the commands available.