### PR TITLE
Stop download notification if fail to importScripts

### DIFF
--- a/src/commands/command_module_loader.ts
+++ b/src/commands/command_module_loader.ts
@@ -21,10 +21,13 @@ export class CommandModuleLoader {
       console.log('Cockle importing JavaScript/WebAssembly from ' + url);
 
       this.downloadModuleCallback(packageName, moduleName, true);
-      importScripts(url);
-      module = (self as any).Module;
-      this.cache.set(packageName, moduleName, module);
-      this.downloadModuleCallback(packageName, moduleName, false);
+      try {
+        importScripts(url);
+        module = (self as any).Module;
+        this.cache.set(packageName, moduleName, module);
+      } finally {
+        this.downloadModuleCallback(packageName, moduleName, false);
+      }
     }
     return module;
   }


### PR DESCRIPTION
If `importScripts` fails then currently the download feedback notification continues for ever. This ensures it stops.