### PR TITLE
Use maxChars when reading input from wasm command

### DIFF
--- a/src/callback.ts
+++ b/src/callback.ts
@@ -37,7 +37,7 @@ export interface IInitDriveFSCallback {
  * Wait for and return a sequence of utf16 code units from stdin, if buffered stdin is enabled.
  */
 export interface IStdinCallback {
-  (): number[];
+  (maxChars: number): number[];
 }
 
 /**

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -55,7 +55,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
         // No buffer to store in.
         return 0;
       }
-      let chars = stdin.readChar();
+      let chars = stdin.read(length);
       if (chars.length === 1 && chars[0] === 4) {
         chars = [];
       }

--- a/src/io/input.ts
+++ b/src/io/input.ts
@@ -2,9 +2,9 @@ export interface IInput {
   isTerminal(): boolean;
 
   /**
-   * Read and return a single character as a sequence of ASCII character codes. Note this might be
-   * more than one actual character such as \n or escape code for up arrow, etc. No further input is
-   * indicated by a single-width character with an ASCII code of 4 (EOT = End Of Transmission).
+   * Read up to maxChars as a sequence of utf16 character codes.
+   * This is the read function used by WebAssembly commands.
+   * Could perhaps return a TypedArray instead?
    */
-  readChar(): number[];
+  read(maxChars: number): number[];
 }

--- a/src/io/input_all.ts
+++ b/src/io/input_all.ts
@@ -11,7 +11,7 @@ export abstract class InputAll implements IInput {
    */
   abstract readAll(): string;
 
-  readChar(): number[] {
+  read(maxChars: number): number[] {
     if (this._buffer === undefined) {
       this._buffer = this.readAll();
       this._index = 0;

--- a/src/io/terminal_input.ts
+++ b/src/io/terminal_input.ts
@@ -8,10 +8,10 @@ export class TerminalInput implements IInput {
     return true;
   }
 
-  readChar(): number[] {
+  read(maxChars: number): number[] {
     if (this.stdinCallback === undefined) {
       return [];
     }
-    return this.stdinCallback();
+    return this.stdinCallback(maxChars);
   }
 }


### PR DESCRIPTION
Now that we are using `read` (#147) rather than `get_char` when reading from a WebAssembly command, we can respect the `maxChars` that it is requesting rather than always returning just on character at a time. `vim` typically requests everything at once (`maxChars=4096`) whereas `namo` requests just one at a time.