### PR TITLE
Support WebAssembly source map files

### DIFF
--- a/src/tools/prepare_wasm.ts
+++ b/src/tools/prepare_wasm.ts
@@ -260,9 +260,8 @@ const requiredJavaScriptSuffixes = {
 const requiredWasmSuffixes = {
   '.js': true,
   '.wasm': true,
-  '.data': false,
-  '-fs.js': false,
-  '-fs.data': false
+  '.wasm.map': false,
+  '.data': false
 };
 
 for (const packageName in cockleConfig.packages) {


### PR DESCRIPTION
Support the use of emscripten WebAssembly debug builds that include source map files with names like `moduleName.wasm.map`, as obtained using the compilation flags `-g -gsource-map`.

Also removed checking for filesystem-only module files as not currently using any of these.