### PR TITLE
Make external IOutputCallback synchronous

### DIFF
--- a/src/callback.ts
+++ b/src/callback.ts
@@ -6,7 +6,7 @@
  * Send output string to be displayed in terminal.
  */
 export interface IOutputCallback {
-  (output: string): Promise<void>;
+  (output: string): void;
 }
 
 /**

--- a/src/io/terminal_output.ts
+++ b/src/io/terminal_output.ts
@@ -1,8 +1,5 @@
 import { IOutput } from './output';
-
-interface IOutputCallback {
-  (output: string): void;
-}
+import { IOutputCallback } from '../callback';
 
 export class TerminalOutput implements IOutput {
   constructor(

--- a/test/serve/output_setup.ts
+++ b/test/serve/output_setup.ts
@@ -8,7 +8,7 @@ export class MockTerminalOutput {
     this._started = start;
   }
 
-  callback: IOutputCallback = async (output: string) => {
+  callback: IOutputCallback = (output: string) => {
     if (this._started) {
       this._text = this._text + output;
     }


### PR DESCRIPTION
Make external `IOutputCallback` synchronous as it does not need to be async, the same as in JupyterLab. This is an API change, so will need a corresponding change in the JupyterLite Terminal when this is released.