### PR TITLE
Use ready promise before starting shell

### DIFF
--- a/demo/playwright.config.ts
+++ b/demo/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: './ui-tests',
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
+  workers: process.env.CI ? 1 : undefined,
   reporter: [['html', { open: 'never' }]],
   use: {
     baseURL: 'http://localhost:4501',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@jupyterlite/contents": "^0.5.1",
+                "@lumino/coreutils": "^2.2.0",
                 "@lumino/disposable": "^2.1.3",
                 "@lumino/signaling": "^2.1.3",
                 "comlink": "^4.4.2",
@@ -553,6 +554,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-2.2.0.tgz",
             "integrity": "sha512-x5wnQ/GjWBayJ6vXVaUi6+Q6ETDdcUiH9eSfpRZFbgMQyyM6pi6baKqJBK2CHkCc/YbAEl6ipApTgm3KOJ/I3g==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@lumino/algorithm": "^2.0.2"
             }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     },
     "dependencies": {
         "@jupyterlite/contents": "^0.5.1",
+        "@lumino/coreutils": "^2.2.0",
         "@lumino/disposable": "^2.1.3",
         "@lumino/signaling": "^2.1.3",
         "comlink": "^4.4.2",

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,4 +1,3 @@
-
 import { PromiseDelegate } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,3 +1,5 @@
+
+import { PromiseDelegate } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 
 import { proxy, wrap } from 'comlink';
@@ -14,7 +16,7 @@ import { DownloadTracker } from './download_tracker';
 export class Shell implements IShell {
   constructor(readonly options: IShell.IOptions) {
     this._bufferedIO = new MainBufferedIO(options.outputCallback);
-    this._initWorker(options);
+    this._initWorker(options).then(this._ready.resolve.bind(this._ready));
   }
 
   private async _initWorker(options: IShell.IOptions) {
@@ -120,6 +122,13 @@ export class Shell implements IShell {
     }
   }
 
+  /**
+   * A promise that is fulfilled when the terminal is ready to be started.
+   */
+  get ready(): Promise<void> {
+    return this._ready.promise;
+  }
+
   async setSize(rows: number, columns: number): Promise<void> {
     if (this.isDisposed) {
       return;
@@ -133,6 +142,7 @@ export class Shell implements IShell {
       return;
     }
 
+    await this.ready;
     await this._bufferedIO.start();
     await this._remote!.start();
   }
@@ -142,5 +152,6 @@ export class Shell implements IShell {
   private _bufferedIO: MainBufferedIO;
   private _disposed = new Signal<this, void>(this);
   private _isDisposed = false;
+  private _ready = new PromiseDelegate<void>();
   private _downloadTracker?: DownloadTracker;
 }

--- a/src/shell_worker.ts
+++ b/src/shell_worker.ts
@@ -5,7 +5,8 @@ import { IShellWorker } from './defs_internal';
 import { ShellImpl } from './shell_impl';
 
 /**
- * WebWorker running ShellImpl.
+ * WebWorker running ShellImpl. Implementation-specific code (comlink) is here to avoid polluting
+ * ShellImpl with it.
  */
 export class ShellWorker implements IShellWorker {
   async initialize(

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: './tests',
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
+  workers: process.env.CI ? 1 : undefined,
   reporter: [['html', { open: 'never' }]],
   use: {
     baseURL: 'http://localhost:8000',

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -75,9 +75,5 @@ async function _shellSetupCommon(options: IOptions, level: number): Promise<IShe
   await shell.start();
   output.start();
 
-  // Add a small sleep to avoid timing problems loading wasm modules.
-  const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-  await sleep(20);
-
   return { shell, output };
 }


### PR DESCRIPTION
Use a `ready` `PromiseDelegate` (from `@lumino/coreutils`) to indicate when a `Shell` is ready to be started. This ensures that the shell is not used until the web worker is fully ready to do so, and allows us to resume running tests in parallel without any `sleep` calls. Have returned `workers` setting in `playwright.config.ts` to its default.

FIxes #50.