### PR TITLE
Provide visual feedback when downloading wasm modules

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -30,5 +30,7 @@ export const ansi = {
   styleYellow: ESC + '0;33m',
   styleBlue: ESC + '0;34m',
   stylePurple: ESC + '0;35m',
-  styleCyan: ESC + '0;36m'
+  styleCyan: ESC + '0;36m',
+  showCursor: ESC + '?25h',
+  hideCursor: ESC + '?25l'
 };

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -10,6 +10,13 @@ export interface IOutputCallback {
 }
 
 /**
+ * Callback for start and end of downloading a wasm module so that frontend can inform the user.
+ */
+export interface IDownloadWasmModuleCallback {
+  (packageName: string, moduleName: string, start: boolean): void;
+}
+
+/**
  * Enable/disable buffered stdin.
  */
 export interface IEnableBufferedStdinCallback {

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -1,5 +1,10 @@
 import { WorkerBufferedIO } from './buffered_io';
-import { IEnableBufferedStdinCallback, IStdinCallback, ITerminateCallback } from './callback';
+import {
+  IDownloadWasmModuleCallback,
+  IEnableBufferedStdinCallback,
+  IStdinCallback,
+  ITerminateCallback
+} from './callback';
 
 import { IShell } from './defs';
 
@@ -26,12 +31,16 @@ export interface IShellWorker extends IShellCommon {
   // Callback proxies need to be separate arguments, they cannot be in IOptions.
   initialize(
     options: IShellWorker.IOptions,
+    downloadWasmModuleCallback: IShellWorker.IProxyDownloadWasmModuleCallback,
     enableBufferedStdinCallback: IShellWorker.IProxyEnableBufferedStdinCallback,
     terminateCallback: IShellWorker.IProxyTerminateCallback
   ): void;
 }
 
 export namespace IShellWorker {
+  export interface IProxyDownloadWasmModuleCallback
+    extends IDownloadWasmModuleCallback,
+      ProxyMarked {}
   export interface IProxyEnableBufferedStdinCallback
     extends IEnableBufferedStdinCallback,
       ProxyMarked {}
@@ -46,6 +55,7 @@ export type IRemoteShell = Remote<IShellWorker>;
 
 export namespace IShellImpl {
   export interface IOptions extends IOptionsCommon {
+    downloadWasmModuleCallback: IShellWorker.IProxyDownloadWasmModuleCallback;
     enableBufferedStdinCallback: IEnableBufferedStdinCallback;
     stdinCallback: IStdinCallback;
     terminateCallback: IShellWorker.IProxyTerminateCallback;

--- a/src/download_tracker.ts
+++ b/src/download_tracker.ts
@@ -1,0 +1,72 @@
+import { IDisposable } from '@lumino/disposable';
+
+import { ansi } from './ansi';
+import { IOutputCallback } from './callback';
+
+export class DownloadTracker implements IDisposable {
+  constructor(
+    readonly packageName: string,
+    readonly moduleName: string,
+    readonly outputCallback: IOutputCallback
+  ) {}
+
+  dispose() {
+    if (this._isDisposed) {
+      return;
+    }
+
+    this.stop();
+    this._isDisposed = true;
+  }
+
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  start() {
+    if (this._intervalId !== undefined) {
+      this.stop();
+    }
+
+    this._intervalId = setInterval(this._callback.bind(this), this._delayMs);
+  }
+
+  stop() {
+    if (this._intervalId !== undefined) {
+      clearTimeout(this._intervalId);
+      this._intervalId = undefined;
+      this._callbackCount = 0;
+
+      if (this._displayed) {
+        this.outputCallback(ansi.eraseEndLine + ansi.showCursor);
+      }
+      this._displayed = false;
+    }
+  }
+
+  private _callback() {
+    if (this._callbackCount < this._initialIgnore) {
+      // Do nothing yet
+    } else if (!this._displayed) {
+      // Start displaying download message
+      const message = ` downloading wasm module '${this.moduleName}'`;
+      const n = message.length;
+      this.outputCallback(ansi.hideCursor + this._dots[0] + message + ansi.cursorLeft(n + 1));
+      this._displayed = true;
+    } else {
+      // Update the rotating dots
+      const dots = this._dots[(this._callbackCount - this._initialIgnore) % this._dots.length];
+      this.outputCallback(dots + ansi.cursorLeft(1));
+    }
+
+    this._callbackCount++;
+  }
+
+  private _callbackCount = 0;
+  private _delayMs = 100;
+  private _dots = '⠇⠋⠙⠸⠴⠦';
+  private _initialIgnore = 3; // Number of callbacks to ignore before displaying message
+  private _intervalId?: any;
+  private _isDisposed = false;
+  private _displayed = false;
+}

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -23,7 +23,10 @@ import { WasmCommandPackage } from './commands/wasm_command_package';
 export class ShellImpl implements IShellWorker {
   constructor(readonly options: IShellImpl.IOptions) {
     this._environment = new Environment(options.color);
-    this._wasmModuleLoader = new WasmModuleLoader(options.wasmBaseUrl);
+    this._wasmModuleLoader = new WasmModuleLoader(
+      options.wasmBaseUrl,
+      options.downloadWasmModuleCallback
+    );
     this._commandRegistry = new CommandRegistry();
   }
 

--- a/src/shell_worker.ts
+++ b/src/shell_worker.ts
@@ -10,10 +10,12 @@ import { ShellImpl } from './shell_impl';
 export class ShellWorker implements IShellWorker {
   async initialize(
     options: IShellWorker.IOptions,
+    downloadWasmModuleCallback: IShellWorker.IProxyDownloadWasmModuleCallback,
     enableBufferedStdinCallback: IShellWorker.IProxyEnableBufferedStdinCallback,
     terminateCallback: IShellWorker.IProxyTerminateCallback
   ) {
     this._bufferedIO = new WorkerBufferedIO(options.sharedArrayBuffer);
+    this._downloadWasmModuleCallback = downloadWasmModuleCallback;
     this._enableBufferedStdinCallback = enableBufferedStdinCallback;
     this._terminateCallback = terminateCallback;
 
@@ -26,6 +28,7 @@ export class ShellWorker implements IShellWorker {
       driveFsBaseUrl,
       initialDirectories,
       initialFiles,
+      downloadWasmModuleCallback: this._downloadWasmModuleCallback.bind(this),
       enableBufferedStdinCallback: this.enableBufferedStdin.bind(this),
       terminateCallback: this._terminateCallback.bind(this),
       stdinCallback: this._bufferedIO.read.bind(this._bufferedIO),
@@ -70,6 +73,7 @@ export class ShellWorker implements IShellWorker {
 
   private _shellImpl?: ShellImpl;
   private _bufferedIO?: WorkerBufferedIO;
+  private _downloadWasmModuleCallback?: IShellWorker.IProxyDownloadWasmModuleCallback;
   private _enableBufferedStdinCallback?: IShellWorker.IProxyEnableBufferedStdinCallback;
   private _terminateCallback?: IShellWorker.IProxyTerminateCallback;
 }

--- a/src/wasm_module_loader.ts
+++ b/src/wasm_module_loader.ts
@@ -1,11 +1,15 @@
 import { WasmModuleCache } from './wasm_module_cache';
+import { IShellWorker } from './defs_internal';
 
 /**
  * Loader of WASM modules. Once loaded, a module is cached so that it is faster to subsequently.
  * Must be run in a WebWorker.
  */
 export class WasmModuleLoader {
-  constructor(readonly wasmBaseUrl: string) {}
+  constructor(
+    readonly wasmBaseUrl: string,
+    readonly downloadWasmModuleCallback: IShellWorker.IProxyDownloadWasmModuleCallback
+  ) {}
 
   public getModule(packageName: string, moduleName: string): any {
     let module = this.cache.get(packageName, moduleName);
@@ -14,9 +18,12 @@ export class WasmModuleLoader {
       const filename = this.cache.key(packageName, moduleName) + '.js';
       const url = this.wasmBaseUrl + filename;
       console.log('Importing JS/WASM from ' + url);
+
+      this.downloadWasmModuleCallback(packageName, moduleName, true);
       importScripts(url);
       module = (self as any).Module;
       this.cache.set(packageName, moduleName, module);
+      this.downloadWasmModuleCallback(packageName, moduleName, false);
     }
     return module;
   }


### PR DESCRIPTION
This provides visual feedback in the form of an animated message in the terminal when downloading wasm modules if they are taking a long time (> 0.3 seconds). Here is an example of it in action:

https://github.com/user-attachments/assets/b6971f25-5995-4128-ae04-355feea8f79b

The form of the feedback is hard coded in the `DownloadTracker` class. Eventually I expect this will be configurable and optional, and perhaps could be extended with signals so that the feedback could be displayed elsewhere in JupyterLite as discussed elsewhere for kernels downloading packages.