### PR TITLE
Support local_directory wasm install in JupyterLite Terminal

### DIFF
--- a/src/tools/prepare_wasm.ts
+++ b/src/tools/prepare_wasm.ts
@@ -201,7 +201,7 @@ for (const packageConfig of cockleConfig) {
         const targetFileName = path.join(target, filename);
         fs.copyFileSync(srcFilename, targetFileName);
       } else {
-        filenames.push(path.join(envPath, 'bin', moduleName + suffix));
+        filenames.push(srcFilename);
       }
     }
   }


### PR DESCRIPTION
This fixes an omission in PR #75 which did support use of `local_directory` wasm packages in `cockle` but not in `terminal`.