### PR TITLE
Add tests for `nano` and `vim` editors

### DIFF
--- a/test/integration-tests/command/nano.test.ts
+++ b/test/integration-tests/command/nano.test.ts
@@ -7,32 +7,73 @@ test.describe('nano command', () => {
     expect(output).toMatch(/^nano --version\r\n GNU nano, version 8.2\r\n/);
   });
 
-  test('should open and close', async ({ page }) => {
-    await page.evaluate(async () => {
-      const { shell } = await globalThis.cockle.shellSetupEmpty({ color: true });
-      const { terminalInput } = globalThis.cockle;
-      const exit = '\x18'; // Ctrl-X
-      await Promise.all([shell.inputLine('nano'), terminalInput(shell, [exit])]);
+  const stdinOptions = ['sab', 'sw'];
+  stdinOptions.forEach(stdinOption => {
+    test(`should open and close using ${stdinOption}`, async ({ page }) => {
+      await page.evaluate(async stdinOption => {
+        const { shellSetupEmpty, terminalInput } = globalThis.cockle;
+        const { shell } = await shellSetupEmpty({ color: true, stdinOption });
+        const exit = '\x18'; // Ctrl-X
+        await Promise.all([shell.inputLine('nano'), terminalInput(shell, [exit])]);
+      });
+      // If nano does not close, test will timeout.
     });
-    // If nano does not close, test will timeout.
-  });
 
-  test('should create new file', async ({ page }) => {
-    const output = await page.evaluate(async () => {
-      const { shell, output } = await globalThis.cockle.shellSetupEmpty({ color: true });
-      const { keys, terminalInput } = globalThis.cockle;
-      const { enter } = keys;
-      const exit = '\x18'; // Ctrl-X
-      const writeFile = '\x0f'; // Ctrl-O
-      await Promise.all([
-        shell.inputLine('nano'),
-        terminalInput(shell, [...('abc\ndef' + writeFile + 'out.txt' + enter + exit)])
-      ]);
-      // New file should exist.
-      output.clear();
-      await shell.inputLine('cat out.txt');
-      return output.text;
+    test(`should create new file using ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { keys, shellSetupEmpty, terminalInput } = globalThis.cockle;
+        const { shell, output } = await shellSetupEmpty({ color: true, stdinOption });
+        const { enter } = keys;
+        const exit = '\x18'; // Ctrl-X
+        const writeFile = '\x0f'; // Ctrl-O
+        await Promise.all([
+          shell.inputLine('nano'),
+          terminalInput(shell, [...('abc' + enter + 'def' + writeFile + 'out.txt' + enter + exit)])
+        ]);
+        // New file should exist.
+        output.clear();
+        await shell.inputLine('cat out.txt');
+        return output.text;
+      });
+      expect(output).toMatch(/^cat out.txt\r\nabc\r\ndef\r\n/);
     });
-    expect(output).toMatch(/^cat out.txt\r\nabc\r\ndef\r\n/);
+
+    test(`should add to existing file using ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { keys, shellSetupSimple, terminalInput } = globalThis.cockle;
+        const { shell, output } = await shellSetupSimple({ color: true, stdinOption });
+        const { downArrow, enter } = keys;
+        const exit = '\x18'; // Ctrl-X
+        const writeFile = '\x0f'; // Ctrl-O
+        await Promise.all([
+          shell.inputLine('nano file2'),
+          terminalInput(shell, [...(downArrow + 'New' + enter + writeFile + enter + exit)])
+        ]);
+        output.clear();
+        await shell.inputLine('cat file2');
+        return output.text;
+      });
+      expect(output).toMatch(/^cat file2\r\nSome other file\r\nNew\r\nSecond line\r\n/);
+    });
+
+    test(`should delete from existing file using ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { keys, shellSetupSimple, terminalInput } = globalThis.cockle;
+        const { shell, output } = await shellSetupSimple({ color: true, stdinOption });
+        const { enter } = keys;
+        const deleteLine = '\x0b'; // Ctrl-K
+        const exit = '\x18'; // Ctrl-X
+        const writeFile = '\x0f'; // Ctrl-O
+        await Promise.all([
+          shell.inputLine('nano file2'),
+          // Delete first line of file, leaving just the second line.
+          terminalInput(shell, [deleteLine, writeFile, enter, exit])
+        ]);
+        output.clear();
+        await shell.inputLine('cat file2');
+        return output.text;
+      });
+      expect(output).toMatch(/^cat file2\r\nSecond line\r\n/);
+    });
   });
 });

--- a/test/integration-tests/command/vim.test.ts
+++ b/test/integration-tests/command/vim.test.ts
@@ -7,63 +7,85 @@ test.describe('vim command', () => {
     expect(output).toMatch(/^vim --version\r\nVIM - Vi IMproved 9.1/);
   });
 
-  test.describe('should accept synchronous stdin whilst running', () => {
-    const stdinOptions = ['sab', 'sw'];
-    stdinOptions.forEach(stdinOption => {
-      test(`should run interactively and exit using ${stdinOption}`, async ({ page }) => {
-        await page.evaluate(async stdinOption => {
-          // Use color: true to ensure TERM env var is set.
-          const { shell } = await globalThis.cockle.shellSetupEmpty({ color: true, stdinOption });
-          const { terminalInput } = globalThis.cockle;
-          await Promise.all([
-            shell.inputLine('vim'),
-            terminalInput(shell, ['\x1b', ':', 'q', '\r'])
-          ]);
-        });
+  const stdinOptions = ['sab', 'sw'];
+  stdinOptions.forEach(stdinOption => {
+    test(`should run interactively and exit using ${stdinOption}`, async ({ page }) => {
+      await page.evaluate(async stdinOption => {
+        // Use color: true to ensure TERM env var is set.
+        const { shellSetupEmpty, terminalInput } = globalThis.cockle;
+        const { shell } = await shellSetupEmpty({ color: true, stdinOption });
+        await Promise.all([shell.inputLine('vim'), terminalInput(shell, ['\x1b', ':', 'q', '\r'])]);
       });
+    });
 
-      test(`should create new file using ${stdinOption}`, async ({ page }) => {
-        const output = await page.evaluate(async stdinOption => {
-          const { shell, output } = await globalThis.cockle.shellSetupEmpty({
-            color: true,
-            stdinOption
-          });
-          const { terminalInput } = globalThis.cockle;
-          await Promise.all([
-            shell.inputLine('vim'),
-            terminalInput(shell, [...'ihi QW\x1b:wq out\r'])
-          ]);
-          // New file should exist.
-          output.clear();
-          await shell.inputLine('cat out');
-          return output.text;
-        });
-        expect(output).toMatch(/^cat out\r\nhi QW\r\n/);
+    test(`should create new file using ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { shellSetupEmpty, terminalInput } = globalThis.cockle;
+        const { shell, output } = await shellSetupEmpty({ color: true, stdinOption });
+        await Promise.all([
+          shell.inputLine('vim'),
+          terminalInput(shell, [...'ihi QW\x1b:wq out\r'])
+        ]);
+        // New file should exist.
+        output.clear();
+        await shell.inputLine('cat out');
+        return output.text;
       });
+      expect(output).toMatch(/^cat out\r\nhi QW\r\n/);
+    });
 
-      test(`should support multi-character escape sequences using ${stdinOption}`, async ({
-        page
-      }) => {
-        const output = await page.evaluate(async stdinOption => {
-          const { shell, output } = await globalThis.cockle.shellSetupEmpty({
-            color: true,
-            stdinOption
-          });
-          const { keys, terminalInput } = globalThis.cockle;
-          const { escape, leftArrow, upArrow } = keys;
-          await Promise.all([
-            shell.inputLine('vim'),
-            terminalInput(shell, [
-              ...('iabc\rdef' + upArrow + leftArrow + leftArrow + 'XY' + escape + ':wq out\r')
-            ])
-          ]);
-          // New file should exist.
-          output.clear();
-          await shell.inputLine('cat out');
-          return output.text;
-        });
-        expect(output).toMatch(/^cat out\r\naXYbc\r\ndef\r\n/);
+    test(`should add to existing file using ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { keys, shellSetupSimple, terminalInput } = globalThis.cockle;
+        const { shell, output } = await shellSetupSimple({ color: true, stdinOption });
+        await Promise.all([
+          shell.inputLine('vim file2'),
+          terminalInput(shell, [keys.down, ...'iNew\r\x1b:wq\r'])
+        ]);
+        output.clear();
+        await shell.inputLine('cat file2');
+        return output.text;
       });
+      expect(output).toMatch(/^cat file2\r\nSome other file\r\nNew\r\nSecond line\r\n/);
+    });
+
+    test(`should delete from existing file using ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { shellSetupSimple, terminalInput } = globalThis.cockle;
+        const { shell, output } = await shellSetupSimple({ color: true, stdinOption });
+        await Promise.all([
+          shell.inputLine('vim file2'),
+          terminalInput(shell, [...'dd\r\x1b:wq\r'])
+        ]);
+        output.clear();
+        await shell.inputLine('cat file2');
+        return output.text;
+      });
+      expect(output).toMatch(/^cat file2\r\nSecond line\r\n/);
+    });
+
+    test(`should support multi-character escape sequences using ${stdinOption}`, async ({
+      page
+    }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { shell, output } = await globalThis.cockle.shellSetupEmpty({
+          color: true,
+          stdinOption
+        });
+        const { keys, terminalInput } = globalThis.cockle;
+        const { escape, leftArrow, upArrow } = keys;
+        await Promise.all([
+          shell.inputLine('vim'),
+          terminalInput(shell, [
+            ...('iabc\rdef' + upArrow + leftArrow + leftArrow + 'XY' + escape + ':wq out\r')
+          ])
+        ]);
+        // New file should exist.
+        output.clear();
+        await shell.inputLine('cat out');
+        return output.text;
+      });
+      expect(output).toMatch(/^cat out\r\naXYbc\r\ndef\r\n/);
     });
   });
 });


### PR DESCRIPTION
Add full tests for file editors `nano` and `vim`, to test creating and modifying files, both adding and removing content. Using both SharedArrayBuffer and ServiceWorker for `stdin`. 