### PR TITLE
Support multi-character inputs (escape sequences) whilst command running

### DIFF
--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -17,10 +17,19 @@ export abstract class WasmCommandRunner implements ICommandRunner {
     const start = Date.now();
     const wasmModule = this.wasmLoader.getModule(this.moduleName());
 
+    let _getCharBuffer: number[] = [];
+
     // Functions for monkey-patching.
     function getChar(tty: any) {
+      if (_getCharBuffer.length > 0) {
+        return _getCharBuffer.shift()!;
+      }
+
       const utf16codes = stdin.readChar();
       const utf16 = utf16codes[0];
+      if (utf16codes.length > 1) {
+        _getCharBuffer = utf16codes.slice(1);
+      }
 
       if (stdin.isTerminal()) {
         if (utf16 === 10) {

--- a/test/tests/shell.test.ts
+++ b/test/tests/shell.test.ts
@@ -79,6 +79,20 @@ test.describe('Shell', () => {
       expect(output).toMatch(/^wc\r\na b\r\nc {6}1 {7}3 {7}5\r\n/);
     });
 
+    test('should support terminal stdin of an ansi escape sequence', async ({ page }) => {
+      const output = await page.evaluate(async () => {
+        const { shell, output } = await globalThis.cockle.shellSetupEmpty();
+        const EOT = String.fromCharCode(4);
+        const downArrow = '\x1B[B';
+        await Promise.all([
+          shell.inputLine('wc'),
+          globalThis.cockle.terminalInput(shell, ['a', downArrow, 'b', EOT])
+        ]);
+        return output.text;
+      });
+      expect(output).toMatch(/^wc\r\nab {6}0 {7}1 {7}5\r\n/);
+    });
+
     test('should support terminal stdin more than once', async ({ page }) => {
       const output = await page.evaluate(async () => {
         const { shell, output } = await globalThis.cockle.shellSetupEmpty();


### PR DESCRIPTION
When a wasm command is running, stdin can take a multi-character string such as an ansi escape sequence. This PR supports such multi-character inputs by passing on all the characters one at a time rather then just the first character.