### PR TITLE
Shell id, and stored in static ShellManager

### DIFF
--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -20,7 +20,7 @@ export abstract class BaseShellWorker implements IShellWorker {
     this._downloadModuleCallback = downloadModuleCallback;
     this._enableBufferedStdinCallback = enableBufferedStdinCallback;
     this._terminateCallback = terminateCallback;
-    
+
     this._shellImpl = new ShellImpl({
       id: options.id,
       color: options.color,

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -20,24 +20,16 @@ export abstract class BaseShellWorker implements IShellWorker {
     this._downloadModuleCallback = downloadModuleCallback;
     this._enableBufferedStdinCallback = enableBufferedStdinCallback;
     this._terminateCallback = terminateCallback;
-
-    const {
-      color,
-      mountpoint,
-      wasmBaseUrl,
-      driveFsBaseUrl,
-      browsingContextId,
-      initialDirectories,
-      initialFiles
-    } = options;
+    
     this._shellImpl = new ShellImpl({
-      color,
-      mountpoint,
-      wasmBaseUrl,
-      driveFsBaseUrl,
-      browsingContextId,
-      initialDirectories,
-      initialFiles,
+      id: options.id,
+      color: options.color,
+      mountpoint: options.mountpoint,
+      wasmBaseUrl: options.wasmBaseUrl,
+      driveFsBaseUrl: options.driveFsBaseUrl,
+      browsingContextId: options.browsingContextId,
+      initialDirectories: options.initialDirectories,
+      initialFiles: options.initialFiles,
       downloadModuleCallback: this._downloadModuleCallback.bind(this),
       enableBufferedStdinCallback: this.enableBufferedStdin.bind(this),
       initDriveFSCallback: this.initDriveFS.bind(this),

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -3,6 +3,7 @@ import type { IObservableDisposable } from '@lumino/disposable';
 import { IOutputCallback } from './callback';
 
 export interface IShell extends IObservableDisposable {
+  id: string;
   input(char: string): Promise<void>;
   setSize(rows: number, columns: number): Promise<void>;
   start(): Promise<void>;
@@ -10,6 +11,7 @@ export interface IShell extends IObservableDisposable {
 
 export namespace IShell {
   export interface IOptions {
+    id?: string;
     color?: boolean;
     mountpoint?: string;
     wasmBaseUrl: string;

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -13,6 +13,7 @@ import {
 import { IShell } from './defs';
 
 interface IOptionsCommon {
+  id: string;
   color: boolean;
   mountpoint?: string;
   wasmBaseUrl: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,6 @@ export * from './io';
 export { IJavaScriptContext } from './javascript_context';
 export { parse } from './parse';
 export { Shell } from './shell';
+export { ShellManager } from './shell_manager';
 export * from './termios';
 export { tokenize, Token } from './tokenize';

--- a/src/shell_manager.ts
+++ b/src/shell_manager.ts
@@ -1,4 +1,4 @@
-import { IShell } from "./defs";
+import { IShell } from './defs';
 
 /**
  * Shell manager that knows about all shells in a particular browser tab.
@@ -34,5 +34,5 @@ export class ShellManager {
   }
 
   // Only created when first needed.
-  private static _shells? : Map<string, IShell>;
+  private static _shells?: Map<string, IShell>;
 }

--- a/src/shell_manager.ts
+++ b/src/shell_manager.ts
@@ -1,0 +1,38 @@
+import { IShell } from "./defs";
+
+/**
+ * Shell manager that knows about all shells in a particular browser tab.
+ * Routes service worker requests received in the UI thread to the correct shell.
+ */
+export class ShellManager {
+  static get(id: string): IShell | undefined {
+    return this._checkInitialised().get(id);
+  }
+
+  static ids(): string[] {
+    const shells = this._checkInitialised();
+    return [...shells.keys()];
+  }
+
+  static register(shell: IShell) {
+    const shells = this._checkInitialised();
+    const { id } = shell;
+    shells.set(id, shell);
+  }
+
+  static unregister(shell: IShell) {
+    const shells = this._checkInitialised();
+    const { id } = shell;
+    shells.delete(id);
+  }
+
+  private static _checkInitialised(): Map<string, IShell> {
+    if (this._shells === undefined) {
+      this._shells = new Map<string, IShell>();
+    }
+    return this._shells;
+  }
+
+  // Only created when first needed.
+  private static _shells? : Map<string, IShell>;
+}

--- a/test/integration-tests/shell_manager.test.ts
+++ b/test/integration-tests/shell_manager.test.ts
@@ -35,7 +35,7 @@ test.describe('ShellManager', () => {
       const shell0 = obj0.shell;
       const obj1 = await shellSetupEmpty();
       const shell1 = obj1.shell;
-      const ret0 = shell0.id
+      const ret0 = shell0.id;
       const ret1 = shell1.id;
       const ret2 = ShellManager.ids();
       shell0.dispose();

--- a/test/integration-tests/shell_manager.test.ts
+++ b/test/integration-tests/shell_manager.test.ts
@@ -1,0 +1,59 @@
+import { expect } from '@playwright/test';
+import { test } from './utils';
+
+test.describe('ShellManager', () => {
+  test('should support no shells created', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { ShellManager } = globalThis.cockle;
+      return ShellManager.ids();
+    });
+    expect(output).toEqual([]);
+  });
+
+  test('should support one shell created', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { ShellManager, shellSetupEmpty } = globalThis.cockle;
+      const { shell } = await shellSetupEmpty();
+      const ret0 = shell.id;
+      const ret1 = ShellManager.ids();
+      shell.dispose();
+      const ret2 = ShellManager.ids();
+      return [ret0, ret1, ret2];
+    });
+    const shellId = output[0];
+    expect(shellId).toEqual(expect.any(String));
+    expect(shellId.length).toBeGreaterThan(0);
+
+    expect(output[1]).toEqual([shellId]);
+    expect(output[2]).toEqual([]);
+  });
+
+  test('should support two shells created', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { ShellManager, shellSetupEmpty } = globalThis.cockle;
+      const obj0 = await shellSetupEmpty();
+      const shell0 = obj0.shell;
+      const obj1 = await shellSetupEmpty();
+      const shell1 = obj1.shell;
+      const ret0 = shell0.id
+      const ret1 = shell1.id;
+      const ret2 = ShellManager.ids();
+      shell0.dispose();
+      shell1.dispose();
+      const ret3 = ShellManager.ids();
+      return [ret0, ret1, ret2, ret3];
+    });
+    const shellId0 = output[0];
+    expect(shellId0).toEqual(expect.any(String));
+    expect(shellId0.length).toBeGreaterThan(0);
+
+    const shellId1 = output[1];
+    expect(shellId1).toEqual(expect.any(String));
+    expect(shellId1.length).toBeGreaterThan(0);
+
+    expect(shellId0).not.toEqual(shellId1);
+
+    expect(output[2]).toEqual(expect.arrayContaining([shellId0, shellId1]));
+    expect(output[3]).toEqual([]);
+  });
+});

--- a/test/serve/index.ts
+++ b/test/serve/index.ts
@@ -1,4 +1,4 @@
-import { OutputFlag, Termios } from '@jupyterlite/cockle';
+import { OutputFlag, ShellManager, Termios } from '@jupyterlite/cockle';
 import { delay, terminalInput } from './input_setup';
 import { keys } from './keys';
 import { shellSetupEmpty, shellSetupComplex, shellSetupSimple } from './shell_setup';
@@ -6,6 +6,7 @@ import { shellSetupEmpty, shellSetupComplex, shellSetupSimple } from './shell_se
 async function setup() {
   const cockle = {
     OutputFlag,
+    ShellManager,
     Termios,
     delay,
     keys,


### PR DESCRIPTION
Add a string `id` to `Shell`, which should be unique (in a particular browser tab). It can be specified via `IOptions` when the shell is created, and if not a `uuid` is used. IDs are stored in the new `ShellManager`, and will be used for routing of service worker requests to the correct Shell.