### PR TITLE
Join URLs correctly with a single slash between baseUrl and path

### DIFF
--- a/src/buffered_io/service_worker_utils.ts
+++ b/src/buffered_io/service_worker_utils.ts
@@ -1,4 +1,5 @@
 import { IStdinReply, IStdinRequest } from './defs';
+import { joinURL } from '../utils';
 
 export enum AsyncOrSync {
   ASYNC = 0,
@@ -7,10 +8,12 @@ export enum AsyncOrSync {
 
 export class ServiceWorkerUtils {
   constructor(
-    readonly baseUrl: string,
+    baseUrl: string,
     readonly browsingContextId: string,
     readonly shellId: string
-  ) {}
+  ) {
+    this._url = joinURL(baseUrl, 'api/stdin/terminal');
+  }
 
   getStdin(timeoutMs: number): string {
     try {
@@ -44,8 +47,7 @@ export class ServiceWorkerUtils {
     test: boolean = false
   ): { xhr: XMLHttpRequest; msg: string } {
     const xhr = new XMLHttpRequest();
-    const url = new URL('/api/stdin/terminal', this.baseUrl).href;
-    xhr.open('POST', url, asyncOrSync === AsyncOrSync.ASYNC);
+    xhr.open('POST', this._url, asyncOrSync === AsyncOrSync.ASYNC);
     const data: IStdinRequest = { shellId: this.shellId, timeoutMs };
     if (test) {
       data['test'] = true;
@@ -65,4 +67,6 @@ export class ServiceWorkerUtils {
       throw new Error(`Invalid stdin response: ${reply}`);
     }
   }
+
+  private _url: string;
 }

--- a/src/commands/command_module_loader.ts
+++ b/src/commands/command_module_loader.ts
@@ -2,6 +2,7 @@ import { CommandModuleCache } from './command_module_cache';
 import { IShellWorker } from '../defs_internal';
 import { IJavaScriptModule } from '../types/javascript_module';
 import { IWebAssemblyModule } from '../types/wasm_module';
+import { joinURL } from '../utils';
 
 /**
  * Loader of JavaScript/WebAssembly modules. Once loaded, a module is cached so that it is faster
@@ -42,7 +43,7 @@ export class CommandModuleLoader {
     if (module === undefined) {
       // Maybe should use @jupyterlab/coreutils.URLExt to combine URL components.
       const filename = this.cache.key(packageName, moduleName) + '.js';
-      const url = this.wasmBaseUrl + filename;
+      const url = joinURL(this.wasmBaseUrl, filename);
       console.log(`Cockle loading ${wasm ? 'WebAssembly' : 'JavaScript'} module from ${url}`);
 
       this.downloadModuleCallback(packageName, moduleName, true);

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -5,6 +5,7 @@ import { FindCommandError } from '../error_exit_code';
 import { ExitCode } from '../exit_code';
 import type { MainModule } from '../types/wasm_module';
 import { ITermios } from '../termios';
+import { joinURL } from '../utils';
 
 export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
   constructor(readonly module: CommandModule) {
@@ -103,7 +104,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
     const wasm = await wasmModule({
       thisProgram: cmdName,
       arguments: args,
-      locateFile: (path: string) => wasmBaseUrl + this.packageName + '/' + path,
+      locateFile: (path: string) => joinURL(wasmBaseUrl, this.packageName + '/' + path),
       onExit: (moduleExitCode: number) => setExitCode(moduleExitCode),
       quit: (moduleExitCode: number, toThrow: any) => setExitCode(moduleExitCode),
       preRun: [

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -25,6 +25,7 @@ import { CommandModule } from './commands/command_module';
 import { CommandModuleLoader } from './commands/command_module_loader';
 import { CommandPackage } from './commands/command_package';
 import { CommandRegistry } from './commands/command_registry';
+import { joinURL } from './utils';
 
 /**
  * Shell implementation.
@@ -338,7 +339,7 @@ export class ShellImpl implements IShellWorker {
       return;
     }
     const module = await fsModule({
-      locateFile: (path: string) => wasmBaseUrl + 'cockle_fs/' + path
+      locateFile: (path: string) => joinURL(wasmBaseUrl, 'cockle_fs/' + path)
     });
     const { FS, PATH, ERRNO_CODES, PROXYFS } = module;
 
@@ -373,7 +374,7 @@ export class ShellImpl implements IShellWorker {
   }
 
   private async _initWasmPackages(): Promise<void> {
-    const url = this._options.wasmBaseUrl + 'cockle-config.json';
+    const url = joinURL(this._options.wasmBaseUrl, 'cockle-config.json');
     const response = await fetch(url);
     if (!response.ok) {
       // Would be nice to report this via the terminal.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,15 @@ export async function delay(milliseconds: number = 10): Promise<void> {
 }
 
 /**
+ * Join a baseUrl to a path, ensuring there is exactly one slash at the join position.
+ */
+export function joinURL(baseUrl: string, path: string): string {
+  baseUrl = baseUrl.replace(/\/+$/, ''); // Remove trailing slashes.
+  path = path.replace(/^\/+/, ''); // Remove leading slashes.
+  return `${baseUrl}/${path}`;
+}
+
+/**
  * Find the longest string that starts all of the supplied strings.
  * startIndex is the index to start at, if you already know that the first startIndex characters
  * are identical.

--- a/test/integration-tests/command/external-command.test.ts
+++ b/test/integration-tests/command/external-command.test.ts
@@ -1,4 +1,3 @@
-import { IExternalCommand } from '@jupyterlite/cockle';
 import { expect } from '@playwright/test';
 import { test } from '../utils';
 

--- a/test/unit-tests/utils.test.ts
+++ b/test/unit-tests/utils.test.ts
@@ -1,0 +1,16 @@
+import { joinURL } from '../../src/utils';
+
+describe('joinURL', () => {
+  test('should should use just one slash between baseUrl and path', () => {
+    const expected = 'http://localhost/path';
+    expect(joinURL('http://localhost', 'path')).toEqual(expected);
+    expect(joinURL('http://localhost/', 'path')).toEqual(expected);
+    expect(joinURL('http://localhost//', 'path')).toEqual(expected);
+    expect(joinURL('http://localhost', '/path')).toEqual(expected);
+    expect(joinURL('http://localhost', '//path')).toEqual(expected);
+    expect(joinURL('http://localhost/', '/path')).toEqual(expected);
+    expect(joinURL('http://localhost//', '/path')).toEqual(expected);
+    expect(joinURL('http://localhost/', '//path')).toEqual(expected);
+    expect(joinURL('http://localhost//', '//path')).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Previously we were creating URLs somewhat simplistically by combining `baseUrl` and `path` strings or using `URL`. This worked fine in simple situations such as the local demo and testing, but in more complicated situations this wasn't always correct as it could lead to, for example, an incorrect number of slashes. In the `terminal` extension we would use JupyterLab's `URLExt.join` but we don't want to add a dependency on JupyterLab here, so instead this PR adds a new function `joinURL` to use the correct number of slashes.