### PR TITLE
Deploy on github pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to github pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install micromamba
+        uses: mamba-org/setup-micromamba@v2
+
+      - name: Build cockle
+        shell: bash -l {0}
+        run: |
+          npm install
+          npm run build
+
+      - name: Build demo
+        shell: bash -l {0}
+        working-directory: demo
+        run: |
+          npm install
+          npm run build
+          cp lib/* assets/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./demo/assets
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ playwright-report/
 test-results/
 *.data
 *.js
+*.js.map
 *.wasm
 cockle_wasm_env/
 cockle-config.json

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ In-browser bash-like shell implemented in a combination of TypeScript and WebAss
 
 Used in the [JupyterLite terminal extension](https://github.com/jupyterlite/terminal).
 
+Try it out outside of JupyterLite on github pages at https://jupyterlite.github.io/cockle.
+
 ⚠️ This is an early-stage work in progress and should be considered experimental code. Anything and
 everything could change at any time.
 


### PR DESCRIPTION
Now that we no longer need to serve with cross-origin headers we can now deploy on github pages. This PR will build and deploy the demo site on every push to `main`.