### PR TITLE
Remove extraneous newline when closing vim or nano

### DIFF
--- a/src/buffered_io.ts
+++ b/src/buffered_io.ts
@@ -1,5 +1,5 @@
 import { IOutputCallback } from './callback';
-import { InputFlag, LocalFlag, OutputFlag, Termios } from './termios';
+import { InputFlag, LocalFlag, OutputFlag, ITermios, Termios } from './termios';
 
 /**
  * Classes to deal with buffered IO between main worker and web worker. Both have access to the same
@@ -348,6 +348,11 @@ export class WorkerBufferedIO extends BufferedIO {
     return this._termios;
   }
 
+  setTermios(iTermios: ITermios): void {
+    this.termios.set(iTermios);
+    this._writeColumn = 0;
+  }
+
   write(text: string | Int8Array | number[]): void {
     let chars: number[] = [];
     if (typeof text === 'string') {
@@ -464,7 +469,7 @@ export class WorkerBufferedIO extends BufferedIO {
           }
           break;
         default:
-          if (!inEscape) {
+          if (!inEscape && char >= 32) {
             this._writeColumn++;
           }
           ret.push(char);

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -29,7 +29,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
 
     function setTermios(tty: any, optional_actions: any, data: ITermios) {
       // TODO: handle optional_actions
-      bufferedIO.termios.set(data);
+      bufferedIO.setTermios(data);
       return 0;
     }
 


### PR DESCRIPTION
Remove extraneous newline when closing `vim` or `nano`. Fixes #157.

Here resetting the current write column to zero when setting `termios`.