### PR TITLE
Reuse common key definitions in in-browser tests

### DIFF
--- a/test/serve/index.ts
+++ b/test/serve/index.ts
@@ -1,5 +1,6 @@
 import { Aliases, OutputFlag, Termios, parse, tokenize } from '@jupyterlite/cockle';
 import { terminalInput } from './input_setup';
+import { keys } from './keys';
 import { shellSetupEmpty, shellSetupComplex, shellSetupSimple } from './shell_setup';
 
 async function setup() {
@@ -7,6 +8,7 @@ async function setup() {
     Aliases,
     OutputFlag,
     Termios,
+    keys,
     parse,
     shellSetupComplex,
     shellSetupEmpty,

--- a/test/serve/keys.ts
+++ b/test/serve/keys.ts
@@ -1,0 +1,22 @@
+const ESCAPE = '\x1b';
+
+export const keys = {
+  enter: '\r',
+  tab: '\t',
+  EOT: '\x04',
+  backspace: '\x7F',
+  escape: ESCAPE,
+  upArrow: ESCAPE + '[A',
+  downArrow: ESCAPE + '[B',
+  rightArrow: ESCAPE + '[C',
+  leftArrow: ESCAPE + '[D',
+  delete_: ESCAPE + '[3~',
+  home: ESCAPE + '[H',
+  end: ESCAPE + '[F',
+  prev: ESCAPE + '[1;2D',
+  next: ESCAPE + '[1;2C',
+  up: ESCAPE + 'OA',
+  down: ESCAPE + 'OB',
+  right: ESCAPE + 'OC',
+  left: ESCAPE + 'OD'
+};

--- a/test/tests/command/nano.test.ts
+++ b/test/tests/command/nano.test.ts
@@ -20,8 +20,8 @@ test.describe('nano command', () => {
   test('should create new file', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { shell, output } = await globalThis.cockle.shellSetupEmpty({ color: true });
-      const { terminalInput } = globalThis.cockle;
-      const enter = '\r';
+      const { keys, terminalInput } = globalThis.cockle;
+      const { enter } = keys;
       const exit = '\x18'; // Ctrl-X
       const writeFile = '\x0f'; // Ctrl-O
       await Promise.all([

--- a/test/tests/command/vim.test.ts
+++ b/test/tests/command/vim.test.ts
@@ -31,11 +31,9 @@ test.describe('vim command', () => {
 
   test('should support multi-character escape sequences', async ({ page }) => {
     const output = await page.evaluate(async () => {
-      const escape = '\x1b';
-      const upArrow = escape + 'OA';
-      const leftArrow = escape + 'OD';
       const { shell, output } = await globalThis.cockle.shellSetupEmpty({ color: true });
-      const { terminalInput } = globalThis.cockle;
+      const { keys, terminalInput } = globalThis.cockle;
+      const { escape, leftArrow, upArrow } = keys;
       await Promise.all([
         shell.inputLine('vim'),
         terminalInput(shell, [

--- a/test/tests/history.test.ts
+++ b/test/tests/history.test.ts
@@ -90,13 +90,12 @@ test.describe('history', () => {
   test('should scroll up and down', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { shell, output } = await globalThis.cockle.shellSetupEmpty();
+      const { keys } = globalThis.cockle;
+      const { downArrow, upArrow } = keys;
       await shell.inputLine('cat a');
       await shell.inputLine('echo hello');
       await shell.inputLine('ls');
       output.clear();
-
-      const upArrow = '\x1B[A';
-      const downArrow = '\x1B[B';
 
       await shell.input(upArrow);
       await shell.input(upArrow);

--- a/test/tests/termios.test.ts
+++ b/test/tests/termios.test.ts
@@ -8,8 +8,9 @@ test.describe('termios', () => {
     flagOptions.forEach(({ flag }) => {
       test(`should support OutputFlag.ONLCR ${flag}`, async ({ page }) => {
         const output = await page.evaluate(async flag => {
-          const EOT = '\x04';
           const { shell, output } = await globalThis.cockle.shellSetupEmpty();
+          const { keys } = globalThis.cockle;
+          const { EOT } = keys;
 
           let cmdText = 'check_termios';
           if (flag !== 'default') {


### PR DESCRIPTION
Add a `keys` object that is available in in-browser tests to avoid redefining them in multiple tests.