### PR TITLE
Separate external and internal defs

### DIFF
--- a/src/defs.ts
+++ b/src/defs.ts
@@ -1,70 +1,25 @@
 import { IObservableDisposable } from '@lumino/disposable';
 
-import {
-  IEnableBufferedStdinCallback,
-  IOutputCallback,
-  IStdinCallback,
-  ITerminateCallback
-} from './callback';
+import { IOutputCallback } from './callback';
 
-import { ProxyMarked, Remote } from 'comlink';
-
-interface IOptionsCommon {
-  color?: boolean;
-  mountpoint?: string;
-  wasmBaseUrl: string;
-  driveFsBaseUrl?: string;
-  // Initial directories and files to create, for testing purposes.
-  initialDirectories?: string[];
-  initialFiles?: IShell.IFiles;
-}
-
-export interface IShellCommon {
+export interface IShell extends IObservableDisposable {
   input(char: string): Promise<void>;
   setSize(rows: number, columns: number): Promise<void>;
   start(): Promise<void>;
 }
 
-export interface IShell extends IObservableDisposable, IShellCommon {}
-
 export namespace IShell {
-  export interface IOptions extends IOptionsCommon {
+  export interface IOptions {
+    color?: boolean;
+    mountpoint?: string;
+    wasmBaseUrl: string;
+    driveFsBaseUrl?: string;
+    // Initial directories and files to create, for testing purposes.
+    initialDirectories?: string[];
+    initialFiles?: IShell.IFiles;
+
     outputCallback: IOutputCallback;
   }
 
   export type IFiles = { [key: string]: string };
-}
-
-export interface IShellWorker extends IShellCommon {
-  // Handle any lazy initialization activities.
-  // Callback proxies need to be separate arguments, they cannot be in IOptions.
-  initialize(
-    options: IShellWorker.IOptions,
-    outputCallback: IShellWorker.IProxyOutputCallback,
-    enableBufferedStdinCallback: IShellWorker.IProxyEnableBufferedStdinCallback,
-    terminateCallback: IShellWorker.IProxyTerminateCallback
-  ): void;
-}
-
-export namespace IShellWorker {
-  export interface IProxyOutputCallback extends IOutputCallback, ProxyMarked {}
-  export interface IProxyEnableBufferedStdinCallback
-    extends IEnableBufferedStdinCallback,
-      ProxyMarked {}
-  export interface IProxyTerminateCallback extends ITerminateCallback, ProxyMarked {}
-
-  export interface IOptions extends IOptionsCommon {
-    sharedArrayBuffer: SharedArrayBuffer;
-  }
-}
-
-export type IRemoteShell = Remote<IShellWorker>;
-
-export namespace IShellImpl {
-  export interface IOptions extends IOptionsCommon {
-    outputCallback: IOutputCallback;
-    enableBufferedStdinCallback: IEnableBufferedStdinCallback;
-    stdinCallback: IStdinCallback;
-    terminateCallback: IShellWorker.IProxyTerminateCallback;
-  }
 }

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -1,0 +1,60 @@
+import {
+  IEnableBufferedStdinCallback,
+  IOutputCallback,
+  IStdinCallback,
+  ITerminateCallback
+} from './callback';
+
+import { IShell } from './defs';
+
+import { ProxyMarked, Remote } from 'comlink';
+
+interface IOptionsCommon {
+  color?: boolean;
+  mountpoint?: string;
+  wasmBaseUrl: string;
+  driveFsBaseUrl?: string;
+  // Initial directories and files to create, for testing purposes.
+  initialDirectories?: string[];
+  initialFiles?: IShell.IFiles;
+}
+
+interface IShellCommon {
+  input(char: string): Promise<void>;
+  setSize(rows: number, columns: number): Promise<void>;
+  start(): Promise<void>;
+}
+
+export interface IShellWorker extends IShellCommon {
+  // Handle any lazy initialization activities.
+  // Callback proxies need to be separate arguments, they cannot be in IOptions.
+  initialize(
+    options: IShellWorker.IOptions,
+    outputCallback: IShellWorker.IProxyOutputCallback,
+    enableBufferedStdinCallback: IShellWorker.IProxyEnableBufferedStdinCallback,
+    terminateCallback: IShellWorker.IProxyTerminateCallback
+  ): void;
+}
+
+export namespace IShellWorker {
+  export interface IProxyOutputCallback extends IOutputCallback, ProxyMarked {}
+  export interface IProxyEnableBufferedStdinCallback
+    extends IEnableBufferedStdinCallback,
+      ProxyMarked {}
+  export interface IProxyTerminateCallback extends ITerminateCallback, ProxyMarked {}
+
+  export interface IOptions extends IOptionsCommon {
+    sharedArrayBuffer: SharedArrayBuffer;
+  }
+}
+
+export type IRemoteShell = Remote<IShellWorker>;
+
+export namespace IShellImpl {
+  export interface IOptions extends IOptionsCommon {
+    outputCallback: IOutputCallback;
+    enableBufferedStdinCallback: IEnableBufferedStdinCallback;
+    stdinCallback: IStdinCallback;
+    terminateCallback: IShellWorker.IProxyTerminateCallback;
+  }
+}

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -3,7 +3,8 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { proxy, wrap } from 'comlink';
 
 import { MainBufferedStdin } from './buffered_stdin';
-import { IRemoteShell, IShell } from './defs';
+import { IShell } from './defs';
+import { IRemoteShell } from './defs_internal';
 
 /**
  * External-facing Shell class that external libraries use.  It communicates with the real shell

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -4,7 +4,7 @@ import { Aliases } from './aliases';
 import { ansi } from './ansi';
 import { CommandRegistry } from './command_registry';
 import { Context } from './context';
-import { IShellImpl, IShellWorker } from './defs';
+import { IShellImpl, IShellWorker } from './defs_internal';
 import { Environment } from './environment';
 import { ErrorExitCode, FindCommandError, GeneralError } from './error_exit_code';
 import { ExitCode } from './exit_code';

--- a/src/shell_worker.ts
+++ b/src/shell_worker.ts
@@ -1,7 +1,7 @@
 import { expose } from 'comlink';
 
 import { WorkerBufferedStdin } from './buffered_stdin';
-import { IShellWorker } from './defs';
+import { IShellWorker } from './defs_internal';
 import { ShellImpl } from './shell_impl';
 
 /**


### PR DESCRIPTION
The definitions of interfaces and options are combined in `defs.ts` for both external classes (`Shell`) and internal (`ShellWorker`, `ShellImpl`) ones. Here splitting them so that the external ones stay in `defs.ts` and the internal ones are in `defs_internal.ts`, so that client projects such as `terminal` can ignore the internal ones.