### PR TITLE
Use xtermjs onData rather than onKey

### DIFF
--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -44,7 +44,7 @@ export class Demo {
 
   async start(): Promise<void> {
     this._term!.onResize(async (arg: any) => await this.onResize(arg));
-    this._term!.onKey(async (arg: any) => await this.onKey(arg));
+    this._term!.onData(async (data: string) => await this.onData(data));
 
     const resizeObserver = new ResizeObserver(entries => {
       this._fitAddon!.fit();
@@ -55,8 +55,8 @@ export class Demo {
     resizeObserver.observe(this._options!.targetDiv);
   }
 
-  async onKey(arg: any): Promise<void> {
-    await this._shell.input(arg.key);
+  async onData(data: string): Promise<void> {
+    await this._shell.input(data);
   }
 
   async onResize(arg: any): Promise<void> {


### PR DESCRIPTION
Use xtermjs `onData` rather than `onKey` for the demo as that is what is used in JupyterLab:
https://github.com/jupyterlab/jupyterlab/blob/48908a8b07128b651faab72434f8d442b99bc91c/packages/terminal/src/widget.ts#L366

This supports better mapping of keys to characters, and also pasting into the terminal.