### PR TITLE
Improve config JSON file format

### DIFF
--- a/cockle-config-base.json
+++ b/cockle-config-base.json
@@ -1,23 +1,19 @@
-[
-  {
-    "package": "cockle_fs",
-    "modules": [
-      {
-        "name": "fs",
-        "commands": ""
+{
+  "packages": {
+    "cockle_fs": {
+      "modules": {
+        "fs": {
+          "commands": ""
+        }
       }
-    ]
-  },
-  {
-    "package": "coreutils",
-    "modules": [
-      {
-        "name": "coreutils",
-        "commands": "basename,cat,chmod,cp,cut,date,dir,dircolors,dirname,echo,env,expr,head,id,join,ln,logname,ls,md5sum,mkdir,mv,nl,pwd,realpath,rm,rmdir,seq,sha1sum,sha224sum,sha256sum,sha384sum,sha512sum,sleep,sort,stat,stty,tail,touch,tr,tty,uname,uniq,vdir,wc"
+    },
+    "coreutils": {
+      "modules": {
+        "coreutils": {
+          "commands": "basename,cat,chmod,cp,cut,date,dir,dircolors,dirname,echo,env,expr,head,id,join,ln,logname,ls,md5sum,mkdir,mv,nl,pwd,realpath,rm,rmdir,seq,sha1sum,sha224sum,sha256sum,sha384sum,sha512sum,sleep,sort,stat,stty,tail,touch,tr,tty,uname,uniq,vdir,wc"
+        }
       }
-    ]
-  },
-  {
-    "package": "grep"
+    },
+    "grep": {}
   }
-]
+}

--- a/demo/cockle-config-in.json
+++ b/demo/cockle-config-in.json
@@ -1,15 +1,10 @@
-[
-  {
-    "package": "lua"
-  },
-  {
-    "package": "local-cmd",
-    "local_directory": "../test/wasm-util/wasm"
-  },
-  {
-    "package": "tree"
-  },
-  {
-    "package": "vim"
+{
+  "packages": {
+    "lua": {},
+    "local-cmd": {
+      "local_directory": "../test/wasm-util/wasm"
+    },
+    "tree": {},
+    "vim": {}
   }
-]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "@types/react": "^18.2.79",
                 "@typescript-eslint/eslint-plugin": "^7.16.1",
                 "@typescript-eslint/parser": "^7.16.1",
+                "deepmerge-ts": "^7.1.4",
                 "eslint": "^8.56.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.1.3",
@@ -2168,6 +2169,16 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
+        },
+        "node_modules/deepmerge-ts": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.4.tgz",
+            "integrity": "sha512-fxqo6nHGQ9zOVgI4KXqtWXJR/yCLtC7aXIVq+6jc8tHPFUxlFmuUcm2kC4vztQ+LJxQ3gER/XAWearGYQ8niGA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=16.0.0"
+            }
         },
         "node_modules/default-browser": {
             "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@types/react": "^18.2.79",
         "@typescript-eslint/eslint-plugin": "^7.16.1",
         "@typescript-eslint/parser": "^7.16.1",
+        "deepmerge-ts": "^7.1.4",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -315,25 +315,26 @@ export class ShellImpl implements IShellWorker {
     // Check JSON follows schema?
     // May want to store JSON config.
 
-    const packageNames = cockleConfig.map((x: any) => x.package);
+    const packageNames = Object.keys(cockleConfig.packages);
     const fsPackage = 'cockle_fs';
     if (!packageNames.includes(fsPackage)) {
       console.error(`cockle-config.json does not include required package '${fsPackage}'`);
     }
 
     // Create command runners for each wasm module of each emscripten-forge package.
-    for (const pkgConfig of cockleConfig) {
-      const commandModules = pkgConfig.modules.map(
-        (moduleConfig: any) =>
+    for (const packageName of packageNames) {
+      const pkgConfig = cockleConfig.packages[packageName];
+      const commandModules = Object.entries(pkgConfig.modules).map(
+        ([moduleName, moduleConfig]) =>
           new WasmCommandModule(
             this._wasmModuleLoader,
-            moduleConfig.name,
-            moduleConfig.commands ? moduleConfig.commands.split(',') : [],
-            pkgConfig.package
+            moduleName,
+            (moduleConfig as any).commands ? (moduleConfig as any).commands.split(',') : [],
+            packageName
           )
       );
       const commandPackage = new WasmCommandPackage(
-        pkgConfig.package,
+        packageName,
         pkgConfig.version,
         pkgConfig.build_string,
         pkgConfig.channel,

--- a/test/cockle-config-in.json
+++ b/test/cockle-config-in.json
@@ -1,19 +1,13 @@
-[
-  {
-    "package": "lua"
-  },
-  {
-    "package": "tree"
-  },
-  {
-    "package": "vim"
-  },
-  {
-    "package": "local-cmd",
-    "local_directory": "wasm-util/wasm"
-  },
-  {
-    "package": "check_termios",
-    "local_directory": "wasm-util/wasm"
+{
+  "packages": {
+    "check_termios": {
+      "local_directory": "../test/wasm-util/wasm"
+    },
+    "lua": {},
+    "local-cmd": {
+      "local_directory": "../test/wasm-util/wasm"
+    },
+    "tree": {},
+    "vim": {}
   }
-]
+}


### PR DESCRIPTION
Improve config JSON file format. Rather than use arrays of dicts, this uses dicts that map from package or module name to their properties. It makes them more complex to parse, but the config files themselves are more concise and will allow us to add other configuration options such as aliases and env vars. A key benefit now is that you can use a config JSON file to override the base one (`cockle-config-base.json`) if you want to test a different local build of a core package, or which commands that `coreutils` exposes, etc.