### PR TITLE
Simplify syntax of Options argument parsing

### DIFF
--- a/src/builtin/alias_command.ts
+++ b/src/builtin/alias_command.ts
@@ -15,7 +15,7 @@ export class AliasCommand extends BuiltinCommand {
 
   protected async _run(context: IContext): Promise<number> {
     const { aliases, args, stdout } = context;
-    const options = Options.fromArgs(args, AliasOptions);
+    const options = new AliasOptions().parse(args);
 
     if (options.trailingStrings.isSet) {
       for (const name of options.trailingStrings.strings) {

--- a/src/builtin/cd_command.ts
+++ b/src/builtin/cd_command.ts
@@ -16,7 +16,7 @@ export class CdCommand extends BuiltinCommand {
 
   protected async _run(context: IContext): Promise<number> {
     const { args } = context;
-    const options = Options.fromArgs(args, CdOptions);
+    const options = new CdOptions().parse(args);
     const paths = options.trailingStrings.strings;
 
     if (paths.length < 1) {

--- a/src/builtin/export_command.ts
+++ b/src/builtin/export_command.ts
@@ -15,7 +15,7 @@ export class ExportCommand extends BuiltinCommand {
 
   protected async _run(context: IContext): Promise<number> {
     const { args, environment } = context;
-    const options = Options.fromArgs(args, ExportOptions);
+    const options = new ExportOptions().parse(args);
 
     if (options.trailingStrings.isSet) {
       for (const name of options.trailingStrings.strings) {

--- a/src/builtin/history_command.ts
+++ b/src/builtin/history_command.ts
@@ -16,7 +16,7 @@ export class HistoryCommand extends BuiltinCommand {
 
   protected async _run(context: IContext): Promise<number> {
     const { args, history, stdout } = context;
-    const options = Options.fromArgs(args, HistoryOptions);
+    const options = new HistoryOptions().parse(args);
 
     if (options.help.isSet) {
       options.writeHelp(stdout);

--- a/src/builtin/options.ts
+++ b/src/builtin/options.ts
@@ -6,10 +6,8 @@ import { GeneralError } from '../error_exit_code';
 import { IOutput } from '../io';
 
 export abstract class Options {
-  static fromArgs<T extends Options>(args: string[], optionsType: new () => T): T {
-    const options = new optionsType();
-
-    const trailingStrings: TrailingStringsOption | null = options._getStrings();
+  parse(args: string[]): this {
+    const trailingStrings = this._getStrings();
     let inTrailingStrings = false;
 
     for (const arg of args) {
@@ -19,10 +17,10 @@ export abstract class Options {
         }
         if (arg.startsWith('--')) {
           const longName = arg.slice(2);
-          options._findByLongName(longName).set();
+          this._findByLongName(longName).set();
         } else {
           const shortName = arg.slice(1);
-          options._findByShortName(shortName).set();
+          this._findByShortName(shortName).set();
         }
       } else if (trailingStrings !== null) {
         trailingStrings.add(arg);
@@ -36,7 +34,7 @@ export abstract class Options {
       throw new GeneralError('Insufficient trailing strings options specified');
     }
 
-    return options;
+    return this;
   }
 
   writeHelp(output: IOutput): void {


### PR DESCRIPTION
Simplify syntax of `Options` argument parsing, removing the complex generic syntax in `fromArgs`.