### PR TITLE
Negative timeout passed to poll() means infinite timeout

### DIFF
--- a/src/buffered_io/shared_array_buffer_worker_io.ts
+++ b/src/buffered_io/shared_array_buffer_worker_io.ts
@@ -30,8 +30,10 @@ export class SharedArrayBufferWorkerIO extends WorkerIO implements IWorkerIO {
       return POLLIN | (writable ? POLLOUT : 0);
     }
 
-    const t = timeoutMs > 0 ? timeoutMs : 0;
-    const readableCheck = Atomics.wait(this._intArray, SAB.MAIN, this._readCount, t);
+    if (timeoutMs < 0) {
+      timeoutMs = Infinity;
+    }
+    const readableCheck = Atomics.wait(this._intArray, SAB.MAIN, this._readCount, timeoutMs);
     const readable = readableCheck === 'not-equal';
     return (readable ? POLLIN : 0) | (writable ? POLLOUT : 0);
   }


### PR DESCRIPTION
A negative timeout passed to `poll` by a WebAssembly command is treated as an infinite timeout, see https://man7.org/linux/man-pages/man2/poll.2.html.

This is not currently used in any WebAssembly commands but it is in some that I have been experimenting with locally.