### PR TITLE
Fix handling of timeout when vim uses service worker for stdin

### DIFF
--- a/src/buffered_io/defs.ts
+++ b/src/buffered_io/defs.ts
@@ -44,5 +44,5 @@ export interface IStdinRequest {
  */
 export interface IStdinReply {
   error?: string;
-  text?: string | null; // null means timeout reached before any input available.
+  text?: string; // An empty string means timeout reached before any input available.
 }

--- a/src/buffered_io/service_worker_main_io.ts
+++ b/src/buffered_io/service_worker_main_io.ts
@@ -3,6 +3,7 @@ import { PromiseDelegate } from '@lumino/coreutils';
 import { IMainIO, IStdinReply, IStdinRequest } from './defs';
 import { MainIO } from './main';
 import { ServiceWorkerUtils } from './service_worker_utils';
+import { delay } from '../utils';
 
 export class ServiceWorkerMainIO extends MainIO implements IMainIO {
   constructor(baseUrl: string, browsingContextId: string, shellId: string) {
@@ -61,15 +62,10 @@ export class ServiceWorkerMainIO extends MainIO implements IMainIO {
       return { text };
     }
 
-    const stdinPromise = new PromiseDelegate<string | null>();
+    const stdinPromise = new PromiseDelegate<string>();
 
     if (timeoutMs > 0) {
-      const timeoutPromise = new Promise<null>(resolve => {
-        setTimeout(() => resolve(null), timeoutMs);
-      });
-      timeoutPromise.then(() => {
-        stdinPromise.resolve(null);
-      });
+      delay(timeoutMs).then(() => stdinPromise.resolve(''));
     }
 
     // Store stdinPromise so that it can be resolved by next push() call.
@@ -101,6 +97,6 @@ export class ServiceWorkerMainIO extends MainIO implements IMainIO {
   }
 
   private _readBuffer: string = '';
-  private _stdinPromise?: PromiseDelegate<string | null>;
+  private _stdinPromise?: PromiseDelegate<string>;
   private _utils: ServiceWorkerUtils;
 }

--- a/src/buffered_io/service_worker_worker_io.ts
+++ b/src/buffered_io/service_worker_worker_io.ts
@@ -23,7 +23,9 @@ export class ServiceWorkerWorkerIO extends WorkerIO implements IWorkerIO {
     if (!readable && timeoutMs > 0) {
       const chars = this._utils.getStdin(timeoutMs);
       this._postRead(chars);
-      readable = this._readBuffer.length > 0;
+      // If chars.length > 0 then there are characters to read, so readable is true.
+      // If chars.length === 0 then the call timed out, readable is true to request next poll().
+      readable = true;
     }
 
     // Constants.


### PR DESCRIPTION
This fixes a bug when using the ServiceWorker for `stdin` and a command such as `vim` which calls `poll` with a `timeout` to check if there is input available. If the call times out without any input then `stdin` should still be classified as readable so that the next `poll` call occurs. `vim` does this with a 4 second timeout, so I have added a slow (more than 4 second) test to verify the fix.

This also includes some streamlining of the `timeout` handling code.

The SharedArrayBuffer implementation is already working correctly.