### PR TITLE
Use input read() function rather than get_char() to read multiple characters at a time

### DIFF
--- a/src/io/input_all.ts
+++ b/src/io/input_all.ts
@@ -25,7 +25,7 @@ export abstract class InputAll implements IInput {
       }
       return ret;
     } else {
-      return [4]; // EOT
+      return [];
     }
   }
 

--- a/src/io/terminal_input.ts
+++ b/src/io/terminal_input.ts
@@ -9,19 +9,9 @@ export class TerminalInput implements IInput {
   }
 
   readChar(): number[] {
-    if (this._finished || this.stdinCallback === undefined) {
-      return [4]; // EOT
-    } else {
-      // What to do if more than one character?
-      const utf16 = this.stdinCallback();
-      if (utf16[0] === 4) {
-        this._finished = true;
-      } else if (utf16[0] === 13) {
-        return [10];
-      }
-      return utf16;
+    if (this.stdinCallback === undefined) {
+      return [];
     }
+    return this.stdinCallback();
   }
-
-  private _finished = false;
 }

--- a/test/tests/termios.test.ts
+++ b/test/tests/termios.test.ts
@@ -36,11 +36,11 @@ test.describe('termios', () => {
 
         expect(output[1]).toEqual('ab');
         if (flag !== 'disabled') {
-          expect(output[2]).toEqual('c\r\n');
-          expect(output[3]).toMatch(/^abc\r\nEnd of input\r\n/);
+          expect(output[2]).toEqual('c\r\nabc\r\n');
+          expect(output[3]).toMatch(/^End of input\r\n/);
         } else {
-          expect(output[2]).toEqual('c\n');
-          expect(output[3]).toMatch(/^abc\nEnd of input\n/);
+          expect(output[2]).toEqual('c\nabc\n');
+          expect(output[3]).toMatch(/^End of input\n/);
         }
       });
     });


### PR DESCRIPTION
Currently WebAssembly commands that read `stdin` whilst they are running override the emscripten `get_char` function to read a single character at a time, even if there are multiple characters that go together such as ansi escape sequences like up and down arrows. This replaces that with overriding the `read` function that returns multiple characters in a single call.