### PR TITLE
Add MockTerminalOutput.textAndClear function

### DIFF
--- a/test/serve/output_setup.ts
+++ b/test/serve/output_setup.ts
@@ -26,6 +26,12 @@ export class MockTerminalOutput {
     return this._text;
   }
 
+  textAndClear(): string {
+    const ret = this.text;
+    this.clear();
+    return ret;
+  }
+
   private _started: boolean;
   private _text: string = '';
 }

--- a/test/tests/command/ls.test.ts
+++ b/test/tests/command/ls.test.ts
@@ -28,17 +28,15 @@ test.describe('ls command', () => {
       const { shell, output } = await globalThis.cockle.shellSetupSimple(options);
       await shell.setSize(10, 50);
       await shell.inputLine('ls');
-      const ret = [output.text];
-      output.clear();
+      const ret = [output.textAndClear()];
 
       await shell.setSize(10, 40);
       await shell.inputLine('ls');
-      ret.push(output.text);
-      output.clear();
+      ret.push(output.textAndClear());
 
       await shell.setSize(10, 20);
       await shell.inputLine('ls');
-      ret.push(output.text);
+      ret.push(output.textAndClear());
       return ret;
     });
     expect(output[0]).toMatch(

--- a/test/tests/command/stty.test.ts
+++ b/test/tests/command/stty.test.ts
@@ -6,8 +6,7 @@ test.describe('stty command', () => {
     const output = await page.evaluate(async () => {
       const { shell, output } = await globalThis.cockle.shellSetupEmpty();
       await shell.inputLine('stty size');
-      const output0 = output.text;
-      output.clear();
+      const output0 = output.textAndClear();
 
       await shell.setSize(10, 43);
       await shell.inputLine('stty size');

--- a/test/tests/command/touch.test.ts
+++ b/test/tests/command/touch.test.ts
@@ -11,21 +11,18 @@ test.describe('touch command', () => {
       await shell.inputLine('touch abc');
       output.clear();
       await shell.inputLine('env | grep ^?=');
-      ret.push(output.text);
-      output.clear();
+      ret.push(output.textAndClear());
 
       await shell.inputLine('ls abc');
-      ret.push(output.text);
-      output.clear();
+      ret.push(output.textAndClear());
 
       await shell.inputLine('touch abc');
       output.clear();
       await shell.inputLine('env | grep ^?=');
-      ret.push(output.text);
-      output.clear();
+      ret.push(output.textAndClear());
 
       await shell.inputLine('ls abc');
-      ret.push(output.text);
+      ret.push(output.textAndClear());
       return ret;
     });
     expect(output[0]).toMatch("ls: cannot access 'abc': No such file or directory");

--- a/test/tests/history.test.ts
+++ b/test/tests/history.test.ts
@@ -100,27 +100,22 @@ test.describe('history', () => {
 
       await shell.input(upArrow);
       await shell.input(upArrow);
-      const ret = [output.text];
-      output.clear();
+      const ret = [output.textAndClear()];
 
       await shell.input(upArrow);
-      ret.push(output.text);
-      output.clear();
+      ret.push(output.textAndClear());
 
       await shell.input(upArrow);
-      ret.push(output.text);
-      output.clear();
+      ret.push(output.textAndClear());
 
       await shell.input(downArrow);
-      ret.push(output.text);
-      output.clear();
+      ret.push(output.textAndClear());
 
       await shell.input(downArrow);
-      ret.push(output.text);
-      output.clear();
+      ret.push(output.textAndClear());
 
       await shell.input(downArrow);
-      ret.push(output.text);
+      ret.push(output.textAndClear());
       return ret;
     });
     expect(output[0]).toMatch(/echo hello$/);

--- a/test/tests/shell.test.ts
+++ b/test/tests/shell.test.ts
@@ -101,8 +101,7 @@ test.describe('Shell', () => {
           shell.inputLine('wc'),
           globalThis.cockle.terminalInput(shell, ['a', ' ', 'b', '\n', 'c', EOT])
         ]);
-        const ret0 = output.text;
-        output.clear();
+        const ret0 = output.textAndClear();
 
         await Promise.all([
           shell.inputLine('wc'),
@@ -201,12 +200,11 @@ test.describe('Shell', () => {
         await shell.setSize(40, 10);
         await shell.input('t');
         await shell.input('\t');
-        const ret0 = output.text;
-        output.clear();
+        const ret0 = output.textAndClear();
 
         await shell.setSize(40, 20);
         await shell.input('\t');
-        const ret1 = output.text;
+        const ret1 = output.textAndClear();
         return [ret0, ret1];
       });
       expect(output[0]).toMatch(/^t\r\ntail\r\ntouch\r\ntr\r\ntty\r\n/);
@@ -345,17 +343,15 @@ test.describe('Shell', () => {
         const ret: string[] = [];
         await shell.setSize(10, 44);
         await shell.inputLine('env|grep LINES;env|grep COLUMNS');
-        ret.push(output.text);
+        ret.push(output.textAndClear());
 
-        output.clear();
         await shell.setSize(0, 45);
         await shell.inputLine('env|grep LINES;env|grep COLUMNS');
-        ret.push(output.text);
+        ret.push(output.textAndClear());
 
-        output.clear();
         await shell.setSize(14, -1);
         await shell.inputLine('env|grep LINES;env|grep COLUMNS');
-        ret.push(output.text);
+        ret.push(output.textAndClear());
         return ret;
       });
       expect(output[0]).toMatch('\r\nLINES=10\r\nCOLUMNS=44\r\n');

--- a/test/tests/utils.ts
+++ b/test/tests/utils.ts
@@ -25,8 +25,7 @@ export async function shellInputsSimpleN(
         for (const char of chars) {
           await shell.input(char);
         }
-        ret.push(output.text);
-        output.clear();
+        ret.push(output.textAndClear());
       }
       return ret;
     },
@@ -55,8 +54,7 @@ export async function shellLineSimpleN(
       const ret: string[] = [];
       for (const line of lines) {
         await shell.inputLine(line);
-        ret.push(output.text);
-        output.clear();
+        ret.push(output.textAndClear());
       }
       return ret;
     },
@@ -75,8 +73,7 @@ export async function shellLineComplexN(
       const ret: string[] = [];
       for (const line of lines) {
         await shell.inputLine(line);
-        ret.push(output.text);
-        output.clear();
+        ret.push(output.textAndClear());
       }
       return ret;
     },


### PR DESCRIPTION
Add new function `MockTerminalOutput.textAndClear` that combines `text` and `clear` to simplify some tests.