### PR TITLE
Support filename expansion of * and ?

### DIFF
--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -203,7 +203,7 @@ export class ShellImpl implements IShellWorker {
   }
 
   _filenameExpansion(args: string[]): string[] {
-    let ret: string[] = []
+    let ret: string[] = [];
     let nFlags = 0;
 
     // ToDo:
@@ -254,12 +254,12 @@ export class ShellImpl implements IShellWorker {
       possibles = possibles.filter((path: string) => !path.startsWith('.'));
 
       if (relativePath.length > 0) {
-          possibles = possibles.map((path: string) => relativePath + '/' + path);
+        possibles = possibles.map((path: string) => relativePath + '/' + path);
       }
       ret = ret.concat(possibles);
     }
 
-    if (ret.length == nFlags) {
+    if (ret.length === nFlags) {
       // If no matches return initial arguments.
       ret = args;
     }

--- a/test/serve/index.ts
+++ b/test/serve/index.ts
@@ -1,11 +1,12 @@
 import { Aliases, parse, tokenize } from '@jupyterlite/cockle';
 import { terminalInput } from './input_setup';
-import { shell_setup_empty, shell_setup_simple } from './shell_setup';
+import { shell_setup_empty, shell_setup_complex, shell_setup_simple } from './shell_setup';
 
 async function setup() {
   const cockle = {
     Aliases,
     parse,
+    shell_setup_complex,
     shell_setup_empty,
     shell_setup_simple,
     terminalInput,

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -20,15 +20,39 @@ export async function shell_setup_simple(options: IOptions = {}): Promise<IShell
   return await _shell_setup_common(options, 1);
 }
 
+export async function shell_setup_complex(options: IOptions = {}): Promise<IShellSetup> {
+  return await _shell_setup_common(options, 2);
+}
+
 async function _shell_setup_common(options: IOptions, level: number): Promise<IShellSetup> {
   const output = new MockTerminalOutput(false);
 
   const initialDirectories = options.initialDirectories ?? [];
   const initialFiles = options.initialFiles ?? {};
-  if (level > 0) {
+  if (level === 1) {
+    // 📁 dirA
+    // 📄 file1
+    // 📄 file2
     initialDirectories.push('dirA');
     initialFiles['file1'] = 'Contents of the file';
     initialFiles['file2'] = 'Some other file\nSecond line';
+  } else if (level === 2) {
+    // 📄 file1.txt
+    // 📄 file2.txt
+    // 📄 otherfile
+    // 📁 dir
+    // ├── 📄 subfile.txt
+    // ├── 📄 subfile.md
+    // └── 📁 subdir
+    //     └── 📄 nestedfile
+    initialDirectories.push('dir');
+    initialDirectories.push('dir/subdir');
+    initialFiles['file1.txt'] = '';
+    initialFiles['file2.txt'] = '';
+    initialFiles['otherfile'] = '';
+    initialFiles['dir/subfile.txt'] = '';
+    initialFiles['dir/subfile.md'] = '';
+    initialFiles['dir/subdir/nestedfile'] = '';
   }
 
   const shell = new Shell({

--- a/test/tests/shell.test.ts
+++ b/test/tests/shell.test.ts
@@ -438,7 +438,9 @@ test.describe('Shell', () => {
 
     test('should include directory contents in match', async ({ page }) => {
       const output = await shellLineComplex(page, 'ls *');
-      expect(output).toMatch('\r\nfile1.txt  file2.txt  otherfile\r\n\r\ndir:\r\nsubdir	subfile.md  subfile.txt\r\n');
+      expect(output).toMatch(
+        '\r\nfile1.txt  file2.txt  otherfile\r\n\r\ndir:\r\nsubdir	subfile.md  subfile.txt\r\n'
+      );
     });
 
     test('should expand ? in pwd', async ({ page }) => {
@@ -458,11 +460,7 @@ test.describe('Shell', () => {
     });
 
     test('should match special characters', async ({ page }) => {
-      const output = await shellLineComplexN(page, [
-        'touch ab+c',
-        'ls a*',
-        'ls *+c',
-      ]);
+      const output = await shellLineComplexN(page, ['touch ab+c', 'ls a*', 'ls *+c']);
       expect(output[1]).toMatch('\r\nab+c\r\n');
       expect(output[2]).toMatch('\r\nab+c\r\n');
     });
@@ -470,7 +468,6 @@ test.describe('Shell', () => {
     test('should expand * in subdirectory', async ({ page }) => {
       const output0 = await shellLineComplex(page, 'ls dir/subf*');
       expect(output0).toMatch(/\r\ndir\/subfile\.md\s+dir\/subfile\.txt\r\n/);
-
     });
   });
 });

--- a/test/tests/shell.test.ts
+++ b/test/tests/shell.test.ts
@@ -2,6 +2,8 @@ import { expect } from '@playwright/test';
 import {
   shellInputsSimple,
   shellInputsSimpleN,
+  shellLineComplex,
+  shellLineComplexN,
   shellLineSimple,
   shellLineSimpleN,
   test
@@ -419,6 +421,56 @@ test.describe('Shell', () => {
       expect(output['isDisposed0']).toBeFalsy();
       expect(output['isDisposed1']).toBeTruthy();
       expect(output['signalled']).toBeTruthy();
+    });
+  });
+
+  test.describe('filename expansion', () => {
+    test('should expand * in pwd', async ({ page }) => {
+      const output0 = await shellLineComplex(page, 'ls file*');
+      expect(output0).toMatch('\r\nfile1.txt  file2.txt\r\n');
+
+      const output1 = await shellLineComplex(page, 'ls *file');
+      expect(output1).toMatch('\r\notherfile\r\n');
+
+      const output2 = await shellLineComplex(page, 'ls *file*');
+      expect(output2).toMatch('\r\nfile1.txt  file2.txt  otherfile\r\n');
+    });
+
+    test('should include directory contents in match', async ({ page }) => {
+      const output = await shellLineComplex(page, 'ls *');
+      expect(output).toMatch('\r\nfile1.txt  file2.txt  otherfile\r\n\r\ndir:\r\nsubdir	subfile.md  subfile.txt\r\n');
+    });
+
+    test('should expand ? in pwd', async ({ page }) => {
+      const output0 = await shellLineComplex(page, 'ls file?.txt');
+      expect(output0).toMatch('\r\nfile1.txt  file2.txt\r\n');
+
+      const output1 = await shellLineComplex(page, 'ls file2?txt');
+      expect(output1).toMatch('\r\nfile2.txt\r\n');
+    });
+
+    test('should use original pattern if no matches', async ({ page }) => {
+      const output0 = await shellLineComplex(page, 'ls z*');
+      expect(output0).toMatch("ls: cannot access 'z*': No such file or directory");
+
+      const output1 = await shellLineComplex(page, 'ls z?');
+      expect(output1).toMatch("ls: cannot access 'z?': No such file or directory");
+    });
+
+    test('should match special characters', async ({ page }) => {
+      const output = await shellLineComplexN(page, [
+        'touch ab+c',
+        'ls a*',
+        'ls *+c',
+      ]);
+      expect(output[1]).toMatch('\r\nab+c\r\n');
+      expect(output[2]).toMatch('\r\nab+c\r\n');
+    });
+
+    test('should expand * in subdirectory', async ({ page }) => {
+      const output0 = await shellLineComplex(page, 'ls dir/subf*');
+      expect(output0).toMatch(/\r\ndir\/subfile\.md\s+dir\/subfile\.txt\r\n/);
+
     });
   });
 });

--- a/test/tests/utils.ts
+++ b/test/tests/utils.ts
@@ -64,10 +64,38 @@ export async function shellLineSimpleN(
   );
 }
 
+export async function shellLineComplexN(
+  page: Page,
+  lines: string[],
+  options: IOptions = {}
+): Promise<string[]> {
+  return await page.evaluate(
+    async ({ lines, options }) => {
+      const { shell, output } = await globalThis.cockle.shell_setup_complex(options);
+      const ret: string[] = [];
+      for (const line of lines) {
+        await shell.inputLine(line);
+        ret.push(output.text);
+        output.clear();
+      }
+      return ret;
+    },
+    { lines, options }
+  );
+}
+
 export async function shellLineSimple(
   page: Page,
   line: string,
   options: IOptions = {}
 ): Promise<string> {
   return (await shellLineSimpleN(page, [line], options))[0];
+}
+
+export async function shellLineComplex(
+  page: Page,
+  line: string,
+  options: IOptions = {}
+): Promise<string> {
+  return (await shellLineComplexN(page, [line], options))[0];
 }


### PR DESCRIPTION
Add support for simple filename expansion of arguments to commands using `*` and `?`.

<img width="524" alt="Screenshot 2024-11-01 at 15 50 47" src="https://github.com/user-attachments/assets/75c533aa-f9f1-4e40-8201-f912e929a326">
