### PR TITLE
Support returning all buffered characters in stdin read function

### DIFF
--- a/src/buffered_io.ts
+++ b/src/buffered_io.ts
@@ -315,8 +315,8 @@ export class WorkerBufferedIO extends BufferedIO {
     return (readable ? POLLIN : 0) | (writable ? POLLOUT : 0);
   }
 
-  read(maxChars: number): number[] {
-    if (maxChars <= 0) {
+  read(maxChars: number | null): number[] {
+    if (maxChars !== null && maxChars <= 0) {
       return [];
     }
 
@@ -490,13 +490,20 @@ export class WorkerBufferedIO extends BufferedIO {
   }
 
   /**
-   * Extract and return up to maxChars from _readBuffer, leaving the remainder in the buffer.
+   * Extract and return up to maxChars from _readBuffer, or all characters if maxChars is null,
+   * leaving the remainder in the buffer.
    * _readBuffer may or may not be empty when this is called.
    */
-  private _readFronBuffer(maxChars: number): number[] {
-    const ret = this._readBuffer.slice(0, maxChars);
-    this._readBuffer.splice(0, ret.length); // ret.length may be < maxChars
-    return ret;
+  private _readFronBuffer(maxChars: number | null): number[] {
+    if (maxChars === null) {
+      const ret = this._readBuffer;
+      this._readBuffer = [];
+      return ret;
+    } else {
+      const ret = this._readBuffer.slice(0, maxChars);
+      this._readBuffer.splice(0, ret.length); // ret.length may be < maxChars
+      return ret;
+    }
   }
 
   private _termios: Termios = Termios.newDefaultWasm();

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -35,9 +35,10 @@ export interface IInitDriveFSCallback {
 
 /**
  * Wait for and return a sequence of utf16 code units from stdin, if buffered stdin is enabled.
+ * Return up to maxChars, or all available characters if maxChars is null.
  */
 export interface IStdinCallback {
-  (maxChars: number): number[];
+  (maxChars: number | null): number[];
 }
 
 /**

--- a/src/io/input.ts
+++ b/src/io/input.ts
@@ -2,9 +2,10 @@ export interface IInput {
   isTerminal(): boolean;
 
   /**
-   * Read up to maxChars as a sequence of utf16 character codes.
+   * Read up to maxChars as a sequence of utf16 character codes, or all available characters if
+   * maxChars is null.
    * This is the read function used by WebAssembly commands.
    * Could perhaps return a TypedArray instead?
    */
-  read(maxChars: number): number[];
+  read(maxChars: number | null): number[];
 }

--- a/src/io/input_all.ts
+++ b/src/io/input_all.ts
@@ -11,7 +11,7 @@ export abstract class InputAll implements IInput {
    */
   abstract readAll(): string;
 
-  read(maxChars: number): number[] {
+  read(maxChars: number | null): number[] {
     if (this._buffer === undefined) {
       this._buffer = this.readAll();
       this._index = 0;

--- a/src/io/terminal_input.ts
+++ b/src/io/terminal_input.ts
@@ -8,7 +8,7 @@ export class TerminalInput implements IInput {
     return true;
   }
 
-  read(maxChars: number): number[] {
+  read(maxChars: number | null): number[] {
     if (this.stdinCallback === undefined) {
       return [];
     }


### PR DESCRIPTION
Support returning all buffered characters in stdin `read` function. This isn't need by WebAssembly commands as they always specify an integer max characters that they can accept, but it will be useful for JavaScript commands so that they can read, for example, a whole escape sequence from the keyboard in one call.