### PR TITLE
Add emscripten-forge-dev channel

### DIFF
--- a/src/tools/prepare_wasm.ts
+++ b/src/tools/prepare_wasm.ts
@@ -17,7 +17,11 @@ const zod = require('zod');
 
 const ENV_NAME = 'cockle_wasm_env';
 const PLATFORM = 'emscripten-wasm32';
-const CHANNELS = ['https://repo.mamba.pm/emscripten-forge', 'https://repo.mamba.pm/conda-forge'];
+const CHANNELS = [
+  'https://repo.prefix.dev/emscripten-forge-dev',
+  'https://repo.mamba.pm/emscripten-forge',
+  'conda-forge'
+];
 
 if (process.argv.length !== 4 || (process.argv[2] !== '--list' && process.argv[2] !== '--copy')) {
   console.log('Usage: prepare_wasm --list list-filename');


### PR DESCRIPTION
Add `emscripten-forge-dev` channel as the first choice to obtain Emscripten-forge packages from, to support emscripten 3.1.73. Now that such packages depend on a particular `emscripten-abi` version, they will not be used unless all the required packages are compiled with emsdk 3.1.73.