### PR TITLE
Register external xommands in Shell constructor only

### DIFF
--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -79,6 +79,7 @@ export class Demo {
       wasmBaseUrl: baseUrl,
       outputCallback: this.outputCallback.bind(this),
       shellManager,
+      externalCommands: [{ name: 'external-cmd', command: externalCommand }],
       initialDirectories: ['dir'],
       initialFiles: {
         'file.txt': 'This is the contents of the file',
@@ -96,8 +97,6 @@ export class Demo {
           'print(factorial(tonumber(arg[1])))\n'
       }
     });
-
-    this._shell.registerExternalCommand({ name: 'external-cmd', command: externalCommand });
   }
 
   async start(): Promise<void> {

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -176,19 +176,16 @@ export abstract class BaseShell implements IShell {
     return this._ready.promise;
   }
 
-  async registerExternalCommand(options: IExternalCommand.IOptions): Promise<boolean> {
+  async registerExternalCommand(options: IExternalCommand.IOptions): Promise<void> {
     if (this.isDisposed) {
-      return false;
+      return;
     }
 
     await this.ready;
 
     const { name, command } = options;
-    const success = await this._remote!.registerExternalCommand(name);
-    if (success) {
-      this._externalCommands.set(name, command);
-    }
-    return success;
+    await this._remote!.registerExternalCommand(name);
+    this._externalCommands.set(name, command);
   }
 
   async setSize(rows: number, columns: number): Promise<void> {

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -105,11 +105,10 @@ export abstract class BaseShellWorker implements IShellWorker {
     }
   }
 
-  registerExternalCommand(name: string): boolean {
+  registerExternalCommand(name: string): void {
     if (this._shellImpl) {
-      return this._shellImpl!.registerExternalCommand(name);
+      this._shellImpl!.registerExternalCommand(name);
     }
-    return false;
   }
 
   async setSize(rows: number, columns: number): Promise<void> {

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -59,6 +59,7 @@ export abstract class BaseShellWorker implements IShellWorker {
       baseUrl: options.baseUrl,
       wasmBaseUrl: options.wasmBaseUrl,
       browsingContextId: options.browsingContextId,
+      externalCommandNames: options.externalCommandNames,
       initialDirectories: options.initialDirectories,
       initialFiles: options.initialFiles,
       callExternalCommand,
@@ -102,12 +103,6 @@ export abstract class BaseShellWorker implements IShellWorker {
   async input(char: string): Promise<void> {
     if (this._shellImpl) {
       await this._shellImpl.input(char);
-    }
-  }
-
-  registerExternalCommand(name: string): void {
-    if (this._shellImpl) {
-      this._shellImpl!.registerExternalCommand(name);
     }
   }
 

--- a/src/commands/command_registry.ts
+++ b/src/commands/command_registry.ts
@@ -67,12 +67,9 @@ export class CommandRegistry {
     }
   }
 
-  registerExternalCommand(name: string): boolean {
-    if (this._map.has(name)) {
-      return false;
-    }
+  registerExternalCommand(name: string): void {
+    // Overwrite if name already registered.
     this._map.set(name, new ExternalCommandRunner(name, this.callExternalCommand));
-    return true;
   }
 
   /**

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -6,7 +6,6 @@ import { IExternalCommand } from './external_command';
 
 export interface IShell extends IObservableDisposable {
   input(char: string): Promise<void>;
-  registerExternalCommand(options: IExternalCommand.IOptions): Promise<void>;
   setSize(rows: number, columns: number): Promise<void>;
   shellId: string;
   start(): Promise<void>;
@@ -21,6 +20,7 @@ export namespace IShell {
     wasmBaseUrl: string;
     browsingContextId?: string;
     shellManager?: IShellManager; // If specified, register this shell with shellManager
+    externalCommands?: IExternalCommand.IOptions[];
 
     // Initial directories and files to create, for testing purposes.
     initialDirectories?: string[];

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -6,7 +6,7 @@ import { IExternalCommand } from './external_command';
 
 export interface IShell extends IObservableDisposable {
   input(char: string): Promise<void>;
-  registerExternalCommand(options: IExternalCommand.IOptions): Promise<boolean>;
+  registerExternalCommand(options: IExternalCommand.IOptions): Promise<void>;
   setSize(rows: number, columns: number): Promise<void>;
   shellId: string;
   start(): Promise<void>;

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -44,7 +44,7 @@ export interface IShellWorker extends IShellCommon {
     setMainIOCallback: IShellWorker.IProxySetMainIOCallback,
     terminateCallback: IShellWorker.IProxyTerminateCallback
   ): void;
-  registerExternalCommand(name: string): boolean;
+  registerExternalCommand(name: string): void;
 }
 
 export namespace IShellWorker {

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -19,6 +19,8 @@ interface IOptionsCommon {
   baseUrl: string;
   wasmBaseUrl: string;
   browsingContextId?: string;
+  externalCommandNames: string[];
+
   // Initial directories and files to create, for testing purposes.
   initialDirectories?: string[];
   initialFiles?: IShell.IFiles;
@@ -44,7 +46,6 @@ export interface IShellWorker extends IShellCommon {
     setMainIOCallback: IShellWorker.IProxySetMainIOCallback,
     terminateCallback: IShellWorker.IProxyTerminateCallback
   ): void;
-  registerExternalCommand(name: string): void;
 }
 
 export namespace IShellWorker {

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -63,6 +63,10 @@ export class ShellImpl implements IShellWorker {
       commandModuleCache: this._commandModuleLoader.cache,
       stdinContext: options.stdinContext
     };
+
+    options.externalCommandNames.forEach(name =>
+      this._context.commandRegistry.registerExternalCommand(name)
+    );
   }
 
   get aliases(): Aliases {
@@ -151,10 +155,6 @@ export class ShellImpl implements IShellWorker {
       return;
     }
     this._context.workerIO.write(text);
-  }
-
-  registerExternalCommand(name: string): void {
-    this._context.commandRegistry.registerExternalCommand(name);
   }
 
   async setSize(rows: number, columns: number): Promise<void> {

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -153,8 +153,8 @@ export class ShellImpl implements IShellWorker {
     this._context.workerIO.write(text);
   }
 
-  registerExternalCommand(name: string): boolean {
-    return this._context.commandRegistry.registerExternalCommand(name);
+  registerExternalCommand(name: string): void {
+    this._context.commandRegistry.registerExternalCommand(name);
   }
 
   async setSize(rows: number, columns: number): Promise<void> {

--- a/test/integration-tests/command/external-command.test.ts
+++ b/test/integration-tests/command/external-command.test.ts
@@ -6,33 +6,32 @@ test.describe('external command', () => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupEmpty } = globalThis.cockle;
       const { shell, output } = await shellSetupEmpty();
-      const ok = await shell.registerExternalCommand({
+      await shell.registerExternalCommand({
         name: 'external-cmd',
         command: externalCommand
       });
       await shell.inputLine('cockle-config -c');
-      return [ok, output.text];
+      return output.text;
     });
-    expect(output[0]).toBeTruthy();
-    expect(output[1]).toMatch('│ external-cmd  │ <external>');
+    expect(output).toMatch('│ external-cmd  │ <external>');
   });
 
-  test('should fail when re-register same name', async ({ page }) => {
+  test('should succeed when re-register same name', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupEmpty } = globalThis.cockle;
-      const { shell } = await shellSetupEmpty();
-      const ok0 = await shell.registerExternalCommand({
+      const { shell, output } = await shellSetupEmpty();
+      await shell.registerExternalCommand({
         name: 'external-cmd',
         command: externalCommand
       });
-      const ok1 = await shell.registerExternalCommand({
+      await shell.registerExternalCommand({
         name: 'external-cmd',
         command: externalCommand
       });
-      return [ok0, ok1];
+      await shell.inputLine('cockle-config -c');
+      return output.text;
     });
-    expect(output[0]).toBeTruthy();
-    expect(output[1]).toBeFalsy();
+    expect(output).toMatch('│ external-cmd  │ <external>');
   });
 
   test('should write to stdout', async ({ page }) => {

--- a/test/integration-tests/command/external-command.test.ts
+++ b/test/integration-tests/command/external-command.test.ts
@@ -5,29 +5,8 @@ test.describe('external command', () => {
   test('should register', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupEmpty } = globalThis.cockle;
-      const { shell, output } = await shellSetupEmpty();
-      await shell.registerExternalCommand({
-        name: 'external-cmd',
-        command: externalCommand
-      });
-      await shell.inputLine('cockle-config -c');
-      return output.text;
-    });
-    expect(output).toMatch('│ external-cmd  │ <external>');
-  });
-
-  test('should succeed when re-register same name', async ({ page }) => {
-    const output = await page.evaluate(async () => {
-      const { externalCommand, shellSetupEmpty } = globalThis.cockle;
-      const { shell, output } = await shellSetupEmpty();
-      await shell.registerExternalCommand({
-        name: 'external-cmd',
-        command: externalCommand
-      });
-      await shell.registerExternalCommand({
-        name: 'external-cmd',
-        command: externalCommand
-      });
+      const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
+      const { shell, output } = await shellSetupEmpty({ externalCommands });
       await shell.inputLine('cockle-config -c');
       return output.text;
     });
@@ -37,8 +16,8 @@ test.describe('external command', () => {
   test('should write to stdout', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupEmpty } = globalThis.cockle;
-      const { shell, output } = await shellSetupEmpty();
-      await shell.registerExternalCommand({ name: 'external-cmd', command: externalCommand });
+      const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
+      const { shell, output } = await shellSetupEmpty({ externalCommands });
       await shell.inputLine('external-cmd stdout');
       return output.text;
     });
@@ -48,8 +27,8 @@ test.describe('external command', () => {
   test('should write to file', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupEmpty } = globalThis.cockle;
-      const { shell, output } = await shellSetupEmpty();
-      await shell.registerExternalCommand({ name: 'external-cmd', command: externalCommand });
+      const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
+      const { shell, output } = await shellSetupEmpty({ externalCommands });
       await shell.inputLine('external-cmd stdout > out.txt');
       const out0 = output.textAndClear();
       await shell.inputLine('cat out.txt');
@@ -62,8 +41,8 @@ test.describe('external command', () => {
   test('should write to stderr', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupEmpty } = globalThis.cockle;
-      const { shell, output } = await shellSetupEmpty();
-      await shell.registerExternalCommand({ name: 'external-cmd', command: externalCommand });
+      const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
+      const { shell, output } = await shellSetupEmpty({ externalCommands });
       await shell.inputLine('external-cmd stderr > out.txt');
       return output.text;
     });
@@ -73,8 +52,8 @@ test.describe('external command', () => {
   test('should return exit code', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupEmpty } = globalThis.cockle;
-      const { shell, output } = await shellSetupEmpty();
-      await shell.registerExternalCommand({ name: 'external-cmd', command: externalCommand });
+      const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
+      const { shell, output } = await shellSetupEmpty({ externalCommands });
       await shell.inputLine('external-cmd');
       output.clear();
       await shell.inputLine('env | grep ?');
@@ -92,8 +71,8 @@ test.describe('external command', () => {
   test('should set new environment variable', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupEmpty } = globalThis.cockle;
-      const { shell, output } = await shellSetupEmpty();
-      await shell.registerExternalCommand({ name: 'external-cmd', command: externalCommand });
+      const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
+      const { shell, output } = await shellSetupEmpty({ externalCommands });
       await shell.inputLine('external-cmd environment');
       output.clear();
       await shell.inputLine('env | grep TEST_VAR');
@@ -105,8 +84,8 @@ test.describe('external command', () => {
   test('should be passed command name', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupEmpty } = globalThis.cockle;
-      const { shell, output } = await shellSetupEmpty();
-      await shell.registerExternalCommand({ name: 'external-cmd', command: externalCommand });
+      const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
+      const { shell, output } = await shellSetupEmpty({ externalCommands });
       await shell.inputLine('external-cmd name');
       return output.text;
     });
@@ -116,8 +95,8 @@ test.describe('external command', () => {
   test('should read from pipe', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupSimple } = globalThis.cockle;
-      const { shell, output } = await shellSetupSimple();
-      await shell.registerExternalCommand({ name: 'external-cmd', command: externalCommand });
+      const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
+      const { shell, output } = await shellSetupSimple({ externalCommands });
       await shell.inputLine('cat file2 | external-cmd stdin');
       return output.text;
     });
@@ -127,8 +106,8 @@ test.describe('external command', () => {
   test('should read from file', async ({ page }) => {
     const output = await page.evaluate(async () => {
       const { externalCommand, shellSetupSimple } = globalThis.cockle;
-      const { shell, output } = await shellSetupSimple();
-      await shell.registerExternalCommand({ name: 'external-cmd', command: externalCommand });
+      const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
+      const { shell, output } = await shellSetupSimple({ externalCommands });
       await shell.inputLine('external-cmd stdin < file2');
       return output.text;
     });
@@ -140,8 +119,8 @@ test.describe('external command', () => {
     test(`should read from stdin via ${stdinOption}`, async ({ page }) => {
       const output = await page.evaluate(async stdinOption => {
         const { externalCommand, keys, shellSetupEmpty } = globalThis.cockle;
-        const { shell, output } = await shellSetupEmpty({ stdinOption });
-        await shell.registerExternalCommand({ name: 'external-cmd', command: externalCommand });
+        const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
+        const { shell, output } = await shellSetupEmpty({ externalCommands, stdinOption });
         await Promise.all([
           shell.inputLine('external-cmd stdin'),
           globalThis.cockle.terminalInput(shell, ['a', 'B', ' ', 'c', keys.EOT])

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -1,4 +1,4 @@
-import { IShell, Shell, ShellManager } from '@jupyterlite/cockle';
+import { IExternalCommand, IShell, Shell, ShellManager } from '@jupyterlite/cockle';
 import { MockTerminalOutput } from './output_setup';
 
 export interface IShellSetup {
@@ -8,6 +8,7 @@ export interface IShellSetup {
 
 export interface IOptions {
   color?: boolean;
+  externalCommands?: IExternalCommand.IOptions[];
   initialDirectories?: string[];
   initialFiles?: IShell.IFiles;
   shellId?: string;
@@ -59,7 +60,7 @@ async function _shellSetupCommon(options: IOptions, level: number): Promise<IShe
   }
 
   const baseUrl = 'http://localhost:8000/';
-  const { shellId, stdinOption } = options;
+  const { externalCommands, shellId, stdinOption } = options;
   let { shellManager } = options;
   if (stdinOption !== undefined && shellManager === undefined) {
     shellManager = new ShellManager();
@@ -76,6 +77,7 @@ async function _shellSetupCommon(options: IOptions, level: number): Promise<IShe
     baseUrl,
     wasmBaseUrl: baseUrl,
     browsingContextId,
+    externalCommands,
     shellId,
     shellManager,
     initialDirectories,


### PR DESCRIPTION
This changes the registration of `ExternalCommand`s to occur via `IOptions` in the `BaseShell` constructor rather than via `BaseShell.registerExternalCommand`. If we keep it as it is via the separate register function then we have to deal with it being called at any time, such as when a WebAssembly command is running. By setting them in the constructor we can ensure the registration is complete before the shell is `ready`.

This will make no difference to the JupyterLite terminal as external commands are registered with the one and only  `LiteTerminalAPIClient` and they are set on each `Shell` as it is created.