### PR TITLE
Support 24-bit RGB foreground and background color in TS/JS commands

### DIFF
--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -1,4 +1,4 @@
-import { ExitCode, IExternalContext, IShell, Shell } from '@jupyterlite/cockle';
+import { ansi, ExitCode, IExternalContext, IShell, Shell } from '@jupyterlite/cockle';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import { IDemo } from './defs';
@@ -21,6 +21,17 @@ async function externalCommand(context: IExternalContext): Promise<number> {
 
   if (args.includes('stderr')) {
     context.stderr.write('Error message\n');
+  }
+
+  if (args.includes('color')) {
+    for (let j = 0; j < 16; j++) {
+      let line = '';
+      for (let i = 0; i < 32; i++) {
+        const rgb = ansi.styleRGB((i + 1) * 8 - 1, 128, (j + 1) * 16 - 1);
+        line += rgb + String.fromCharCode(65 + i) + ansi.styleReset;
+      }
+      context.stdout.write(line + '\n');
+    }
   }
 
   if (args.includes('stdin')) {

--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -4,6 +4,10 @@
 
 const ESC = '\x1B[';
 
+function clamp(n: number): number {
+  return Math.min(Math.max(Math.round(n), 0), 255);
+}
+
 export const ansi = {
   cursorUp: (count = 1) => (count > 0 ? ESC + count + 'A' : ''),
   cursorDown: (count = 1) => (count > 0 ? ESC + count + 'B' : ''),
@@ -15,6 +19,11 @@ export const ansi = {
   eraseSavedLines: ESC + '3J',
   eraseEndLine: ESC + 'K',
   eraseStartLine: ESC + '1K',
+
+  styleRGB: (r: number, g: number, b: number, foreground: boolean = true) => {
+    const code = foreground ? '38' : '48';
+    return `${ESC}${code};2;${clamp(r)};${clamp(g)};${clamp(b)}m`;
+  },
 
   styleReset: ESC + '1;0m',
   styleBoldRed: ESC + '1;31m',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { Aliases } from './aliases';
+export { ansi } from './ansi';
 export { BaseShell } from './base_shell';
 export { BaseShellWorker } from './base_shell_worker';
 export { IHandleStdin, IStdinReply, IStdinRequest } from './buffered_io';


### PR DESCRIPTION
Support 24-bit RGB colors in TypeScript/JavaScript commands via helper function `ansi.styleRGB`. Example in the `demo` external command:

<img width="386" alt="Screenshot 2025-06-16 at 16 27 39" src="https://github.com/user-attachments/assets/1cdd6a45-22b4-4412-851a-660dd1de74d0" />

