### PR TITLE
Use service worker based DriveFS

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Install micromamba executable
         uses: mamba-org/setup-micromamba@main
+        with:
+          micromamba-version: '2.0.5-0'
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Install micromamba executable
         uses: mamba-org/setup-micromamba@main
+        with:
+          micromamba-version: '2.0.5-0'
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install micromamba executable
         uses: mamba-org/setup-micromamba@main
+        with:
+          micromamba-version: '2.0.5-0'
 
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
           environment-file: environment-dev.yml
           init-shell: bash
           cache-downloads: true
+          micromamba-version: '2.0.5-0'
 
       - name: Lint
         run: |
@@ -56,6 +57,7 @@ jobs:
           environment-file: environment-dev.yml
           init-shell: bash
           cache-downloads: true
+          micromamba-version: '2.0.5-0'
 
       - name: Build
         run: |
@@ -86,6 +88,7 @@ jobs:
           environment-file: environment-dev.yml
           init-shell: bash
           cache-downloads: true
+          micromamba-version: '2.0.5-0'
 
       - name: Build
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
             "version": "0.0.14",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@jupyterlite/contents": "^0.4.1",
+                "@jupyterlite/contents": "^0.5.1",
                 "@lumino/disposable": "^2.1.3",
                 "@lumino/signaling": "^2.1.3",
-                "comlink": "^4.4.1",
+                "comlink": "^4.4.2",
                 "deepmerge-ts": "^7.1.4",
                 "rimraf": "^6.0.1",
                 "zod": "^3.23.8"
@@ -408,9 +408,10 @@
             }
         },
         "node_modules/@jupyter/ydoc": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@jupyter/ydoc/-/ydoc-2.1.1.tgz",
-            "integrity": "sha512-NeEwqXQ2j1OyLq4uezeQmsMiI+Qo5k7dYIMqNByOM7dJp6sHeP0jQ96w7BEc9E4SmrxwcOT4cLvcJWJE8Xun4g==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@jupyter/ydoc/-/ydoc-3.0.3.tgz",
+            "integrity": "sha512-DYkLU7bsf5RT6IwrK6GW380dEZbK3q10lo7Ddt8smxKWDrBsQgbdYmQswBtavyihMMDtBlrczjx2OYPFz3Ku8Q==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@jupyterlab/nbformat": "^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0",
                 "@lumino/coreutils": "^1.11.0 || ^2.0.0",
@@ -421,55 +422,59 @@
             }
         },
         "node_modules/@jupyterlab/coreutils": {
-            "version": "6.2.5",
-            "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-6.2.5.tgz",
-            "integrity": "sha512-P3HniEv3bZ3EvV3zUwCmruR713fclGvSTfsuwFPBgI8M3rNIZYqGQ13xkTun7Zl6DUr2E8mrC/cq9jNwxW33yw==",
+            "version": "6.3.5",
+            "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-6.3.5.tgz",
+            "integrity": "sha512-ZPi9bhftYH0RAotTA1N8WA4uf8s4XBnQAN745PTTzvkrsiYCLUEJ4CGjCb3QsAeLlnee5vJfC9Kvjz4nMJFQHQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "@lumino/coreutils": "^2.1.2",
-                "@lumino/disposable": "^2.1.2",
-                "@lumino/signaling": "^2.1.2",
+                "@lumino/coreutils": "^2.2.0",
+                "@lumino/disposable": "^2.1.3",
+                "@lumino/signaling": "^2.1.3",
                 "minimist": "~1.2.0",
                 "path-browserify": "^1.0.0",
                 "url-parse": "~1.5.4"
             }
         },
         "node_modules/@jupyterlab/nbformat": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-4.2.5.tgz",
-            "integrity": "sha512-DF8bdlsEziUR5oKUr3Mm0wUx7kHZjlAtEjD6oJ8cOogQqTrMyBnUAgVjPr9QQob5J7qiyzz9aW2DYtaX+jFhng==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-4.3.5.tgz",
+            "integrity": "sha512-rTge5VNBKoPbTzwMagbZ8KgQa3R805eqPDVVPQhXb0F9ND3vfEbINbZOgz+6/5b0ABlbRnOYWWvTR4iU8cD77w==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "@lumino/coreutils": "^2.1.2"
+                "@lumino/coreutils": "^2.2.0"
             }
         },
         "node_modules/@jupyterlab/services": {
-            "version": "7.2.5",
-            "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-7.2.5.tgz",
-            "integrity": "sha512-Ya/jA8p8WOfiPPERinZasigsfSth54nNNWBQUrT2MEitdka3jVsjC3fR9R5XBpYQ59Qkczz782jMfXvaWNfCHQ==",
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-7.3.5.tgz",
+            "integrity": "sha512-TPRnUsRaxU3mcx01iiJ5JvxF/1JJd9pAwQE0v0Oshvvxowndf8hjf0NkYAbBVaRUrF01zW7QdSY80ERlbHvIqw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "@jupyter/ydoc": "^2.0.1",
-                "@jupyterlab/coreutils": "^6.2.5",
-                "@jupyterlab/nbformat": "^4.2.5",
-                "@jupyterlab/settingregistry": "^4.2.5",
-                "@jupyterlab/statedb": "^4.2.5",
-                "@lumino/coreutils": "^2.1.2",
-                "@lumino/disposable": "^2.1.2",
-                "@lumino/polling": "^2.1.2",
-                "@lumino/properties": "^2.0.1",
-                "@lumino/signaling": "^2.1.2",
+                "@jupyter/ydoc": "^3.0.0",
+                "@jupyterlab/coreutils": "^6.3.5",
+                "@jupyterlab/nbformat": "^4.3.5",
+                "@jupyterlab/settingregistry": "^4.3.5",
+                "@jupyterlab/statedb": "^4.3.5",
+                "@lumino/coreutils": "^2.2.0",
+                "@lumino/disposable": "^2.1.3",
+                "@lumino/polling": "^2.1.3",
+                "@lumino/properties": "^2.0.2",
+                "@lumino/signaling": "^2.1.3",
                 "ws": "^8.11.0"
             }
         },
         "node_modules/@jupyterlab/settingregistry": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-4.2.5.tgz",
-            "integrity": "sha512-RTHwFoldrP8h4hMxZrKafrOt3mLYKAcmUsnExkzKCqHuc3CIOh9hj+eN3gCh1mxjabbP9QIK0/08e89Rp/EG5w==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-4.3.5.tgz",
+            "integrity": "sha512-ygP9x0SWpTfWH8/gu9nnn4rB2+j9ZTBTvGVOH2rBShqsywPlHIG1jJz6Dn6ptq7Obg5KwHh3OFE7dEqRwvacJA==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "@jupyterlab/nbformat": "^4.2.5",
-                "@jupyterlab/statedb": "^4.2.5",
-                "@lumino/commands": "^2.3.0",
-                "@lumino/coreutils": "^2.1.2",
-                "@lumino/disposable": "^2.1.2",
-                "@lumino/signaling": "^2.1.2",
+                "@jupyterlab/nbformat": "^4.3.5",
+                "@jupyterlab/statedb": "^4.3.5",
+                "@lumino/commands": "^2.3.1",
+                "@lumino/coreutils": "^2.2.0",
+                "@lumino/disposable": "^2.1.3",
+                "@lumino/signaling": "^2.1.3",
                 "@rjsf/utils": "^5.13.4",
                 "ajv": "^8.12.0",
                 "json5": "^2.2.3"
@@ -479,25 +484,27 @@
             }
         },
         "node_modules/@jupyterlab/statedb": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-4.2.5.tgz",
-            "integrity": "sha512-GGP4NSkVzcn/zYZyjKId8OvDxq+JQTHEmiE2ayzUvvP4BwpGJ2GafY1V+QT5Tl+4SB0AzowpNud6XHUJ28M/tA==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-4.3.5.tgz",
+            "integrity": "sha512-zUqywCIRhq26IuE6jW3qqk5EjPtP0lKSuHqRPG4TTRujVnwsksjIvwrmBCAB7rGfn13SLXUab7whYeNFDNAelg==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "@lumino/commands": "^2.3.0",
-                "@lumino/coreutils": "^2.1.2",
-                "@lumino/disposable": "^2.1.2",
-                "@lumino/properties": "^2.0.1",
-                "@lumino/signaling": "^2.1.2"
+                "@lumino/commands": "^2.3.1",
+                "@lumino/coreutils": "^2.2.0",
+                "@lumino/disposable": "^2.1.3",
+                "@lumino/properties": "^2.0.2",
+                "@lumino/signaling": "^2.1.3"
             }
         },
         "node_modules/@jupyterlite/contents": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@jupyterlite/contents/-/contents-0.4.1.tgz",
-            "integrity": "sha512-PSDm307yT3zhMC+3R3fxM+tmD3sRZtAFDD12BLHotQ6xHWwyuac/oWxw7V2LKc1rDnWgRzmaGFxUyVjhQrnzrQ==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@jupyterlite/contents/-/contents-0.5.1.tgz",
+            "integrity": "sha512-TlMoq755YniEcYARYdPMg46Lbj9PyO/5paqq5WQTZ6Q4DBBC3KeVA7oT8CjV1tFKQMR5O6L8tAPQr1fjxz+zcg==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "@jupyterlab/nbformat": "~4.2.5",
-                "@jupyterlab/services": "~7.2.5",
-                "@jupyterlite/localforage": "^0.4.1",
+                "@jupyterlab/nbformat": "~4.3.4",
+                "@jupyterlab/services": "~7.3.4",
+                "@jupyterlite/localforage": "^0.5.1",
                 "@lumino/coreutils": "^2.2.0",
                 "@types/emscripten": "^1.39.6",
                 "localforage": "^1.9.0",
@@ -505,11 +512,12 @@
             }
         },
         "node_modules/@jupyterlite/localforage": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@jupyterlite/localforage/-/localforage-0.4.1.tgz",
-            "integrity": "sha512-/m2da3Y4G7EbFkHqb+dXHxvsr4lg+GzNQyPMcnqkHZIgcCVGXKFecSqjwDxPyGSfwmIbnfILB/4HB840/UZBwg==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@jupyterlite/localforage/-/localforage-0.5.1.tgz",
+            "integrity": "sha512-QAswNRQxYPeXe4vPVh9CB9+xStJbuwWcK/RH/U1NaZv5o7mmHy6Du1sLbksQo0CC6+bGlkQJaoV2gHOsX9oe4w==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "@jupyterlab/coreutils": "~6.2.5",
+                "@jupyterlab/coreutils": "~6.3.4",
                 "@lumino/coreutils": "^2.2.0",
                 "localforage": "^1.9.0",
                 "localforage-memoryStorageDriver": "^0.9.2"
@@ -530,6 +538,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-2.3.1.tgz",
             "integrity": "sha512-DpX1kkE4PhILpvK1T4ZnaFb6UP4+YTkdZifvN3nbiomD64O2CTd+wcWIBpZMgy6MMgbVgrE8dzHxHk1EsKxNxw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@lumino/algorithm": "^2.0.2",
                 "@lumino/coreutils": "^2.2.0",
@@ -560,17 +569,20 @@
         "node_modules/@lumino/domutils": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-2.0.2.tgz",
-            "integrity": "sha512-2Kp6YHaMNI1rKB0PrALvOsZBHPy2EvVVAvJLWjlCm8MpWOVETjFp0MA9QpMubT9I76aKbaI5s1o1NJyZ8Y99pQ=="
+            "integrity": "sha512-2Kp6YHaMNI1rKB0PrALvOsZBHPy2EvVVAvJLWjlCm8MpWOVETjFp0MA9QpMubT9I76aKbaI5s1o1NJyZ8Y99pQ==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@lumino/keyboard": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-2.0.2.tgz",
-            "integrity": "sha512-icRUpvswDaFjqmAJNbQRb/aTu6Iugo6Y2oC08TiIwhQtLS9W+Ee9VofdqvbPSvCm6DkyP+DCWMuA3KXZ4V4g4g=="
+            "integrity": "sha512-icRUpvswDaFjqmAJNbQRb/aTu6Iugo6Y2oC08TiIwhQtLS9W+Ee9VofdqvbPSvCm6DkyP+DCWMuA3KXZ4V4g4g==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@lumino/polling": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/@lumino/polling/-/polling-2.1.3.tgz",
             "integrity": "sha512-WEZk96ddK6eHEhdDkFUAAA40EOLit86QVbqQqnbPmhdGwFogek26Kq9b1U273LJeirv95zXCATOJAkjRyb7D+w==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@lumino/coreutils": "^2.2.0",
                 "@lumino/disposable": "^2.1.3",
@@ -580,7 +592,8 @@
         "node_modules/@lumino/properties": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-2.0.2.tgz",
-            "integrity": "sha512-b312oA3Bh97WFK8efXejYmC3DVJmvzJk72LQB7H3fXhfqS5jUWvL7MSnNmgcQvGzl9fIhDWDWjhtSTi0KGYYBg=="
+            "integrity": "sha512-b312oA3Bh97WFK8efXejYmC3DVJmvzJk72LQB7H3fXhfqS5jUWvL7MSnNmgcQvGzl9fIhDWDWjhtSTi0KGYYBg==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@lumino/signaling": {
             "version": "2.1.3",
@@ -596,6 +609,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-2.0.2.tgz",
             "integrity": "sha512-HYZThOtZSoknjdXA102xpy5CiXtTFCVz45EXdWeYLx3NhuEwuAIX93QBBIhupalmtFlRg1yhdDNV40HxJ4kcXg==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@lumino/algorithm": "^2.0.2"
             }
@@ -699,9 +713,10 @@
             "dev": true
         },
         "node_modules/@rjsf/utils": {
-            "version": "5.20.1",
-            "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.20.1.tgz",
-            "integrity": "sha512-bQrJt5lsAHbdmivIDDVJPXPCkkXJZvXBx8MrjA5umGO2+tykPcphZx/75+1AY5WhUECSgwBeZe2DEWhPbX46oQ==",
+            "version": "5.24.3",
+            "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.24.3.tgz",
+            "integrity": "sha512-IFzMyr6RDRgSi9jdfFBomwc8LMul6zLBsRSAgzD9wAB9laDcYHwPNEL2kZhOkAGrc+4iNQSPsawGFOA6CXH87Q==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "json-schema-merge-allof": "^0.8.1",
                 "jsonpointer": "^5.0.1",
@@ -1979,9 +1994,10 @@
             "dev": true
         },
         "node_modules/comlink": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.1.tgz",
-            "integrity": "sha512-+1dlx0aY5Jo1vHy/tSsIGpSkN4tS9rZSW8FIhG0JH/crs9wwweswIo/POr451r7bZww3hFbPAKnTpimzL/mm4Q=="
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+            "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+            "license": "Apache-2.0"
         },
         "node_modules/commander": {
             "version": "2.20.3",
@@ -3536,7 +3552,8 @@
         "node_modules/immediate": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -3772,6 +3789,7 @@
             "version": "0.2.5",
             "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
             "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+            "license": "MIT",
             "funding": {
                 "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
@@ -3823,12 +3841,6 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "peer": true
-        },
         "node_modules/js-yaml": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -3858,6 +3870,7 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
             "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.4"
             }
@@ -3866,6 +3879,7 @@
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
             "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
+            "license": "MIT",
             "dependencies": {
                 "compute-lcm": "^1.1.2",
                 "json-schema-compare": "^0.2.2",
@@ -3890,6 +3904,7 @@
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "license": "MIT",
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -3901,6 +3916,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
             "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3938,9 +3954,10 @@
             }
         },
         "node_modules/lib0": {
-            "version": "0.2.97",
-            "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.97.tgz",
-            "integrity": "sha512-Q4d1ekgvufi9FiHkkL46AhecfNjznSL9MRNoJRQ76gBHS9OqU2ArfQK0FvBpuxgWeJeNI0LVgAYMIpsGeX4gYg==",
+            "version": "0.2.99",
+            "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
+            "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+            "license": "MIT",
             "dependencies": {
                 "isomorphic.js": "^0.2.4"
             },
@@ -3961,6 +3978,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
             "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+            "license": "MIT",
             "dependencies": {
                 "immediate": "~3.0.5"
             }
@@ -3979,6 +3997,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
             "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "lie": "3.1.1"
             }
@@ -4014,25 +4033,14 @@
         "node_modules/lodash-es": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+            "license": "MIT"
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
-        },
-        "node_modules/loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "peer": true,
-            "dependencies": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            },
-            "bin": {
-                "loose-envify": "cli.js"
-            }
         },
         "node_modules/lru-cache": {
             "version": "10.4.3",
@@ -4180,6 +4188,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -4459,7 +4468,8 @@
         "node_modules/path-browserify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "license": "MIT"
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -4625,7 +4635,8 @@
         "node_modules/querystringify": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "license": "MIT"
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -4682,13 +4693,11 @@
             }
         },
         "node_modules/react": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "version": "19.0.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+            "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+            "license": "MIT",
             "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4696,7 +4705,8 @@
         "node_modules/react-is": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "license": "MIT"
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",
@@ -5821,6 +5831,7 @@
             "version": "1.5.10",
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "license": "MIT",
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -5853,7 +5864,8 @@
         "node_modules/validate.io-array": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-            "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
+            "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==",
+            "license": "MIT"
         },
         "node_modules/validate.io-function": {
             "version": "1.0.2",
@@ -6352,6 +6364,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
             "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+            "license": "MIT",
             "dependencies": {
                 "lib0": "^0.2.85"
             },
@@ -6404,11 +6417,12 @@
             }
         },
         "node_modules/yjs": {
-            "version": "13.6.18",
-            "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.18.tgz",
-            "integrity": "sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==",
+            "version": "13.6.23",
+            "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
+            "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
+            "license": "MIT",
             "dependencies": {
-                "lib0": "^0.2.86"
+                "lib0": "^0.2.99"
             },
             "engines": {
                 "node": ">=16.0.0",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
         "prettier:check": "prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml}\""
     },
     "dependencies": {
-        "@jupyterlite/contents": "^0.4.1",
+        "@jupyterlite/contents": "^0.5.1",
         "@lumino/disposable": "^2.1.3",
         "@lumino/signaling": "^2.1.3",
-        "comlink": "^4.4.1",
+        "comlink": "^4.4.2",
         "deepmerge-ts": "^7.1.4",
         "rimraf": "^6.0.1",
         "zod": "^3.23.8"

--- a/src/cockle_drive_fs.ts
+++ b/src/cockle_drive_fs.ts
@@ -1,0 +1,16 @@
+import { ContentsAPI, DriveFS, ServiceWorkerContentsAPI } from '@jupyterlite/contents';
+
+/**
+ * Custom drive implementation using the service worker
+ */
+export class CockleDriveFS extends DriveFS {
+  createAPI(options: DriveFS.IOptions): ContentsAPI {
+    return new ServiceWorkerContentsAPI(
+      options.baseUrl,
+      options.driveName,
+      options.mountpoint,
+      options.FS,
+      options.ERRNO_CODES
+    );
+  }
+}

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -1,7 +1,6 @@
-import { DriveFS } from '@jupyterlite/contents';
-
 import { Aliases } from './aliases';
 import { ansi } from './ansi';
+import { CockleDriveFS } from './cockle_drive_fs';
 import { CommandRegistry } from './command_registry';
 import { Context } from './context';
 import { IShellImpl, IShellWorker } from './defs_internal';
@@ -276,18 +275,18 @@ export class ShellImpl implements IShellWorker {
     const { FS, PATH, ERRNO_CODES, PROXYFS } = module;
 
     const { mountpoint } = this;
-    FS.mkdir(mountpoint, 0o777);
+    FS.mkdirTree(mountpoint, 0o777);
     this._fileSystem = { FS, PATH, ERRNO_CODES, PROXYFS };
 
     const { driveFsBaseUrl, initialDirectories, initialFiles } = this.options;
     if (driveFsBaseUrl) {
-      this._driveFS = new DriveFS({
+      this._driveFS = new CockleDriveFS({
         FS,
         PATH,
         ERRNO_CODES,
         baseUrl: driveFsBaseUrl,
         driveName: '',
-        mountpoint: mountpoint
+        mountpoint
       });
       FS.mount(this._driveFS, {}, mountpoint);
     }
@@ -581,5 +580,5 @@ export class ShellImpl implements IShellWorker {
   private _wasmModuleLoader: WasmModuleLoader;
 
   private _fileSystem?: IFileSystem;
-  private _driveFS?: DriveFS;
+  private _driveFS?: CockleDriveFS;
 }


### PR DESCRIPTION
Switch the JupyterLite `DriveFS` access to use the service worker as is done in both pyodide and xeus kernels in situations with a similar architecture (kernel/terminal running in a webworker, communicating with main worker using `comlink`, `DriveFS` accessed from webworker).

Fixes #106. Tested locally to show this. We will need a new release after this followed by testing and release of `terminal`.