### PR TITLE
Remove use of default emscripten-forge channel

### DIFF
--- a/src/tools/prepare_wasm.ts
+++ b/src/tools/prepare_wasm.ts
@@ -18,10 +18,7 @@ const zod = require('zod');
 
 const ENV_NAME = 'cockle_wasm_env';
 const PLATFORM = 'emscripten-wasm32';
-const CHANNELS = [
-  'https://repo.prefix.dev/emscripten-forge-dev',
-  'conda-forge'
-];
+const CHANNELS = ['https://repo.prefix.dev/emscripten-forge-dev', 'conda-forge'];
 
 if (process.argv.length !== 4 || (process.argv[2] !== '--list' && process.argv[2] !== '--copy')) {
   console.log('Usage: prepare_wasm --list list-filename');

--- a/src/tools/prepare_wasm.ts
+++ b/src/tools/prepare_wasm.ts
@@ -20,7 +20,6 @@ const ENV_NAME = 'cockle_wasm_env';
 const PLATFORM = 'emscripten-wasm32';
 const CHANNELS = [
   'https://repo.prefix.dev/emscripten-forge-dev',
-  'https://repo.mamba.pm/emscripten-forge',
   'conda-forge'
 ];
 


### PR DESCRIPTION
Now that `emscripten-forge-dev` channel is working well, with packages compiled using emscripten 3.1.73, we can remove the `emscripten-forge` channel for packages compiled using 3.1.45 and/or 3.1.58. Although it is possible to mix packages compiled using different emscripten versions (I've tested 3.1.58 and 3.1.73 together) in general this will not be the case, and in fact the emscripten ABI pins should enforce a single emscripten version when resolving emscripten-forge packages in `prepare_wasm.ts`. It is still possible to try out packages using a different emscripten version via the `local_directory` option in `cockle-config-in.json`.