### PR TITLE
Fix blocking writes by correctly handling Atomics.waitAsync returns

### DIFF
--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -63,7 +63,7 @@ export class Demo {
     await this._shell.setSize(arg.rows, arg.cols);
   }
 
-  private async outputCallback(text: string): Promise<void> {
+  private outputCallback(text: string): void {
     this._term!.write(text);
   }
 

--- a/src/history.ts
+++ b/src/history.ts
@@ -58,7 +58,7 @@ export class History {
     }
   }
 
-  async write(output: IOutput): Promise<void> {
+  write(output: IOutput): void {
     for (let i = 0; i < this._history.length; i++) {
       const index = String(i).padStart(5, ' ');
       output.write(`${index}  ${this._history[i]}\n`);


### PR DESCRIPTION
Fixes #89.

Fixes a bug when writing to `stdout` sometimes blocks so the shell freezes. This was due to not handling all of the possible returns from `Atomics.waitAsync` as sometimes the wait is resolved immediately and the new value returned rather than a `Promise`.

This will be following by a new release (0.0.13) as it is a significant bug.