### PR TITLE
Add experimental support for external commands

### DIFF
--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -1,7 +1,29 @@
-import { IShell, Shell } from '@jupyterlite/cockle';
+import { IExternalContext, IShell, Shell } from '@jupyterlite/cockle';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import { IDemo } from './defs';
+
+async function externalCommand(context: IExternalContext): Promise<number> {
+  const { args } = context;
+
+  if (args.includes('environment')) {
+    context.environment.set('TEST_VAR', '23');
+  }
+
+  if (args.includes('stdout')) {
+    context.stdout.write('Output line 1\n');
+    context.stdout.write('Output line 2\n');
+  }
+
+  if (args.includes('stderr')) {
+    context.stderr.write('Error message\n');
+  }
+
+  if (args.includes('exitCode')) {
+    return 1;
+  }
+  return 0;
+}
 
 export class Demo {
   constructor(options: IDemo.IOptions) {
@@ -45,6 +67,8 @@ export class Demo {
           'print(factorial(tonumber(arg[1])))\n'
       }
     });
+
+    this._shell.registerExternalCommand('external-cmd', externalCommand);
   }
 
   async start(): Promise<void> {

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -11,6 +11,7 @@ import { ShellImpl } from './shell_impl';
 export abstract class BaseShellWorker implements IShellWorker {
   async initialize(
     options: IShellWorker.IOptions,
+    callExternalCommand: IShellWorker.IProxyCallExternalCommand,
     downloadModuleCallback: IShellWorker.IProxyDownloadModuleCallback,
     enableBufferedStdinCallback: IShellWorker.IProxyEnableBufferedStdinCallback,
     outputCallback: IShellWorker.IProxyOutputCallback,
@@ -60,6 +61,7 @@ export abstract class BaseShellWorker implements IShellWorker {
       browsingContextId: options.browsingContextId,
       initialDirectories: options.initialDirectories,
       initialFiles: options.initialFiles,
+      callExternalCommand,
       downloadModuleCallback: this._downloadModuleCallback.bind(this),
       enableBufferedStdinCallback: this.enableBufferedStdin.bind(this),
       initDriveFSCallback: this.initDriveFS.bind(this),
@@ -84,6 +86,10 @@ export abstract class BaseShellWorker implements IShellWorker {
     }
   }
 
+  externalOutput(text: string, isStderr: boolean): void {
+    this._shellImpl?.externalOutput(text, isStderr);
+  }
+
   /**
    * Initialize the DriveFS to mount an external file system.
    */
@@ -93,6 +99,13 @@ export abstract class BaseShellWorker implements IShellWorker {
     if (this._shellImpl) {
       await this._shellImpl.input(char);
     }
+  }
+
+  registerExternalCommand(name: string): boolean {
+    if (this._shellImpl) {
+      return this._shellImpl!.registerExternalCommand(name);
+    }
+    return false;
   }
 
   async setSize(rows: number, columns: number): Promise<void> {

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -2,7 +2,15 @@
  * Callbacks used by a shell to call functions in the frontend.
  */
 
+import { IExternalContext } from './context';
 import { IDriveFSOptions } from './drive_fs';
+
+/**
+ * Run an external command from the Shell.
+ */
+export interface IExternalCommand {
+  (context: IExternalContext): Promise<number>;
+}
 
 /**
  * Send output string to be displayed in terminal.
@@ -12,49 +20,8 @@ export interface IOutputCallback {
 }
 
 /**
- * Callback for start and end of downloading a JavaScript/WebAssembly module so that frontend can
- * inform the user.
- */
-export interface IDownloadModuleCallback {
-  (packageName: string, moduleName: string, start: boolean): void;
-}
-
-/**
- * Enable/disable buffered stdin.
- */
-export interface IEnableBufferedStdinCallback {
-  (enable: boolean): Promise<void>;
-}
-
-/**
  * Initialise DriveFS to mount external drive into the shell's filesystem.
  */
 export interface IInitDriveFSCallback {
   (options: IDriveFSOptions): void;
-}
-
-/**
- * Callback for worker to set IMainIO, to switch between SharedArrayBuffer and ServiceWorker.
- */
-export interface ISetMainIOCallback {
-  (shortName: string): void;
-}
-
-/**
- * Wait for and return a sequence of utf16 code units from stdin, if buffered stdin is enabled.
- * Return up to maxChars, or all available characters if maxChars is null.
- */
-export interface IStdinCallback {
-  (maxChars: number | null): number[];
-}
-
-export interface IStdinAsyncCallback {
-  (maxChars: number | null): Promise<number[]>;
-}
-
-/**
- * Request to terminate the shell.
- */
-export interface ITerminateCallback {
-  (): void;
 }

--- a/src/callback_internal.ts
+++ b/src/callback_internal.ts
@@ -1,0 +1,57 @@
+/**
+ * Internal callbacks used by a shell impl/worker to call functions in the shell.
+ */
+
+/**
+ * Internal caller (from ShellImpl/ShellWorker to Shell) to run external command.
+ */
+export interface ICallExternalCommand {
+  (
+    name: string,
+    args: string[],
+    environment: Map<string, string>,
+    stdoutSupportsAnsiEscapes: boolean,
+    stderrSupportsAnsiEscapes: boolean
+  ): Promise<{ exitCode: number; newEnvironment?: Map<string, string> }>;
+}
+
+/**
+ * Callback for start and end of downloading a JavaScript/WebAssembly module so that frontend can
+ * inform the user.
+ */
+export interface IDownloadModuleCallback {
+  (packageName: string, moduleName: string, start: boolean): void;
+}
+
+/**
+ * Enable/disable buffered stdin.
+ */
+export interface IEnableBufferedStdinCallback {
+  (enable: boolean): Promise<void>;
+}
+
+/**
+ * Callback for worker to set IMainIO, to switch between SharedArrayBuffer and ServiceWorker.
+ */
+export interface ISetMainIOCallback {
+  (shortName: string): void;
+}
+
+/**
+ * Wait for and return a sequence of utf16 code units from stdin, if buffered stdin is enabled.
+ * Return up to maxChars, or all available characters if maxChars is null.
+ */
+export interface IStdinCallback {
+  (maxChars: number | null): number[];
+}
+
+export interface IStdinAsyncCallback {
+  (maxChars: number | null): Promise<number[]>;
+}
+
+/**
+ * Request to terminate the shell.
+ */
+export interface ITerminateCallback {
+  (): void;
+}

--- a/src/commands/command_registry.ts
+++ b/src/commands/command_registry.ts
@@ -1,10 +1,12 @@
 import { CommandModule } from './command_module';
 import { CommandPackage } from './command_package';
 import { ICommandRunner } from './command_runner';
+import { ExternalCommandRunner } from './external_command_runner';
 import * as AllBuiltinCommands from '../builtin';
+import { ICallExternalCommand } from '../callback_internal';
 
 export class CommandRegistry {
-  constructor() {
+  constructor(readonly callExternalCommand: ICallExternalCommand) {
     this.registerBuiltinCommands(AllBuiltinCommands);
   }
 
@@ -63,6 +65,14 @@ export class CommandRegistry {
     for (const module of commandPackage.modules) {
       this._register(module.runner);
     }
+  }
+
+  registerExternalCommand(name: string): boolean {
+    if (this._map.has(name)) {
+      return false;
+    }
+    this._map.set(name, new ExternalCommandRunner(name, this.callExternalCommand));
+    return true;
   }
 
   /**

--- a/src/commands/external_command_runner.ts
+++ b/src/commands/external_command_runner.ts
@@ -1,0 +1,50 @@
+import { ICallExternalCommand } from '../callback_internal';
+import { ICommandRunner } from './command_runner';
+import { IContext } from '../context';
+import { FindCommandError } from '../error_exit_code';
+
+export class ExternalCommandRunner implements ICommandRunner {
+  constructor(
+    readonly name: string,
+    readonly callExternalCommand: ICallExternalCommand
+  ) {}
+
+  get moduleName() {
+    return '<external>';
+  }
+
+  names(): string[] {
+    return [this.name];
+  }
+
+  get packageName(): string {
+    return '';
+  }
+
+  async run(cmdName: string, context: IContext): Promise<number> {
+    if (cmdName !== this.name) {
+      // This should not happen.
+      throw new FindCommandError(cmdName);
+    }
+
+    const { args, environment, stdout, stderr } = context;
+    const { exitCode, newEnvironment } = await this.callExternalCommand(
+      this.name,
+      args,
+      environment,
+      stdout.supportsAnsiEscapes(),
+      stderr.supportsAnsiEscapes()
+    );
+
+    if (newEnvironment !== undefined) {
+      // Maybe should not return all of the environment, but only those keys that have changed.
+      // Do this by passing to command a wrapper of Map that stores what keys have changed via
+      // set() or delete()
+      for (const [key, value] of newEnvironment) {
+        environment.set(key, value);
+      }
+    }
+
+    return exitCode;
+  }
+}

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,7 +1,7 @@
 import { IStdinContext } from './stdin_context';
 import { Aliases } from '../aliases';
 import { IWorkerIO } from '../buffered_io';
-import { ITerminateCallback } from '../callback';
+import { ITerminateCallback } from '../callback_internal';
 import { Environment } from '../environment';
 import { IFileSystem } from '../file_system';
 import { History } from '../history';

--- a/src/context/external_context.ts
+++ b/src/context/external_context.ts
@@ -1,0 +1,13 @@
+/**
+ * Context for running external command.
+ * This exists in the main UI thread unlike other contexts that exist in the webworker.
+ */
+
+import { ExternalOutput } from '../io';
+
+export interface IExternalContext {
+  args: string[];
+  environment: Map<string, string>;
+  stdout: ExternalOutput;
+  stderr: ExternalOutput;
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,3 +1,4 @@
 export * from './context';
+export * from './external_context';
 export * from './javascript_context';
 export * from './stdin_context';

--- a/src/context/stdin_context.ts
+++ b/src/context/stdin_context.ts
@@ -1,4 +1,4 @@
-import { ISetMainIOCallback } from '../callback';
+import { ISetMainIOCallback } from '../callback_internal';
 
 export interface IStdinContext {
   available(shortName: string): boolean;

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -1,10 +1,11 @@
 import type { IObservableDisposable } from '@lumino/disposable';
 
 import { IStdinHandler, IStdinReply, IStdinRequest } from './buffered_io';
-import { IOutputCallback } from './callback';
+import { IExternalCommand, IOutputCallback } from './callback';
 
 export interface IShell extends IObservableDisposable {
   input(char: string): Promise<void>;
+  registerExternalCommand(name: string, command: IExternalCommand): Promise<boolean>;
   setSize(rows: number, columns: number): Promise<void>;
   shellId: string;
   start(): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 export { Aliases } from './aliases';
 export { BaseShell } from './base_shell';
 export { BaseShellWorker } from './base_shell_worker';
-export { IOutputCallback, IEnableBufferedStdinCallback, IStdinCallback } from './callback';
-export { IJavaScriptContext } from './context';
+export { IOutputCallback } from './callback';
+export { IExternalContext, IJavaScriptContext } from './context';
 export { IShell } from './defs';
 export { IDriveFSOptions } from './drive_fs';
 export * from './exit_code';

--- a/src/io/external_output.ts
+++ b/src/io/external_output.ts
@@ -1,0 +1,22 @@
+/**
+ * Output used by an ExternalCommand, exists in the main UI not webworker.
+ * This effectively wraps a real IOutput in the webworker ShellImpl IContext.
+ */
+export class ExternalOutput {
+  constructor(
+    readonly callback: (text: string) => void,
+    supportsAnsiEscapes: boolean
+  ) {
+    this._supportsAnsiEscapes = supportsAnsiEscapes;
+  }
+
+  supportsAnsiEscapes(): boolean {
+    return this._supportsAnsiEscapes;
+  }
+
+  write(text: string): void {
+    this.callback(text);
+  }
+
+  private _supportsAnsiEscapes: boolean;
+}

--- a/src/io/index.ts
+++ b/src/io/index.ts
@@ -2,6 +2,7 @@ export * from './buffered_output';
 export * from './console_output';
 export * from './dummy_input';
 export * from './dummy_output';
+export * from './external_output';
 export * from './file_input';
 export * from './file_output';
 export * from './input';

--- a/src/io/terminal_input.ts
+++ b/src/io/terminal_input.ts
@@ -1,5 +1,5 @@
 import { IInput } from './input';
-import { IStdinCallback, IStdinAsyncCallback } from '../callback';
+import { IStdinCallback, IStdinAsyncCallback } from '../callback_internal';
 
 export class TerminalInput implements IInput {
   constructor(

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -51,7 +51,7 @@ export class ShellImpl implements IShellWorker {
       args: [],
       fileSystem: this._fileSystem,
       aliases: new Aliases(),
-      commandRegistry: new CommandRegistry(),
+      commandRegistry: new CommandRegistry(options.callExternalCommand),
       environment: new Environment(options.color),
       history: new History(),
       terminate: this.terminate.bind(this),
@@ -70,6 +70,12 @@ export class ShellImpl implements IShellWorker {
 
   get environment(): Environment {
     return this._context.environment;
+  }
+
+  externalOutput(text: string, isStderr: boolean): void {
+    // Pass output from an external command to the current IOutput.
+    const output: IOutput = isStderr ? this._context.stderr : this._context.stdout;
+    output.write(text);
   }
 
   get history(): History {
@@ -139,6 +145,10 @@ export class ShellImpl implements IShellWorker {
       return;
     }
     this._context.workerIO.write(text);
+  }
+
+  registerExternalCommand(name: string): boolean {
+    return this._context.commandRegistry.registerExternalCommand(name);
   }
 
   async setSize(rows: number, columns: number): Promise<void> {

--- a/test/integration-tests/command/external-command.test.ts
+++ b/test/integration-tests/command/external-command.test.ts
@@ -1,0 +1,96 @@
+import { expect } from '@playwright/test';
+import { test } from '../utils';
+
+test.describe('external command', () => {
+  test('should register', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { externalCommand, shellSetupEmpty } = globalThis.cockle;
+      const { shell, output } = await shellSetupEmpty();
+      const ok = await shell.registerExternalCommand('external-cmd', externalCommand);
+      await shell.inputLine('cockle-config -c');
+      return [ok, output.text];
+    });
+    expect(output[0]).toBeTruthy();
+    expect(output[1]).toMatch('│ external-cmd  │ <external>');
+  });
+
+  test('should fail when re-register same name', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { externalCommand, shellSetupEmpty } = globalThis.cockle;
+      const { shell } = await shellSetupEmpty();
+      const ok0 = await shell.registerExternalCommand('external-cmd', externalCommand);
+      const ok1 = await shell.registerExternalCommand('external-cmd', externalCommand);
+      return [ok0, ok1];
+    });
+    expect(output[0]).toBeTruthy();
+    expect(output[1]).toBeFalsy();
+  });
+
+  test('should write to stdout', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { externalCommand, shellSetupEmpty } = globalThis.cockle;
+      const { shell, output } = await shellSetupEmpty();
+      await shell.registerExternalCommand('external-cmd', externalCommand);
+      await shell.inputLine('external-cmd stdout');
+      return output.text;
+    });
+    expect(output).toMatch('Output line 1\r\nOutput line 2\r\n');
+  });
+
+  test('should write to file', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { externalCommand, shellSetupEmpty } = globalThis.cockle;
+      const { shell, output } = await shellSetupEmpty();
+      await shell.registerExternalCommand('external-cmd', externalCommand);
+      await shell.inputLine('external-cmd stdout > out.txt');
+      const out0 = output.textAndClear();
+      await shell.inputLine('cat out.txt');
+      return [out0, output.text];
+    });
+    expect(output[0]).not.toMatch('Output line');
+    expect(output[1]).toMatch('cat out.txt\r\nOutput line 1\r\nOutput line 2\r\n');
+  });
+
+  test('should write to stderr', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { externalCommand, shellSetupEmpty } = globalThis.cockle;
+      const { shell, output } = await shellSetupEmpty();
+      await shell.registerExternalCommand('external-cmd', externalCommand);
+      await shell.inputLine('external-cmd stderr > out.txt');
+      return output.text;
+    });
+    expect(output).toMatch('Error message\r\n');
+  });
+
+  test('should return exit code', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { externalCommand, shellSetupEmpty } = globalThis.cockle;
+      const { shell, output } = await shellSetupEmpty();
+      await shell.registerExternalCommand('external-cmd', externalCommand);
+      await shell.inputLine('external-cmd');
+      output.clear();
+      await shell.inputLine('env | grep ?');
+      const ret0 = output.textAndClear();
+      await shell.inputLine('external-cmd exitCode');
+      output.clear();
+      await shell.inputLine('env | grep ?');
+      const ret1 = output.textAndClear();
+      return [ret0, ret1];
+    });
+    expect(output[0]).toMatch('\r\n?=0\r\n');
+    expect(output[1]).toMatch('\r\n?=1\r\n');
+  });
+
+  test('should set new environment variable', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { externalCommand, shellSetupEmpty } = globalThis.cockle;
+      const { shell, output } = await shellSetupEmpty();
+      await shell.registerExternalCommand('external-cmd', externalCommand);
+      await shell.inputLine('external-cmd environment');
+      output.clear();
+      await shell.inputLine('env | grep TEST_VAR');
+      return output.text;
+    });
+    expect(output).toMatch('\r\nTEST_VAR=23\r\n');
+  });
+});

--- a/test/serve/external_command.ts
+++ b/test/serve/external_command.ts
@@ -1,0 +1,25 @@
+import { IExternalContext } from '@jupyterlite/cockle';
+
+// External command with different bahaviour depending on supplied args, to test
+// external command functionality.
+export async function externalCommand(context: IExternalContext): Promise<number> {
+  const { args } = context;
+
+  if (args.includes('environment')) {
+    context.environment.set('TEST_VAR', '23');
+  }
+
+  if (args.includes('stdout')) {
+    context.stdout.write('Output line 1\n');
+    context.stdout.write('Output line 2\n');
+  }
+
+  if (args.includes('stderr')) {
+    context.stderr.write('Error message\n');
+  }
+
+  if (args.includes('exitCode')) {
+    return 1;
+  }
+  return 0;
+}

--- a/test/serve/index.ts
+++ b/test/serve/index.ts
@@ -1,4 +1,5 @@
 import { OutputFlag, ShellManager, Termios, delay } from '@jupyterlite/cockle';
+import { externalCommand } from './external_command';
 import { terminalInput } from './input_setup';
 import { keys } from './keys';
 import { shellSetupEmpty, shellSetupComplex, shellSetupSimple } from './shell_setup';
@@ -10,6 +11,7 @@ async function setup() {
     OutputFlag,
     Termios,
     delay,
+    externalCommand,
     keys,
     shellManager,
     shellSetupComplex,


### PR DESCRIPTION
This adds experimental support for external commands. These are TypeScript commands that run in the browser's main UI thread, whereas all other forms of command (WebAssembly, JavaScript and builtin) all run in the shell's webworker. Such commands are registered at runtime via `Shell.registerExternalCommand` and they run in a much more limited context than the internal commands, for example they do not have direct access to the WebAssembly file system. The intended use case for these are commands that access internals of JupyterLite such as kernels and settings.

Labelled experimental as the API here will definitely change, this first attempt is to try it out in the `terminal`.

Currently do not support any form of `stdin` whilst running. Outputs (`stdout` and `stderr`) are sent to the webworker so that they can be handled like all other forms of output such as pipes and writing to file.