### PR TITLE
Validate JSON config files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@jupyterlite/contents": "^0.4.1",
-                "comlink": "^4.4.1"
+                "comlink": "^4.4.1",
+                "zod": "^3.23.8"
             },
             "devDependencies": {
                 "@rspack/cli": "^1.0.3",
@@ -1552,6 +1553,7 @@
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -6337,6 +6339,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.23.8",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     },
     "dependencies": {
         "@jupyterlite/contents": "^0.4.1",
-        "comlink": "^4.4.1"
+        "comlink": "^4.4.1",
+        "zod": "^3.23.8"
     },
     "devDependencies": {
         "@rspack/cli": "^1.0.3",


### PR DESCRIPTION
This adds validation of the cockle config JSON files introduced in #61. Schema validation uses [zod](https://github.com/colinhacks/zod) as it is small, and the validation occurs in the `postbuild` stage (i.e. `jupyter lite build`) rather than at runtime so there is no detrimental impact on speed or download size when a `Shell` is started.