### PR TITLE
Add sideEffects config to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     ],
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
+    "sideEffects": false,
     "scripts": {
         "build": "tsc",
         "eslint": "npm run eslint:check -- --fix",


### PR DESCRIPTION
Add `sideEffects` config to `package.json` to specify that none of the `cockle` code contains side effects such as statically running code when JavaScript files are imported. This setting is used by bundlers such as `webpack` to support tree shaking, i.e. removal of `cockle` dead code when building downstream projects that use `cockle`. This will be important when building JavaScript commands for `cockle` that contain some but not all (of course) of the `cockle` code.