### PR TITLE
Include command name in `IExternalContext` and `IJavaScriptContext`

### DIFF
--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -10,6 +10,10 @@ async function externalCommand(context: IExternalContext): Promise<number> {
     context.environment.set('TEST_VAR', '23');
   }
 
+  if (args.includes('name')) {
+    context.stdout.write(context.name + '\n');
+  }
+
   if (args.includes('stdout')) {
     context.stdout.write('Output line 1\n');
     context.stdout.write('Output line 2\n');

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -69,6 +69,7 @@ export abstract class BaseShell implements IShell {
     );
 
     const context: IExternalContext = {
+      name,
       args,
       environment,
       stdout,

--- a/src/commands/javascript_command_runner.ts
+++ b/src/commands/javascript_command_runner.ts
@@ -22,10 +22,18 @@ export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
     // Narrow context passed to JavaScript command so that we don't leak cockle internals.
     const { args, environment, fileSystem, stdout, stderr } = context;
     const stdin = new JavaScriptInput(context.stdin);
-    const jsContext: IJavaScriptContext = { args, environment, fileSystem, stdin, stdout, stderr };
+    const jsContext: IJavaScriptContext = {
+      name: cmdName,
+      args,
+      environment,
+      fileSystem,
+      stdin,
+      stdout,
+      stderr
+    };
 
     try {
-      return await jsModule.run(cmdName, jsContext);
+      return await jsModule.run(jsContext);
     } catch (err) {
       console.error(`JavascriptCommandRunner: ${err}`);
       throw new RunCommandError(cmdName);

--- a/src/context/external_context.ts
+++ b/src/context/external_context.ts
@@ -6,6 +6,7 @@
 import { ExternalOutput } from '../io';
 
 export interface IExternalContext {
+  name: string;
   args: string[];
   environment: Map<string, string>;
   stdout: ExternalOutput;

--- a/src/context/javascript_context.ts
+++ b/src/context/javascript_context.ts
@@ -6,6 +6,7 @@ import { IJavaScriptInput, IOutput } from '../io';
  * Mininal context used to run imported JavaScript commands.
  */
 export interface IJavaScriptContext {
+  name: string;
   args: string[];
   fileSystem: IFileSystem;
   environment: Environment;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export { Aliases } from './aliases';
 export { BaseShell } from './base_shell';
 export { BaseShellWorker } from './base_shell_worker';
 export { IHandleStdin, IStdinReply, IStdinRequest } from './buffered_io';
-export { IOutputCallback } from './callback';
+export { IExternalCommand, IOutputCallback } from './callback';
 export { IExternalContext, IJavaScriptContext } from './context';
 export { IShell, IShellManager } from './defs';
 export { IDriveFSOptions } from './drive_fs';

--- a/src/types/javascript_module.ts
+++ b/src/types/javascript_module.ts
@@ -1,5 +1,5 @@
 import { IJavaScriptContext } from '../context';
 
 export interface IJavaScriptModule {
-  run(cmdName: string, context: IJavaScriptContext): Promise<number>;
+  run(context: IJavaScriptContext): Promise<number>;
 }

--- a/test/integration-tests/command/external-command.test.ts
+++ b/test/integration-tests/command/external-command.test.ts
@@ -34,7 +34,7 @@ test.describe('external command', () => {
       await shell.inputLine('external-cmd stdout');
       return output.text;
     });
-    expect(output).toMatch('Output line 1\r\nOutput line 2\r\n');
+    expect(output).toMatch('\r\nOutput line 1\r\nOutput line 2\r\n');
   });
 
   test('should write to file', async ({ page }) => {
@@ -92,5 +92,16 @@ test.describe('external command', () => {
       return output.text;
     });
     expect(output).toMatch('\r\nTEST_VAR=23\r\n');
+  });
+
+  test('should be passed command name', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { externalCommand, shellSetupEmpty } = globalThis.cockle;
+      const { shell, output } = await shellSetupEmpty();
+      await shell.registerExternalCommand('external-cmd', externalCommand);
+      await shell.inputLine('external-cmd name');
+      return output.text;
+    });
+    expect(output).toMatch('\r\nexternal-cmd\r\n');
   });
 });

--- a/test/serve/external_command.ts
+++ b/test/serve/external_command.ts
@@ -9,6 +9,10 @@ export async function externalCommand(context: IExternalContext): Promise<number
     context.environment.set('TEST_VAR', '23');
   }
 
+  if (args.includes('name')) {
+    context.stdout.write(context.name + '\n');
+  }
+
   if (args.includes('stdout')) {
     context.stdout.write('Output line 1\n');
     context.stdout.write('Output line 2\n');

--- a/test/util-js/lib/js-capitalise.js
+++ b/test/util-js/lib/js-capitalise.js
@@ -4,9 +4,9 @@ var Module = (function (exports) {
     const ExitCode = {
         GENERAL_ERROR: 1};
 
-    async function run(cmdName, context) {
-        const { args, stdout } = context;
-        stdout.write(cmdName + ': ' + args.map(arg => arg.toUpperCase()).join(','));
+    async function run(context) {
+        const { args, name, stdout } = context;
+        stdout.write(name + ': ' + args.map(arg => arg.toUpperCase()).join(','));
         return ExitCode.GENERAL_ERROR;
     }
 

--- a/test/util-js/lib/js-read.js
+++ b/test/util-js/lib/js-read.js
@@ -4,11 +4,10 @@ var Module = (function (exports) {
     const ExitCode = {
         SUCCESS: 0};
 
-    async function run(cmdName, context) {
+    async function run(context) {
         const { stdin, stdout } = context;
         // Read from stdin a character at a time and write it back capitalised until no further input is
         // available or EOT (ascii 4, Ctrl-C) is read.
-        //while (true) {
         let stop = false;
         while (!stop) {
             const chars = await stdin.readAsync(null);

--- a/test/util-js/lib/js-test.js
+++ b/test/util-js/lib/js-test.js
@@ -4,9 +4,9 @@ var Module = (function (exports) {
     const ExitCode = {
         SUCCESS: 0};
 
-    async function run(cmdName, context) {
-        const { args, stdout } = context;
-        stdout.write(cmdName + ': ' + args.join(','));
+    async function run(context) {
+        const { args, name, stdout } = context;
+        stdout.write(name + ': ' + args.join(','));
         return ExitCode.SUCCESS;
     }
 

--- a/test/util-js/package-lock.json
+++ b/test/util-js/package-lock.json
@@ -16,7 +16,7 @@
         },
         "../..": {
             "name": "@jupyterlite/cockle",
-            "version": "0.0.18",
+            "version": "0.1.0-a1",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {

--- a/test/util-js/src/js-capitalise.ts
+++ b/test/util-js/src/js-capitalise.ts
@@ -1,8 +1,8 @@
 import type { IJavaScriptContext } from '@jupyterlite/cockle';
 import { ExitCode } from '@jupyterlite/cockle';
 
-export async function run(cmdName: string, context: IJavaScriptContext): Promise<number> {
-  const { args, stdout } = context;
-  stdout.write(cmdName + ': ' + args.map(arg => arg.toUpperCase()).join(','));
+export async function run(context: IJavaScriptContext): Promise<number> {
+  const { args, name, stdout } = context;
+  stdout.write(name + ': ' + args.map(arg => arg.toUpperCase()).join(','));
   return ExitCode.GENERAL_ERROR;
 }

--- a/test/util-js/src/js-read.ts
+++ b/test/util-js/src/js-read.ts
@@ -1,7 +1,7 @@
 import type { IJavaScriptContext } from '@jupyterlite/cockle';
 import { ExitCode } from '@jupyterlite/cockle';
 
-export async function run(cmdName: string, context: IJavaScriptContext): Promise<number> {
+export async function run(context: IJavaScriptContext): Promise<number> {
   const { stdin, stdout } = context;
 
   // Read from stdin a character at a time and write it back capitalised until no further input is

--- a/test/util-js/src/js-test.ts
+++ b/test/util-js/src/js-test.ts
@@ -1,8 +1,8 @@
 import type { IJavaScriptContext } from '@jupyterlite/cockle';
 import { ExitCode } from '@jupyterlite/cockle';
 
-export async function run(cmdName: string, context: IJavaScriptContext): Promise<number> {
-  const { args, stdout } = context;
-  stdout.write(cmdName + ': ' + args.join(','));
+export async function run(context: IJavaScriptContext): Promise<number> {
+  const { args, name, stdout } = context;
+  stdout.write(name + ': ' + args.join(','));
   return ExitCode.SUCCESS;
 }


### PR DESCRIPTION
Include command name in `IExternalContext` and `IJavaScriptContext`. As they can be registered under any name, pass them at runtime and do so via the context rather than as a separate argument.