### PR TITLE
Use TypeScript type definitions for WebAssembly modules

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ node_modules
 **/package-lock.json
 !/package.json
 **/wasm/*.js
+src/fs.d.ts

--- a/src/commands/command_module_cache.ts
+++ b/src/commands/command_module_cache.ts
@@ -1,5 +1,7 @@
+import type { default as EmscriptenModuleFactory } from '../fs';
+
 export class CommandModuleCache {
-  get(packageName: string, moduleName: string): any {
+  get(packageName: string, moduleName: string): typeof EmscriptenModuleFactory | undefined {
     const key = this.key(packageName, moduleName);
     return this._cache.get(key) ?? undefined;
   }
@@ -13,10 +15,10 @@ export class CommandModuleCache {
     return [packageName, moduleName].join('/');
   }
 
-  set(packageName: string, moduleName: string, module: any): void {
+  set(packageName: string, moduleName: string, module: typeof EmscriptenModuleFactory): void {
     const key = this.key(packageName, moduleName);
     this._cache.set(key, module);
   }
 
-  private _cache = new Map<string, any>();
+  private _cache = new Map<string, typeof EmscriptenModuleFactory>();
 }

--- a/src/commands/command_module_loader.ts
+++ b/src/commands/command_module_loader.ts
@@ -1,5 +1,6 @@
 import { CommandModuleCache } from './command_module_cache';
 import { IShellWorker } from '../defs_internal';
+import { default as EmscriptenModuleFactory } from '../fs';
 
 /**
  * Loader of JavaScript/WASM modules. Once loaded, a module is cached so that it is faster to
@@ -12,7 +13,15 @@ export class CommandModuleLoader {
     readonly downloadModuleCallback: IShellWorker.IProxyDownloadModuleCallback
   ) {}
 
-  public getModule(packageName: string, moduleName: string): any {
+  /**
+   * Load the specified WebAssembly module.
+   * If loading fails return undefined, and caller is responsible for reporting this to the user if
+   * appropriate.
+   */
+  public getModule(
+    packageName: string,
+    moduleName: string
+  ): typeof EmscriptenModuleFactory | undefined {
     let module = this.cache.get(packageName, moduleName);
     if (module === undefined) {
       // Maybe should use @jupyterlab/coreutils.URLExt to combine URL components.
@@ -23,10 +32,13 @@ export class CommandModuleLoader {
       this.downloadModuleCallback(packageName, moduleName, true);
       try {
         importScripts(url);
-        module = (self as any).Module;
-        this.cache.set(packageName, moduleName, module);
+        module = (self as any).Module as typeof EmscriptenModuleFactory;
       } finally {
         this.downloadModuleCallback(packageName, moduleName, false);
+      }
+
+      if (module !== undefined) {
+        this.cache.set(packageName, moduleName, module);
       }
     }
     return module;

--- a/src/error_exit_code.ts
+++ b/src/error_exit_code.ts
@@ -15,6 +15,12 @@ export class FindCommandError extends ErrorExitCode {
   }
 }
 
+export class LoadCommandError extends ErrorExitCode {
+  constructor(commandName: string) {
+    super(ExitCode.CANNOT_FIND_COMMAND, `'${commandName}': cannot load command`);
+  }
+}
+
 export class GeneralError extends ErrorExitCode {
   constructor(message: string) {
     super(ExitCode.GENERAL_ERROR, message);

--- a/src/file_system.ts
+++ b/src/file_system.ts
@@ -1,7 +1,9 @@
+import { RuntimeExports } from './fs';
+
 export interface IFileSystem {
-  FS: any;
-  PATH: any;
-  ERRNO_CODES: any;
-  PROXYFS: any;
+  FS: typeof RuntimeExports.FS;
+  PATH: typeof RuntimeExports.PATH;
+  ERRNO_CODES: typeof RuntimeExports.ERRNO_CODES;
+  PROXYFS: typeof RuntimeExports.PROXYFS;
   mountpoint: string;
 }

--- a/src/fs.d.ts
+++ b/src/fs.d.ts
@@ -1,0 +1,390 @@
+/**
+ * This file is created by the emscripten build process of the cockle_fs package so that it
+ * matches the version of emscripten (3.1.73) that is used for WebAssembly command packages.
+ *
+ * Modified to add extra optional functions and properties to WasmModule such as ENV and
+ * getEnvStrings.
+ */
+
+// TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
+declare namespace RuntimeExports {
+    namespace FS {
+        export let root: any;
+        export let mounts: any[];
+        export let devices: {};
+        export let streams: any[];
+        export let nextInode: number;
+        export let nameTable: any;
+        export let currentPath: string;
+        export let initialized: boolean;
+        export let ignorePermissions: boolean;
+        export { ErrnoError };
+        export let filesystems: any;
+        export let syncFSRequests: number;
+        export let readFiles: {};
+        export { FSStream };
+        export { FSNode };
+        export function lookupPath(path: any, opts?: {}): {
+            path: string;
+            node: any;
+        };
+        export function getPath(node: any): any;
+        export function hashName(parentid: any, name: any): number;
+        export function hashAddNode(node: any): void;
+        export function hashRemoveNode(node: any): void;
+        export function lookupNode(parent: any, name: any): any;
+        export function createNode(parent: any, name: any, mode: any, rdev: any): any;
+        export function destroyNode(node: any): void;
+        export function isRoot(node: any): boolean;
+        export function isMountpoint(node: any): boolean;
+        export function isFile(mode: any): boolean;
+        export function isDir(mode: any): boolean;
+        export function isLink(mode: any): boolean;
+        export function isChrdev(mode: any): boolean;
+        export function isBlkdev(mode: any): boolean;
+        export function isFIFO(mode: any): boolean;
+        export function isSocket(mode: any): boolean;
+        export function flagsToPermissionString(flag: any): string;
+        export function nodePermissions(node: any, perms: any): 0 | 2;
+        export function mayLookup(dir: any): any;
+        export function mayCreate(dir: any, name: any): any;
+        export function mayDelete(dir: any, name: any, isdir: any): any;
+        export function mayOpen(node: any, flags: any): any;
+        export let MAX_OPEN_FDS: number;
+        export function nextfd(): number;
+        export function getStreamChecked(fd: any): any;
+        export function getStream(fd: any): any;
+        export function createStream(stream: any, fd?: number): any;
+        export function closeStream(fd: any): void;
+        export function dupStream(origStream: any, fd?: number): any;
+        export namespace chrdev_stream_ops {
+            function open(stream: any): void;
+            function llseek(): never;
+        }
+        export function major(dev: any): number;
+        export function minor(dev: any): number;
+        export function makedev(ma: any, mi: any): number;
+        export function registerDevice(dev: any, ops: any): void;
+        export function getDevice(dev: any): any;
+        export function getMounts(mount: any): any[];
+        export function syncfs(populate: any, callback: any): void;
+        export function mount(type: any, opts: any, mountpoint: any): any;
+        export function unmount(mountpoint: any): void;
+        export function lookup(parent: any, name: any): any;
+        export function mknod(path: any, mode: any, dev: any): any;
+        export function statfs(path: any): {
+            bsize: number;
+            frsize: number;
+            blocks: number;
+            bfree: number;
+            bavail: number;
+            files: any;
+            ffree: number;
+            fsid: number;
+            flags: number;
+            namelen: number;
+        };
+        export function create(path: any, mode?: number): any;
+        export function mkdir(path: any, mode?: number): any;
+        export function mkdirTree(path: any, mode: any): void;
+        export function mkdev(path: any, mode: any, dev: any): any;
+        export function symlink(oldpath: any, newpath: any): any;
+        export function rename(old_path: any, new_path: any): void;
+        export function rmdir(path: any): void;
+        export function readdir(path: any): any;
+        export function unlink(path: any): void;
+        export function readlink(path: any): any;
+        export function stat(path: any, dontFollow: any): any;
+        export function lstat(path: any): any;
+        export function chmod(path: any, mode: any, dontFollow: any): void;
+        export function lchmod(path: any, mode: any): void;
+        export function fchmod(fd: any, mode: any): void;
+        export function chown(path: any, uid: any, gid: any, dontFollow: any): void;
+        export function lchown(path: any, uid: any, gid: any): void;
+        export function fchown(fd: any, uid: any, gid: any): void;
+        export function truncate(path: any, len: any): void;
+        export function ftruncate(fd: any, len: any): void;
+        export function utime(path: any, atime: any, mtime: any): void;
+        export function open(path: any, flags: any, mode?: number): any;
+        export function close(stream: any): void;
+        export function isClosed(stream: any): boolean;
+        export function llseek(stream: any, offset: any, whence: any): any;
+        export function read(stream: any, buffer: any, offset: any, length: any, position: any): any;
+        export function write(stream: any, buffer: any, offset: any, length: any, position: any, canOwn: any): any;
+        export function allocate(stream: any, offset: any, length: any): void;
+        export function mmap(stream: any, length: any, position: any, prot: any, flags: any): any;
+        export function msync(stream: any, buffer: any, offset: any, length: any, mmapFlags: any): any;
+        export function ioctl(stream: any, cmd: any, arg: any): any;
+        export function readFile(path: any, opts?: {}): any;
+        export function writeFile(path: any, data: any, opts?: {}): void;
+        export function cwd(): any;
+        export function chdir(path: any): void;
+        export function createDefaultDirectories(): void;
+        export function createDefaultDevices(): void;
+        export function createSpecialDirectories(): void;
+        export function createStandardStreams(input: any, output: any, error: any): void;
+        export function staticInit(): void;
+        export function init(input: any, output: any, error: any): void;
+        export function quit(): void;
+        export function findObject(path: any, dontResolveLastLink: any): any;
+        export function analyzePath(path: any, dontResolveLastLink: any): {
+            isRoot: boolean;
+            exists: boolean;
+            error: number;
+            name: any;
+            path: any;
+            object: any;
+            parentExists: boolean;
+            parentPath: any;
+            parentObject: any;
+        };
+        export function createPath(parent: any, path: any, canRead: any, canWrite: any): any;
+        export function createFile(parent: any, name: any, properties: any, canRead: any, canWrite: any): any;
+        export function createDataFile(parent: any, name: any, data: any, canRead: any, canWrite: any, canOwn: any): void;
+        export function createDevice(parent: any, name: any, input: any, output: any): any;
+        export function forceLoadFile(obj: any): boolean;
+        export function createLazyFile(parent: any, name: any, url: any, canRead: any, canWrite: any): any;
+        export function absolutePath(): void;
+        export function createFolder(): void;
+        export function createLink(): void;
+        export function joinPath(): void;
+        export function mmapAlloc(): void;
+        export function standardizePath(): void;
+    }
+    namespace PATH {
+        function isAbs(path: any): boolean;
+        function splitPath(filename: any): string[];
+        function normalizeArray(parts: any, allowAboveRoot: any): any;
+        function normalize(path: any): string;
+        function dirname(path: any): any;
+        function basename(path: any): any;
+        function join(...paths: any[]): any;
+        function join2(l: any, r: any): any;
+    }
+    namespace ERRNO_CODES {
+        let EPERM: number;
+        let ENOENT: number;
+        let ESRCH: number;
+        let EINTR: number;
+        let EIO: number;
+        let ENXIO: number;
+        let E2BIG: number;
+        let ENOEXEC: number;
+        let EBADF: number;
+        let ECHILD: number;
+        let EAGAIN: number;
+        let EWOULDBLOCK: number;
+        let ENOMEM: number;
+        let EACCES: number;
+        let EFAULT: number;
+        let ENOTBLK: number;
+        let EBUSY: number;
+        let EEXIST: number;
+        let EXDEV: number;
+        let ENODEV: number;
+        let ENOTDIR: number;
+        let EISDIR: number;
+        let EINVAL: number;
+        let ENFILE: number;
+        let EMFILE: number;
+        let ENOTTY: number;
+        let ETXTBSY: number;
+        let EFBIG: number;
+        let ENOSPC: number;
+        let ESPIPE: number;
+        let EROFS: number;
+        let EMLINK: number;
+        let EPIPE: number;
+        let EDOM: number;
+        let ERANGE: number;
+        let ENOMSG: number;
+        let EIDRM: number;
+        let ECHRNG: number;
+        let EL2NSYNC: number;
+        let EL3HLT: number;
+        let EL3RST: number;
+        let ELNRNG: number;
+        let EUNATCH: number;
+        let ENOCSI: number;
+        let EL2HLT: number;
+        let EDEADLK: number;
+        let ENOLCK: number;
+        let EBADE: number;
+        let EBADR: number;
+        let EXFULL: number;
+        let ENOANO: number;
+        let EBADRQC: number;
+        let EBADSLT: number;
+        let EDEADLOCK: number;
+        let EBFONT: number;
+        let ENOSTR: number;
+        let ENODATA: number;
+        let ETIME: number;
+        let ENOSR: number;
+        let ENONET: number;
+        let ENOPKG: number;
+        let EREMOTE: number;
+        let ENOLINK: number;
+        let EADV: number;
+        let ESRMNT: number;
+        let ECOMM: number;
+        let EPROTO: number;
+        let EMULTIHOP: number;
+        let EDOTDOT: number;
+        let EBADMSG: number;
+        let ENOTUNIQ: number;
+        let EBADFD: number;
+        let EREMCHG: number;
+        let ELIBACC: number;
+        let ELIBBAD: number;
+        let ELIBSCN: number;
+        let ELIBMAX: number;
+        let ELIBEXEC: number;
+        let ENOSYS: number;
+        let ENOTEMPTY: number;
+        let ENAMETOOLONG: number;
+        let ELOOP: number;
+        let EOPNOTSUPP: number;
+        let EPFNOSUPPORT: number;
+        let ECONNRESET: number;
+        let ENOBUFS: number;
+        let EAFNOSUPPORT: number;
+        let EPROTOTYPE: number;
+        let ENOTSOCK: number;
+        let ENOPROTOOPT: number;
+        let ESHUTDOWN: number;
+        let ECONNREFUSED: number;
+        let EADDRINUSE: number;
+        let ECONNABORTED: number;
+        let ENETUNREACH: number;
+        let ENETDOWN: number;
+        let ETIMEDOUT: number;
+        let EHOSTDOWN: number;
+        let EHOSTUNREACH: number;
+        let EINPROGRESS: number;
+        let EALREADY: number;
+        let EDESTADDRREQ: number;
+        let EMSGSIZE: number;
+        let EPROTONOSUPPORT: number;
+        let ESOCKTNOSUPPORT: number;
+        let EADDRNOTAVAIL: number;
+        let ENETRESET: number;
+        let EISCONN: number;
+        let ENOTCONN: number;
+        let ETOOMANYREFS: number;
+        let EUSERS: number;
+        let EDQUOT: number;
+        let ESTALE: number;
+        let ENOTSUP: number;
+        let ENOMEDIUM: number;
+        let EILSEQ: number;
+        let EOVERFLOW: number;
+        let ECANCELED: number;
+        let ENOTRECOVERABLE: number;
+        let EOWNERDEAD: number;
+        let ESTRPIPE: number;
+    }
+    namespace PROXYFS {
+        function mount(mount: any): any;
+        function createNode(parent: any, name: any, mode: any, dev: any): any;
+        function realPath(node: any): any;
+        namespace node_ops {
+            function getattr(node: any): {
+                dev: any;
+                ino: any;
+                mode: any;
+                nlink: any;
+                uid: any;
+                gid: any;
+                rdev: any;
+                size: any;
+                atime: any;
+                mtime: any;
+                ctime: any;
+                blksize: any;
+                blocks: any;
+            };
+            function setattr(node: any, attr: any): void;
+            function lookup(parent: any, name: any): any;
+            function mknod(parent: any, name: any, mode: any, dev: any): any;
+            function rename(oldNode: any, newDir: any, newName: any): void;
+            function unlink(parent: any, name: any): void;
+            function rmdir(parent: any, name: any): void;
+            function readdir(node: any): any;
+            function symlink(parent: any, newName: any, oldPath: any): void;
+            function readlink(node: any): any;
+        }
+        namespace stream_ops {
+            function open(stream: any): void;
+            function close(stream: any): void;
+            function read(stream: any, buffer: any, offset: any, length: any, position: any): any;
+            function write(stream: any, buffer: any, offset: any, length: any, position: any): any;
+            function llseek(stream: any, offset: any, whence: any): any;
+        }
+    }
+    let HEAPF32: any;
+    let HEAPF64: any;
+    let HEAP_DATA_VIEW: any;
+    let HEAP8: any;
+    let HEAPU8: any;
+    let HEAP16: any;
+    let HEAPU16: any;
+    let HEAP32: any;
+    let HEAPU32: any;
+    let HEAP64: any;
+    let HEAPU64: any;
+    let FS_createPath: any;
+    function FS_createDataFile(parent: any, name: any, fileData: any, canRead: any, canWrite: any, canOwn: any): void;
+    function FS_createPreloadedFile(parent: any, name: any, url: any, canRead: any, canWrite: any, onload: any, onerror: any, dontCreateFile: any, canOwn: any, preFinish: any): void;
+    function FS_unlink(path: any): any;
+    let FS_createLazyFile: any;
+    let FS_createDevice: any;
+    let addRunDependency: any;
+    let removeRunDependency: any;
+}
+declare class ErrnoError extends Error {
+    constructor(errno: any);
+    errno: any;
+    code: string;
+}
+declare class FSStream {
+    shared: {};
+    set object(val: any);
+    get object(): any;
+    node: any;
+    get isRead(): boolean;
+    get isWrite(): boolean;
+    get isAppend(): number;
+    set flags(val: any);
+    get flags(): any;
+    set position(val: any);
+    get position(): any;
+}
+declare class FSNode {
+    constructor(parent: any, name: any, mode: any, rdev: any);
+    node_ops: {};
+    stream_ops: {};
+    readMode: number;
+    writeMode: number;
+    mounted: any;
+    parent: any;
+    mount: any;
+    id: number;
+    name: any;
+    mode: any;
+    rdev: any;
+    set read(val: boolean);
+    get read(): boolean;
+    set write(val: boolean);
+    get write(): boolean;
+    get isFolder(): any;
+    get isDevice(): any;
+}
+interface WasmModule {
+    ENV?: { [key: string]: string };
+    TTY?: any;
+    getEnvStrings?(): string[];
+}
+
+export type MainModule = WasmModule & typeof RuntimeExports;
+export default function MainModuleFactory (options?: unknown): Promise<MainModule>;

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -281,6 +281,12 @@ export class ShellImpl implements IShellWorker {
   private async _initFileSystem(): Promise<void> {
     const { wasmBaseUrl } = this.options;
     const fsModule = this._commandModuleLoader.getModule('cockle_fs', 'fs');
+    if (fsModule === undefined) {
+      // Cannot report this in the terminal as it has not been started yet.
+      // TODO: Store this information and report it when the terminal is up and running?
+      console.error('Unable to load cockle_fs, shell cannot function');
+      return;
+    }
     const module = await fsModule({
       locateFile: (path: string) => wasmBaseUrl + 'cockle_fs/' + path
     });
@@ -517,7 +523,7 @@ export class ShellImpl implements IShellWorker {
       const initialLookup = lookup;
       lookup = analyze.name;
       const { exists } = analyze;
-      if (exists && !FS.isDir(FS.stat(analyze.path).mode)) {
+      if (exists && !FS.isDir(FS.stat(analyze.path, false).mode)) {
         // Exactly matches a filename.
         possibles = [lookup];
       } else {
@@ -544,7 +550,7 @@ export class ShellImpl implements IShellWorker {
 
         // Directories are displayed with appended /
         possibles = possibles.map((path: string) =>
-          FS.isDir(FS.stat(lookupPath + '/' + path).mode) ? path + '/' : path
+          FS.isDir(FS.stat(lookupPath + '/' + path, false).mode) ? path + '/' : path
         );
       }
     }


### PR DESCRIPTION
Use TypeScript type definitions for WebAssembly modules. These are generated at compile time in the emscripten-forge recipe for `cockle_fs` so that they use the same version of emscripten as the WebAssembly commands, rather than the `npmjs` package `@types/emscripten`.

This allows us to reduce the number of `any` types for interacting with WebAssembly modules.