### PR TITLE
Rename input options shellId and baseUrl

### DIFF
--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -20,8 +20,10 @@ export class Demo {
     this._fitAddon = new FitAddon();
     this._term.loadAddon(this._fitAddon);
 
+    const baseUrl = window.location.href;
     this._shell = new Shell({
-      wasmBaseUrl: window.location.href,
+      baseUrl,
+      wasmBaseUrl: baseUrl,
       outputCallback: this.outputCallback.bind(this),
       initialDirectories: ['dir'],
       initialFiles: {

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -15,7 +15,7 @@ import { ShellManager } from './shell_manager';
  */
 export abstract class BaseShell implements IShell {
   constructor(readonly options: IShell.IOptions) {
-    this._id = options.id ?? UUID.uuid4();
+    this._shellId = options.shellId ?? UUID.uuid4();
     ShellManager.register(this);
 
     this._mainIO = new SharedArrayBufferMainIO();
@@ -33,11 +33,11 @@ export abstract class BaseShell implements IShell {
     const { sharedArrayBuffer } = this._mainIO;
     await this._remote.initialize(
       {
-        id: this._id,
+        shellId: this._shellId,
         color: options.color ?? true,
         mountpoint: options.mountpoint,
+        baseUrl: options.baseUrl,
         wasmBaseUrl: options.wasmBaseUrl,
-        driveFsBaseUrl: options.driveFsBaseUrl,
         browsingContextId: options.browsingContextId,
         sharedArrayBuffer,
         initialDirectories: options.initialDirectories,
@@ -103,10 +103,6 @@ export abstract class BaseShell implements IShell {
     }
   }
 
-  get id(): string {
-    return this._id;
-  }
-
   get isDisposed(): boolean {
     return this._isDisposed;
   }
@@ -150,6 +146,10 @@ export abstract class BaseShell implements IShell {
     await this._remote!.setSize(rows, columns);
   }
 
+  get shellId(): string {
+    return this._shellId;
+  }
+
   async start(): Promise<void> {
     if (this.isDisposed) {
       return;
@@ -163,7 +163,7 @@ export abstract class BaseShell implements IShell {
   private _isDisposed = false;
   private _ready = new PromiseDelegate<void>();
 
-  private _id: string;
+  private _shellId: string;
   private _worker: Worker;
   private _remote?: IRemoteShell;
   private _mainIO: SharedArrayBufferMainIO;

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -22,11 +22,11 @@ export abstract class BaseShellWorker implements IShellWorker {
     this._terminateCallback = terminateCallback;
 
     this._shellImpl = new ShellImpl({
-      id: options.id,
+      shellId: options.shellId,
       color: options.color,
       mountpoint: options.mountpoint,
+      baseUrl: options.baseUrl,
       wasmBaseUrl: options.wasmBaseUrl,
-      driveFsBaseUrl: options.driveFsBaseUrl,
       browsingContextId: options.browsingContextId,
       initialDirectories: options.initialDirectories,
       initialFiles: options.initialFiles,

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -3,19 +3,19 @@ import type { IObservableDisposable } from '@lumino/disposable';
 import { IOutputCallback } from './callback';
 
 export interface IShell extends IObservableDisposable {
-  id: string;
   input(char: string): Promise<void>;
   setSize(rows: number, columns: number): Promise<void>;
+  shellId: string;
   start(): Promise<void>;
 }
 
 export namespace IShell {
   export interface IOptions {
-    id?: string;
+    shellId?: string;
     color?: boolean;
     mountpoint?: string;
+    baseUrl: string;
     wasmBaseUrl: string;
-    driveFsBaseUrl?: string;
     browsingContextId?: string;
     // Initial directories and files to create, for testing purposes.
     initialDirectories?: string[];

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -13,11 +13,11 @@ import {
 import { IShell } from './defs';
 
 interface IOptionsCommon {
-  id: string;
+  shellId: string;
   color: boolean;
   mountpoint?: string;
+  baseUrl: string;
   wasmBaseUrl: string;
-  driveFsBaseUrl?: string;
   browsingContextId?: string;
   // Initial directories and files to create, for testing purposes.
   initialDirectories?: string[];

--- a/src/drive_fs.ts
+++ b/src/drive_fs.ts
@@ -2,7 +2,7 @@ import { IFileSystem } from './file_system';
 
 export interface IDriveFSOptions {
   browsingContextId?: string;
-  driveFsBaseUrl?: string;
+  baseUrl: string;
   fileSystem: IFileSystem;
   mountpoint: string;
 }

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -296,10 +296,10 @@ export class ShellImpl implements IShellWorker {
     FS.mkdirTree(mountpoint, 0o777);
     this._fileSystem = { FS, PATH, ERRNO_CODES, PROXYFS, mountpoint };
 
-    const { browsingContextId, driveFsBaseUrl, initialDirectories, initialFiles } = this.options;
+    const { browsingContextId, baseUrl, initialDirectories, initialFiles } = this.options;
     this.options.initDriveFSCallback({
       browsingContextId,
-      driveFsBaseUrl,
+      baseUrl,
       fileSystem: this._fileSystem,
       mountpoint
     });

--- a/src/shell_manager.ts
+++ b/src/shell_manager.ts
@@ -16,14 +16,14 @@ export class ShellManager {
 
   static register(shell: IShell) {
     const shells = this._checkInitialised();
-    const { id } = shell;
-    shells.set(id, shell);
+    const { shellId } = shell;
+    shells.set(shellId, shell);
   }
 
   static unregister(shell: IShell) {
     const shells = this._checkInitialised();
-    const { id } = shell;
-    shells.delete(id);
+    const { shellId } = shell;
+    shells.delete(shellId);
   }
 
   private static _checkInitialised(): Map<string, IShell> {

--- a/test/integration-tests/shell_manager.test.ts
+++ b/test/integration-tests/shell_manager.test.ts
@@ -14,7 +14,7 @@ test.describe('ShellManager', () => {
     const output = await page.evaluate(async () => {
       const { ShellManager, shellSetupEmpty } = globalThis.cockle;
       const { shell } = await shellSetupEmpty();
-      const ret0 = shell.id;
+      const ret0 = shell.shellId;
       const ret1 = ShellManager.ids();
       shell.dispose();
       const ret2 = ShellManager.ids();
@@ -35,8 +35,8 @@ test.describe('ShellManager', () => {
       const shell0 = obj0.shell;
       const obj1 = await shellSetupEmpty();
       const shell1 = obj1.shell;
-      const ret0 = shell0.id;
-      const ret1 = shell1.id;
+      const ret0 = shell0.shellId;
+      const ret1 = shell1.shellId;
       const ret2 = ShellManager.ids();
       shell0.dispose();
       shell1.dispose();

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -55,10 +55,12 @@ async function _shellSetupCommon(options: IOptions, level: number): Promise<IShe
     initialFiles['dir/subdir/nestedfile'] = '';
   }
 
+  const baseUrl = 'http://localhost:8000/';
   const shell = new Shell({
     color: options.color ?? false,
     outputCallback: output.callback,
-    wasmBaseUrl: 'http://localhost:8000/',
+    baseUrl,
+    wasmBaseUrl: baseUrl,
     initialDirectories,
     initialFiles
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "incremental": true,
-    "lib": ["es2022", "webworker"],
+    "lib": ["dom", "es2022", "webworker"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,


### PR DESCRIPTION
Rename input options `id` to `shellId` and `driveFsBaseUrl` to `baseUrl`.