### PR TITLE
Display wasm module cache status in cockle-config

### DIFF
--- a/src/builtin/cockle_config_command.ts
+++ b/src/builtin/cockle_config_command.ts
@@ -15,8 +15,31 @@ export class CockleConfigCommand extends BuiltinCommand {
 
     stdout.write(`cockle ${COCKLE_VERSION}\n`);
     this._writePackageConfig(context);
+    this._writeModuleConfig(context);
 
     return ExitCode.SUCCESS;
+  }
+
+  private _writeModuleConfig(context: Context) {
+    const { commandRegistry, stdout, wasmModuleCache } = context;
+
+    const allModules = commandRegistry.allModules();
+
+    const lines = [['module', 'package', 'cached']];
+    for (const module of allModules) {
+      lines.push([module.name, module.packageName, wasmModuleCache.has(module.name) ? 'yes' : '']);
+    }
+
+    let colorMap: Map<number, string> | null = null;
+    if (stdout.supportsAnsiEscapes()) {
+      colorMap = new Map();
+      colorMap.set(1, ansi.styleBrightBlue);
+      colorMap.set(2, ansi.styleBrightPurple);
+    }
+
+    for (const line of toTable(lines, 1, false, colorMap)) {
+      stdout.write(line + '\n');
+    }
   }
 
   private _writePackageConfig(context: Context) {

--- a/src/command_registry.ts
+++ b/src/command_registry.ts
@@ -16,10 +16,9 @@ export class CommandRegistry {
     for (const pkg of this.wasmPackageMap.values()) {
       modules.push(...pkg.modules);
     }
-    modules.sort((a, b) => a.name < b.name ? -1 : 1);
+    modules.sort((a, b) => (a.name < b.name ? -1 : 1));
     return modules;
   }
-
 
   get(name: string): ICommandRunner | null {
     return this._map.get(name) ?? null;

--- a/src/command_registry.ts
+++ b/src/command_registry.ts
@@ -1,12 +1,25 @@
 import { ICommandRunner } from './commands/command_runner';
+import { WasmCommandModule } from './commands/wasm_command_module';
 import { WasmCommandPackage } from './commands/wasm_command_package';
 import * as AllBuiltinCommands from './builtin';
-import { WasmLoader } from './wasm_loader';
 
 export class CommandRegistry {
-  constructor(wasmLoader: WasmLoader) {
+  constructor() {
     this.registerBuiltinCommands(AllBuiltinCommands);
   }
+
+  /**
+   * Return sequence of all wasm modules ordered by module name.
+   */
+  allModules(): WasmCommandModule[] {
+    const modules: WasmCommandModule[] = [];
+    for (const pkg of this.wasmPackageMap.values()) {
+      modules.push(...pkg.modules);
+    }
+    modules.sort((a, b) => a.name < b.name ? -1 : 1);
+    return modules;
+  }
+
 
   get(name: string): ICommandRunner | null {
     return this._map.get(name) ?? null;

--- a/src/commands/wasm_command_module.ts
+++ b/src/commands/wasm_command_module.ts
@@ -10,7 +10,7 @@ export class WasmCommandModule extends WasmCommandRunner {
     wasmModuleLoader: WasmModuleLoader,
     readonly name: string,
     private readonly commands: string[],
-    readonly packageName: string,
+    readonly packageName: string
   ) {
     super(wasmModuleLoader);
   }

--- a/src/commands/wasm_command_module.ts
+++ b/src/commands/wasm_command_module.ts
@@ -1,5 +1,5 @@
 import { WasmCommandRunner } from './wasm_command_runner';
-import { WasmLoader } from '../wasm_loader';
+import { WasmModuleLoader } from '../wasm_module_loader';
 
 /**
  * A moduleName.wasm file with its associated moduleName.js wrapper.
@@ -7,11 +7,12 @@ import { WasmLoader } from '../wasm_loader';
  */
 export class WasmCommandModule extends WasmCommandRunner {
   constructor(
-    wasmLoader: WasmLoader,
-    private readonly name: string,
-    private readonly commands: string[]
+    wasmModuleLoader: WasmModuleLoader,
+    readonly name: string,
+    private readonly commands: string[],
+    readonly packageName: string,
   ) {
-    super(wasmLoader);
+    super(wasmModuleLoader);
   }
 
   moduleName(): string {

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -2,10 +2,10 @@ import { ICommandRunner } from './command_runner';
 import { Context } from '../context';
 import { ExitCode } from '../exit_code';
 import { ITermios } from '../termios';
-import { WasmLoader } from '../wasm_loader';
+import { WasmModuleLoader } from '../wasm_module_loader';
 
 export abstract class WasmCommandRunner implements ICommandRunner {
-  constructor(readonly wasmLoader: WasmLoader) {}
+  constructor(readonly wasmModuleLoader: WasmModuleLoader) {}
 
   abstract moduleName(): string;
 
@@ -13,10 +13,10 @@ export abstract class WasmCommandRunner implements ICommandRunner {
 
   async run(cmdName: string, context: Context): Promise<number> {
     const { args, bufferedIO, fileSystem, mountpoint, stdin, stdout, stderr } = context;
-    const { wasmBaseUrl } = this.wasmLoader;
+    const { wasmBaseUrl } = this.wasmModuleLoader;
 
     const start = Date.now();
-    const wasmModule = this.wasmLoader.getModule(this.moduleName());
+    const wasmModule = this.wasmModuleLoader.getModule(this.moduleName());
 
     let _getCharBuffer: number[] = [];
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,6 +6,7 @@ import { Environment } from './environment';
 import { History } from './history';
 import { IFileSystem } from './file_system';
 import { IInput, IOutput } from './io';
+import { WasmModuleCache } from './wasm_module_cache';
 
 /**
  * Context used to run commands.
@@ -23,7 +24,8 @@ export class Context {
     readonly stdin: IInput,
     readonly stdout: IOutput,
     readonly stderr: IOutput,
-    readonly bufferedIO: WorkerBufferedIO
+    readonly bufferedIO: WorkerBufferedIO,
+    readonly wasmModuleCache: WasmModuleCache
   ) {}
 
   flush(): void {

--- a/src/wasm_module_cache.ts
+++ b/src/wasm_module_cache.ts
@@ -1,0 +1,15 @@
+export class WasmModuleCache {
+  get(moduleName: string): any {
+    return this._cache.get(moduleName) ?? undefined;
+  }
+
+  has(moduleName: string): boolean {
+    return this._cache.has(moduleName);
+  }
+
+  set(moduleName: string, module: any): void {
+    this._cache.set(moduleName, module);
+  }
+
+  private _cache = new Map<string, any>();
+}

--- a/src/wasm_module_loader.ts
+++ b/src/wasm_module_loader.ts
@@ -1,22 +1,24 @@
+import { WasmModuleCache } from './wasm_module_cache';
+
 /**
  * Loader of WASM modules. Once loaded, a module is cached so that it is faster to subsequently.
  * Must be run in a WebWorker.
  */
-export class WasmLoader {
+export class WasmModuleLoader {
   constructor(readonly wasmBaseUrl: string) {}
 
   public getModule(name: string): any {
-    let module = this._cache.get(name);
+    let module = this.cache.get(name);
     if (module === undefined) {
       // Maybe should use @jupyterlab/coreutils.URLExt to combine URL components.
       const url = this.wasmBaseUrl + name + '.js';
       console.log('Importing JS/WASM from ' + url);
       importScripts(url);
       module = (self as any).Module;
-      this._cache.set(name, module);
+      this.cache.set(name, module);
     }
     return module;
   }
 
-  private _cache = new Map<string, any>();
+  cache = new WasmModuleCache();
 }


### PR DESCRIPTION
Display wasm module cache status in `cockle-config`, as shown in the second table here:

<img width="756" alt="Screenshot 2025-01-09 at 15 13 09" src="https://github.com/user-attachments/assets/14557488-297f-4ad7-a7fd-1d21800bc2dd" />

Eventually we will add more control here to allow clearing of the cache, preloading of wasm modules, etc.

I have also renamed `WasmLoader` to `WasmModuleLoader`, and there is a new class `WasmModuleCache` rather than it being part of the loader.