### PR TITLE
Move stdin echoing to BufferedIO

### DIFF
--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -32,16 +32,6 @@ export abstract class WasmCommandRunner implements ICommandRunner {
         _getCharBuffer = utf16codes.slice(1);
       }
 
-      if (stdin.isTerminal()) {
-        if (utf16 === 10) {
-          context.stdout.write('\n');
-          context.stdout.flush();
-        } else if (utf16 > 31 && utf16 !== 127) {
-          context.stdout.write(String.fromCharCode(...utf16codes));
-          context.stdout.flush();
-        }
-      }
-
       // What to do with length other than 1?
       if (utf16 === 4) {
         // EOT

--- a/test/tests/shell.test.ts
+++ b/test/tests/shell.test.ts
@@ -90,7 +90,7 @@ test.describe('Shell', () => {
         ]);
         return output.text;
       });
-      expect(output).toMatch(/^wc\r\nab {6}0 {7}1 {7}5\r\n/);
+      expect(output).toMatch('wc\r\na\x1B[Bb      0       1       5\r\n');
     });
 
     test('should support terminal stdin more than once', async ({ page }) => {


### PR DESCRIPTION
Move `stdin` echoing from the `getChar` callback to `BufferedIO` so that it can use the correct `termios` settings.