### PR TITLE
Add deepmerge-ts to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@lumino/disposable": "^2.1.3",
                 "@lumino/signaling": "^2.1.3",
                 "comlink": "^4.4.1",
+                "deepmerge-ts": "^7.1.4",
                 "rimraf": "^6.0.1",
                 "zod": "^3.23.8"
             },
@@ -24,7 +25,6 @@
                 "@types/react": "^18.2.79",
                 "@typescript-eslint/eslint-plugin": "^7.16.1",
                 "@typescript-eslint/parser": "^7.16.1",
-                "deepmerge-ts": "^7.1.4",
                 "eslint": "^8.56.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.1.3",
@@ -2174,7 +2174,6 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.4.tgz",
             "integrity": "sha512-fxqo6nHGQ9zOVgI4KXqtWXJR/yCLtC7aXIVq+6jc8tHPFUxlFmuUcm2kC4vztQ+LJxQ3gER/XAWearGYQ8niGA==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "@lumino/disposable": "^2.1.3",
         "@lumino/signaling": "^2.1.3",
         "comlink": "^4.4.1",
+        "deepmerge-ts": "^7.1.4",
         "rimraf": "^6.0.1",
         "zod": "^3.23.8"
     },
@@ -47,7 +48,6 @@
         "@types/react": "^18.2.79",
         "@typescript-eslint/eslint-plugin": "^7.16.1",
         "@typescript-eslint/parser": "^7.16.1",
-        "deepmerge-ts": "^7.1.4",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",


### PR DESCRIPTION
`deepmerge-ts` needs to be in `dependencies` not `devDependencies` at it is used in `prepare_wasm.ts` by downstream projects such as `terminal` and `cockle-playground`.