### PR TITLE
Output via postMessage rather than SharedArrayBuffer

### DIFF
--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -40,6 +40,7 @@ export abstract class BaseShell implements IShell {
       },
       proxy(this.downloadWasmModuleCallback.bind(this)),
       proxy(this.enableBufferedStdinCallback.bind(this)),
+      proxy(options.outputCallback),
       proxy(this.dispose.bind(this)) // terminateCallback
     );
 

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -12,10 +12,11 @@ export abstract class BaseShellWorker implements IShellWorker {
     options: IShellWorker.IOptions,
     downloadModuleCallback: IShellWorker.IProxyDownloadModuleCallback,
     enableBufferedStdinCallback: IShellWorker.IProxyEnableBufferedStdinCallback,
+    outputCallback: IShellWorker.IProxyOutputCallback,
     terminateCallback: IShellWorker.IProxyTerminateCallback
   ) {
     console.log('Cockle BaseShellWorker.initialize');
-    this._bufferedIO = new WorkerBufferedIO(options.sharedArrayBuffer);
+    this._bufferedIO = new WorkerBufferedIO(options.sharedArrayBuffer, outputCallback);
     this._downloadModuleCallback = downloadModuleCallback;
     this._enableBufferedStdinCallback = enableBufferedStdinCallback;
     this._terminateCallback = terminateCallback;

--- a/src/buffered_io.ts
+++ b/src/buffered_io.ts
@@ -209,7 +209,10 @@ export class MainBufferedIO extends BufferedIO {
 }
 
 export class WorkerBufferedIO extends BufferedIO {
-  constructor(sharedArrayBuffer: SharedArrayBuffer, readonly outputCallback: IOutputCallback) {
+  constructor(
+    sharedArrayBuffer: SharedArrayBuffer,
+    readonly outputCallback: IOutputCallback
+  ) {
     super(sharedArrayBuffer);
   }
 

--- a/src/buffered_io.ts
+++ b/src/buffered_io.ts
@@ -2,13 +2,12 @@ import { IOutputCallback } from './callback';
 import { InputFlag, LocalFlag, OutputFlag, ITermios, Termios } from './termios';
 
 /**
- * Classes to deal with buffered IO between main worker and web worker. Both have access to the same
+ * Classes for buffered input between main worker and web worker. Both have access to the same
  * SharedArrayBuffer and use that to pass stdin characters from the UI (main worker) to the shell
  * (webworker). This is necessary when the shell is running a WASM command that is synchronous and
  * blocking, as the usual async message passing from main to webworker does not work as the received
  * messages would only be processed when the command has finished.
  *
- * Writing (from web worker to main worker) always occurs via here, never directly.
  * Reading (from main worker to web worker) is explicitly enabled/disabled.
  */
 
@@ -18,19 +17,13 @@ const READ_WORKER = 1;
 const READ_LENGTH = 2;
 const READ_START = 3;
 
-const WRITE_CONTROL = 0;
-const WRITE_LENGTH = 1;
-const WRITE_START = 2;
-
 abstract class BufferedIO {
   constructor(sharedArrayBuffer?: SharedArrayBuffer) {
     const bytesPerElement = Int32Array.BYTES_PER_ELEMENT;
     const readLength = this._maxReadChars + 3;
-    const writeLength = this._maxWriteChars + 2;
-    const totaLength = readLength + writeLength;
 
     if (sharedArrayBuffer === undefined) {
-      this._sharedArrayBuffer = new SharedArrayBuffer(totaLength * bytesPerElement);
+      this._sharedArrayBuffer = new SharedArrayBuffer(readLength * bytesPerElement);
     } else {
       this._sharedArrayBuffer = sharedArrayBuffer;
     }
@@ -39,16 +32,6 @@ abstract class BufferedIO {
     if (sharedArrayBuffer === undefined) {
       this._readArray[READ_MAIN] = 0;
       this._readArray[READ_WORKER] = 0;
-    }
-
-    this._writeArray = new Int32Array(
-      this._sharedArrayBuffer,
-      readLength * bytesPerElement,
-      writeLength
-    );
-    if (sharedArrayBuffer !== undefined) {
-      this._writeArray[WRITE_CONTROL] = 0;
-      this._writeArray[WRITE_LENGTH] = 0;
     }
   }
 
@@ -97,9 +80,6 @@ abstract class BufferedIO {
   protected _readArray: Int32Array;
   protected _readCount: number = 0;
 
-  protected _maxWriteChars: number = 256; // Multiples of this can be sent consecutively.
-  protected _writeArray: Int32Array;
-
   private _utf8Decoder?: TextDecoder;
 }
 
@@ -142,11 +122,6 @@ export class MainBufferedIO extends BufferedIO {
       return;
     }
 
-    // Stop listening for writes.
-    this._disposing = true;
-    Atomics.store(this._writeArray, WRITE_CONTROL, 999); // Sentinel value, anything not 0 or 1.
-    Atomics.notify(this._writeArray, WRITE_CONTROL);
-
     this._isDisposed = true;
   }
 
@@ -177,49 +152,7 @@ export class MainBufferedIO extends BufferedIO {
     this._sendStdinNow = sendStdinNow;
   }
 
-  async start(): Promise<void> {
-    this._listenForWrite();
-  }
-
-  async _afterListenWrite() {
-    if (this._disabling) {
-      return;
-    }
-
-    let text = '';
-    let moreToFollow = true;
-    do {
-      let n = Atomics.load(this._writeArray, WRITE_LENGTH);
-      moreToFollow = n === 0;
-      if (moreToFollow) {
-        n = this._maxWriteChars;
-      }
-
-      const chars = new Int16Array(n);
-      for (let i = 0; i < n; i++) {
-        chars[i] = Atomics.load(this._writeArray, WRITE_START + i);
-      }
-      text += String.fromCharCode(...chars);
-
-      Atomics.store(this._writeArray, WRITE_CONTROL, 0); // reset
-      Atomics.notify(this._writeArray, WRITE_CONTROL, 1);
-
-      if (moreToFollow && !this._disposing) {
-        const { async, value } = Atomics.waitAsync(this._writeArray, WRITE_CONTROL, 0);
-        if (async) {
-          await value;
-        }
-      }
-    } while (moreToFollow);
-
-    if (text.length > 0 && !this._disposing) {
-      this.outputCallback(text);
-    }
-
-    if (!this._disposing) {
-      this._listenForWrite();
-    }
-  }
+  async start(): Promise<void> {}
 
   /**
    * After a successful read by the worker, main checks if another character can be stored in the
@@ -241,15 +174,6 @@ export class MainBufferedIO extends BufferedIO {
     this._readBuffer = [];
     this._readBufferCount = 0;
     this._readSentCount = 0;
-  }
-
-  private _listenForWrite() {
-    const { async, value } = Atomics.waitAsync(this._writeArray, WRITE_CONTROL, 0);
-    if (async) {
-      value.then(() => this._afterListenWrite());
-    } else {
-      this._afterListenWrite();
-    }
   }
 
   private _storeInSharedArrayBuffer() {
@@ -276,7 +200,6 @@ export class MainBufferedIO extends BufferedIO {
     }
   }
 
-  private _disposing: boolean = false;
   private _isDisposed: boolean = false;
   private _disabling: boolean = false;
   private _readBuffer: string[] = [];
@@ -286,7 +209,7 @@ export class MainBufferedIO extends BufferedIO {
 }
 
 export class WorkerBufferedIO extends BufferedIO {
-  constructor(sharedArrayBuffer: SharedArrayBuffer) {
+  constructor(sharedArrayBuffer: SharedArrayBuffer, readonly outputCallback: IOutputCallback) {
     super(sharedArrayBuffer);
   }
 
@@ -361,24 +284,7 @@ export class WorkerBufferedIO extends BufferedIO {
       chars = this._processWriteChars(text);
     }
 
-    let length = chars.length;
-    let offset = 0;
-    while (length > 0) {
-      const moreToFollow = length > this._maxWriteChars;
-      Atomics.store(this._writeArray, WRITE_CONTROL, 1);
-      Atomics.store(this._writeArray, WRITE_LENGTH, moreToFollow ? 0 : length);
-      const n = moreToFollow ? this._maxWriteChars : length;
-      for (let i = 0; i < n; i++) {
-        Atomics.store(this._writeArray, WRITE_START + i, chars[offset + i]);
-      }
-      Atomics.notify(this._writeArray, WRITE_CONTROL, 1); // signal other end that buffer is ready to read.
-
-      // Wait for acknowledgement that buffer has been read.
-      Atomics.wait(this._writeArray, WRITE_CONTROL, 1);
-
-      length -= this._maxWriteChars;
-      offset += this._maxWriteChars;
-    }
+    this.outputCallback(String.fromCharCode(...chars));
   }
 
   _maybeEchoToOutput(chars: number[]): void {

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -5,6 +5,7 @@ import {
   IDownloadModuleCallback,
   IEnableBufferedStdinCallback,
   IInitDriveFSCallback,
+  IOutputCallback,
   IStdinCallback,
   ITerminateCallback
 } from './callback';
@@ -33,6 +34,7 @@ export interface IShellWorker extends IShellCommon {
     options: IShellWorker.IOptions,
     downloadModuleCallback: IShellWorker.IProxyDownloadModuleCallback,
     enableBufferedStdinCallback: IShellWorker.IProxyEnableBufferedStdinCallback,
+    outputCallback: IShellWorker.IProxyOutputCallback,
     terminateCallback: IShellWorker.IProxyTerminateCallback
   ): void;
 }
@@ -42,6 +44,7 @@ export namespace IShellWorker {
   export interface IProxyEnableBufferedStdinCallback
     extends IEnableBufferedStdinCallback,
       ProxyMarked {}
+  export interface IProxyOutputCallback extends IOutputCallback, ProxyMarked {}
   export interface IProxyTerminateCallback extends ITerminateCallback, ProxyMarked {}
 
   export interface IOptions extends IOptionsCommon {

--- a/test/serve/index.ts
+++ b/test/serve/index.ts
@@ -1,5 +1,5 @@
 import { Aliases, OutputFlag, Termios, parse, tokenize } from '@jupyterlite/cockle';
-import { terminalInput } from './input_setup';
+import { delay, terminalInput } from './input_setup';
 import { keys } from './keys';
 import { shellSetupEmpty, shellSetupComplex, shellSetupSimple } from './shell_setup';
 
@@ -8,6 +8,7 @@ async function setup() {
     Aliases,
     OutputFlag,
     Termios,
+    delay,
     keys,
     parse,
     shellSetupComplex,

--- a/test/serve/input_setup.ts
+++ b/test/serve/input_setup.ts
@@ -1,5 +1,9 @@
 import { Shell } from '@jupyterlite/cockle';
 
+export async function delay(milliseconds: number = 10): Promise<void> {
+  await new Promise(f => setTimeout(f, milliseconds));
+}
+
 /**
  * Helper to provide terminal input whilst a command is running.
  * Pass EOT (ASCII code 4) to finish.
@@ -12,7 +16,7 @@ export async function terminalInput(
   initialDelayMs: number = 100
 ): Promise<void> {
   if (initialDelayMs > 0) {
-    await new Promise(f => setTimeout(f, initialDelayMs));
+    await delay(initialDelayMs);
   }
 
   for (const char of chars) {

--- a/test/tests/utils.ts
+++ b/test/tests/utils.ts
@@ -25,6 +25,7 @@ export async function shellInputsSimpleN(
         for (const char of chars) {
           await shell.input(char);
         }
+        await globalThis.cockle.delay();
         ret.push(output.textAndClear());
       }
       return ret;
@@ -54,6 +55,7 @@ export async function shellLineSimpleN(
       const ret: string[] = [];
       for (const line of lines) {
         await shell.inputLine(line);
+        await globalThis.cockle.delay();
         ret.push(output.textAndClear());
       }
       return ret;
@@ -73,6 +75,7 @@ export async function shellLineComplexN(
       const ret: string[] = [];
       for (const line of lines) {
         await shell.inputLine(line);
+        await globalThis.cockle.delay();
         ret.push(output.textAndClear());
       }
       return ret;


### PR DESCRIPTION
Change output writing to the main thread to use `postMessage` rather than `SharedArrayBuffer` in the `BufferedIO` class. This is the start of efforts to reduce the dependency on `SharedArrayBuffer`. Because we no longer have direct confirmation that writes have finished, it has been necessary to add some small delays to the test suite to for the messages to be handled and acted upon.