### PR TITLE
Use separate directories for wasm command packages

### DIFF
--- a/src/builtin/cockle_config_command.ts
+++ b/src/builtin/cockle_config_command.ts
@@ -27,7 +27,11 @@ export class CockleConfigCommand extends BuiltinCommand {
 
     const lines = [['module', 'package', 'cached']];
     for (const module of allModules) {
-      lines.push([module.name, module.packageName, wasmModuleCache.has(module.name) ? 'yes' : '']);
+      lines.push([
+        module.name,
+        module.packageName,
+        wasmModuleCache.has(module.packageName, module.name) ? 'yes' : ''
+      ]);
     }
 
     let colorMap: Map<number, string> | null = null;

--- a/src/commands/wasm_command_module.ts
+++ b/src/commands/wasm_command_module.ts
@@ -15,7 +15,7 @@ export class WasmCommandModule extends WasmCommandRunner {
     super(wasmModuleLoader);
   }
 
-  moduleName(): string {
+  get moduleName(): string {
     return this.name;
   }
 

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -266,9 +266,9 @@ export class ShellImpl implements IShellWorker {
 
   private async _initFilesystem(): Promise<void> {
     const { wasmBaseUrl } = this.options;
-    const fsModule = this._wasmModuleLoader.getModule('fs');
+    const fsModule = this._wasmModuleLoader.getModule('cockle_fs', 'fs');
     const module = await fsModule({
-      locateFile: (path: string) => wasmBaseUrl + path
+      locateFile: (path: string) => wasmBaseUrl + 'cockle_fs/' + path
     });
     const { FS, PATH, ERRNO_CODES, PROXYFS } = module;
 

--- a/src/wasm_module_cache.ts
+++ b/src/wasm_module_cache.ts
@@ -1,14 +1,21 @@
 export class WasmModuleCache {
-  get(moduleName: string): any {
-    return this._cache.get(moduleName) ?? undefined;
+  get(packageName: string, moduleName: string): any {
+    const key = this.key(packageName, moduleName);
+    return this._cache.get(key) ?? undefined;
   }
 
-  has(moduleName: string): boolean {
-    return this._cache.has(moduleName);
+  has(packageName: string, moduleName: string): boolean {
+    const key = this.key(packageName, moduleName);
+    return this._cache.has(key);
   }
 
-  set(moduleName: string, module: any): void {
-    this._cache.set(moduleName, module);
+  key(packageName: string, moduleName: string): string {
+    return [packageName, moduleName].join('/');
+  }
+
+  set(packageName: string, moduleName: string, module: any): void {
+    const key = this.key(packageName, moduleName);
+    this._cache.set(key, module);
   }
 
   private _cache = new Map<string, any>();

--- a/src/wasm_module_loader.ts
+++ b/src/wasm_module_loader.ts
@@ -7,15 +7,16 @@ import { WasmModuleCache } from './wasm_module_cache';
 export class WasmModuleLoader {
   constructor(readonly wasmBaseUrl: string) {}
 
-  public getModule(name: string): any {
-    let module = this.cache.get(name);
+  public getModule(packageName: string, moduleName: string): any {
+    let module = this.cache.get(packageName, moduleName);
     if (module === undefined) {
       // Maybe should use @jupyterlab/coreutils.URLExt to combine URL components.
-      const url = this.wasmBaseUrl + name + '.js';
+      const filename = this.cache.key(packageName, moduleName) + '.js';
+      const url = this.wasmBaseUrl + filename;
       console.log('Importing JS/WASM from ' + url);
       importScripts(url);
       module = (self as any).Module;
-      this.cache.set(name, module);
+      this.cache.set(packageName, moduleName, module);
     }
     return module;
   }


### PR DESCRIPTION
Wasm command files are currently all put in the same directory for static serving. There can be multiple modules (i.e. `.wasm` files) per emscripten-forge package, and although the package names are unique there may be multiple modules with the same name in different packages. So to avoid future name conflicts, here I am changing the directory structure for the static serving so that each package is in its own directory.

Summary of changes:
1) Wasm module loading expects `wasmBaseUrl/package/module.js` (and `.wasm` etc) rather than just `wasmBaseUrl/module.js`.
2) `prepare_wasm.ts` puts modules in these package directories.

This will need a corresponding change in JupyterLite terminal `add_on.py` to use the package directories when this is next released.