### PR TITLE
Add COCKLE_WASM_EXTRA_CHANNEL env var to get wasm command packages from an extra channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Check and recreate cockle_wasm_env if it does not contain all required packages [#72](https://github.com/jupyterlite/cockle/pull/72) ([@ianthomas23](https://github.com/ianthomas23))
 - Separate external and internal defs [#70](https://github.com/jupyterlite/cockle/pull/70) ([@ianthomas23](https://github.com/ianthomas23))
 - Add tests for cp and mv [#68](https://github.com/jupyterlite/cockle/pull/68) ([@ianthomas23](https://github.com/ianthomas23))
-- Support filename expansion of * and ? [#67](https://github.com/jupyterlite/cockle/pull/67) ([@ianthomas23](https://github.com/ianthomas23))
+- Support filename expansion of \* and ? [#67](https://github.com/jupyterlite/cockle/pull/67) ([@ianthomas23](https://github.com/ianthomas23))
 - Add Shell.dispose and new exit command [#66](https://github.com/jupyterlite/cockle/pull/66) ([@ianthomas23](https://github.com/ianthomas23))
 
 ### Bugs fixed


### PR DESCRIPTION
Add new environment variable `COCKLE_WASM_EXTRA_CHANNEL` used when building a deployment to look in an extra Emscripten-forge channel, remotely or locally, as well as the default channels. This is useful when trying to build new wasm commands in a local Emscripten-forge `recipes` repo.

For example, if I have my local Emscripten-forge recipes repo in `~/github/emscripten-forge/recipes` then to build the `demo` here I could use:
```bash
COCKLE_WASM_EXTRA_CHANNEL=~/github/emscripten-forge/recipes/output npm run build
```
and the `cockle-command` output when served is:

![cockle-wasm-extra-channel](https://github.com/user-attachments/assets/a9d113ab-8529-4d23-b244-78b31fd0ef0d)
