### PR TITLE
Setting aliases and env vars via Shell constructor

### DIFF
--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -262,6 +262,8 @@ export abstract class BaseShell implements IShell {
         wasmBaseUrl: options.wasmBaseUrl,
         baseUrl: options.baseUrl,
         browsingContextId: options.browsingContextId,
+        aliases: options.aliases ?? {},
+        environment: options.environment ?? {},
         externalCommandNames: options.externalCommands?.map(x => x.name) ?? [],
         sharedArrayBuffer,
         supportsServiceWorker,

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -59,6 +59,8 @@ export abstract class BaseShellWorker implements IShellWorker {
       baseUrl: options.baseUrl,
       wasmBaseUrl: options.wasmBaseUrl,
       browsingContextId: options.browsingContextId,
+      aliases: options.aliases,
+      environment: options.environment,
       externalCommandNames: options.externalCommandNames,
       initialDirectories: options.initialDirectories,
       initialFiles: options.initialFiles,

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -20,6 +20,8 @@ export namespace IShell {
     wasmBaseUrl: string;
     browsingContextId?: string;
     shellManager?: IShellManager; // If specified, register this shell with shellManager
+    aliases?: { [key: string]: string };
+    environment?: { [key: string]: string | null };
     externalCommands?: IExternalCommand.IOptions[];
 
     // Initial directories and files to create, for testing purposes.

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -19,6 +19,8 @@ interface IOptionsCommon {
   baseUrl: string;
   wasmBaseUrl: string;
   browsingContextId?: string;
+  aliases: { [key: string]: string };
+  environment: { [key: string]: string | null };
   externalCommandNames: string[];
 
   // Initial directories and files to create, for testing purposes.

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -47,7 +47,7 @@ export class ShellImpl implements IShellWorker {
       mountpoint: options.mountpoint ?? '/drive'
     };
 
-    // Content within which commands are run,
+    // Content within which commands are run.
     this._context = {
       args: [],
       fileSystem: this._fileSystem,
@@ -64,6 +64,21 @@ export class ShellImpl implements IShellWorker {
       stdinContext: options.stdinContext
     };
 
+    // Aliases.
+    Object.entries(options.aliases).forEach(([name, value]) =>
+      this._context.aliases.set(name, value)
+    );
+
+    // Environment variables.
+    Object.entries(options.environment).forEach(([name, value]) => {
+      if (value === null) {
+        this._context.environment.delete(name);
+      } else {
+        this._context.environment.set(name, value);
+      }
+    });
+
+    // External commands.
     options.externalCommandNames.forEach(name =>
       this._context.commandRegistry.registerExternalCommand(name)
     );

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -568,4 +568,38 @@ test.describe('Shell', () => {
       });
     });
   });
+
+  test.describe('constructor options', () => {
+    test('should support setting aliases', async ({ page }) => {
+      const output = await page.evaluate(async () => {
+        const aliases = { my_alias: 'target --something' };
+        const { output, shell } = await globalThis.cockle.shellSetupEmpty({ aliases });
+        await shell.inputLine('alias my_alias');
+        return output.text;
+      });
+      expect(output).toMatch(/^alias my_alias\r\nmy_alias='target --something'\r\n/);
+    });
+
+    test('should support setting environment variables', async ({ page }) => {
+      const output = await page.evaluate(async () => {
+        const environment = { ABC: 'some_value' };
+        const { output, shell } = await globalThis.cockle.shellSetupEmpty({ environment });
+        await shell.inputLine('env | grep ABC');
+        return output.text;
+      });
+      expect(output).toMatch(/^env | grep ABC'\r\nABC=some_value\r\n/);
+    });
+
+    test('should support deleting environment variables', async ({ page }) => {
+      const output = await page.evaluate(async () => {
+        const environment = { PS1: null };
+        const { output, shell } = await globalThis.cockle.shellSetupEmpty({ environment });
+        await shell.inputLine('env | grep PS1');
+        await shell.inputLine('env | grep ?');
+        return output.text;
+      });
+      // Test error code for 'env | grep PS1'
+      expect(output).toMatch('env | grep ?\r\n?=1\r\n');
+    });
+  });
 });

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -8,6 +8,8 @@ export interface IShellSetup {
 
 export interface IOptions {
   color?: boolean;
+  aliases?: { [key: string]: string };
+  environment?: { [key: string]: string | null };
   externalCommands?: IExternalCommand.IOptions[];
   initialDirectories?: string[];
   initialFiles?: IShell.IFiles;
@@ -60,7 +62,7 @@ async function _shellSetupCommon(options: IOptions, level: number): Promise<IShe
   }
 
   const baseUrl = 'http://localhost:8000/';
-  const { externalCommands, shellId, stdinOption } = options;
+  const { aliases, environment, externalCommands, shellId, stdinOption } = options;
   let { shellManager } = options;
   if (stdinOption !== undefined && shellManager === undefined) {
     shellManager = new ShellManager();
@@ -77,6 +79,8 @@ async function _shellSetupCommon(options: IOptions, level: number): Promise<IShe
     baseUrl,
     wasmBaseUrl: baseUrl,
     browsingContextId,
+    aliases,
+    environment,
     externalCommands,
     shellId,
     shellManager,


### PR DESCRIPTION
Support the setting of aliases and environment variables in Shell constructor via `IOptions`.

This will be exposed in the JupyterLite terminal via `LiteTerminalAPIClient` functions that store aliases and env vars and pass them to each `Shell` constructor when created.