### PR TITLE
Remove some missed async flush calls

### DIFF
--- a/src/builtin/exit_command.ts
+++ b/src/builtin/exit_command.ts
@@ -11,7 +11,7 @@ export class ExitCommand extends BuiltinCommand {
     const { stdout, terminate } = context;
 
     stdout.write('Terminating shell...\n');
-    await stdout.flush();
+    stdout.flush();
 
     terminate();
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -24,8 +24,8 @@ export class Context {
     readonly stderr: IOutput
   ) {}
 
-  async flush(): Promise<void> {
-    await this.stderr.flush();
-    await this.stdout.flush();
+  flush(): void {
+    this.stderr.flush();
+    this.stdout.flush();
   }
 }

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -406,7 +406,7 @@ export class ShellImpl implements IShellWorker {
         exitCode = error.exitCode;
       }
       stderr.write(error + '\n');
-      await stderr.flush();
+      stderr.flush();
     } finally {
       exitCode = exitCode ?? ExitCode.GENERAL_ERROR;
       this.environment.set('?', `${exitCode}`);
@@ -463,7 +463,7 @@ export class ShellImpl implements IShellWorker {
     );
     const exitCode = await runner.run(name, context);
 
-    await context.flush();
+    context.flush();
     return exitCode;
   }
 


### PR DESCRIPTION
`IOutput.write` and `flush` were converted from async to sync in #77 but I missed a few `flush` calls, which are corrected here.