### PR TITLE
Improved `ExternalEnvironment`

### DIFF
--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -8,6 +8,7 @@ async function externalCommand(context: IExternalContext): Promise<number> {
 
   if (args.includes('environment')) {
     context.environment.set('TEST_VAR', '23');
+    context.environment.delete('TEST_VAR2');
   }
 
   if (args.includes('name')) {

--- a/src/callback_internal.ts
+++ b/src/callback_internal.ts
@@ -9,11 +9,11 @@ export interface ICallExternalCommand {
   (
     name: string,
     args: string[],
-    environment: Map<string, string>,
+    environment: { [key: string]: string },
     stdinIsTerminal: boolean,
     stdoutSupportsAnsiEscapes: boolean,
     stderrSupportsAnsiEscapes: boolean
-  ): Promise<{ exitCode: number; newEnvironment?: Map<string, string> }>;
+  ): Promise<{ exitCode: number; environmentChanges?: { [key: string]: string | undefined } }>;
 }
 
 /**

--- a/src/commands/external_command_runner.ts
+++ b/src/commands/external_command_runner.ts
@@ -28,24 +28,24 @@ export class ExternalCommandRunner implements ICommandRunner {
     }
 
     const { args, environment, stdin, stdout, stderr } = context;
-    const { exitCode, newEnvironment } = await this.callExternalCommand(
+    const { exitCode, environmentChanges } = await this.callExternalCommand(
       this.name,
       args,
-      environment,
+      Object.fromEntries(environment),
       stdin.isTerminal(),
       stdout.supportsAnsiEscapes(),
       stderr.supportsAnsiEscapes()
     );
 
-    if (newEnvironment !== undefined) {
-      // Maybe should not return all of the environment, but only those keys that have changed.
-      // Do this by passing to command a wrapper of Map that stores what keys have changed via
-      // set() or delete()
-      for (const [key, value] of newEnvironment) {
-        environment.set(key, value);
-      }
+    if (environmentChanges !== undefined) {
+      Object.entries(environmentChanges).forEach(([name, value]) => {
+        if (value === undefined) {
+          environment.delete(name);
+        } else {
+          environment.set(name, value);
+        }
+      });
     }
-
     return exitCode;
   }
 }

--- a/src/context/external_context.ts
+++ b/src/context/external_context.ts
@@ -3,12 +3,13 @@
  * This exists in the main UI thread unlike other contexts that exist in the webworker.
  */
 
+import { ExternalEnvironment } from '../external_environment';
 import { IExternalInput, IExternalOutput } from '../io';
 
 export interface IExternalContext {
   name: string;
   args: string[];
-  environment: Map<string, string>;
+  environment: ExternalEnvironment;
   stdin: IExternalInput;
   stdout: IExternalOutput;
   stderr: IExternalOutput;

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -21,7 +21,7 @@ export namespace IShell {
     browsingContextId?: string;
     shellManager?: IShellManager; // If specified, register this shell with shellManager
     aliases?: { [key: string]: string };
-    environment?: { [key: string]: string | null };
+    environment?: { [key: string]: string | undefined };
     externalCommands?: IExternalCommand.IOptions[];
 
     // Initial directories and files to create, for testing purposes.

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -20,7 +20,7 @@ interface IOptionsCommon {
   wasmBaseUrl: string;
   browsingContextId?: string;
   aliases: { [key: string]: string };
-  environment: { [key: string]: string | null };
+  environment: { [key: string]: string | undefined };
   externalCommandNames: string[];
 
   // Initial directories and files to create, for testing purposes.

--- a/src/external_environment.ts
+++ b/src/external_environment.ts
@@ -1,0 +1,41 @@
+/**
+ * Environment available in external commands.
+ * Stores which entries have changed so that only the changed values are copied back to
+ * the WebWorker environment rather than all the entries.
+ */
+export class ExternalEnvironment extends Map<string, string> {
+  override delete(key: string): boolean {
+    if (this._changed === undefined) {
+      this._changed = new Set<string>();
+    }
+    this._changed.add(key);
+    return super.delete(key);
+  }
+
+  /**
+   * Return object containing only those entries that have changed, or undefined if no
+   * values have changed.
+   * An entry with a string value has changed to that string.
+   * An entry with an undefined value has been deleted.
+   */
+  get changed(): { [key: string]: string | undefined } | undefined {
+    if (this._changed === undefined) {
+      return undefined;
+    }
+
+    const ret: { [key: string]: string | undefined } = {};
+    this._changed.forEach(name => (ret[name] = this.get(name)));
+    return ret;
+  }
+
+  override set(key: string, value: string): this {
+    if (this._changed === undefined) {
+      this._changed = new Set<string>();
+    }
+    this._changed.add(key);
+    super.set(key, value);
+    return this;
+  }
+
+  private _changed?: Set<string>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { IShell, IShellManager } from './defs';
 export { IDriveFSOptions } from './drive_fs';
 export * from './exit_code';
 export { IExternalCommand } from './external_command';
+export { ExternalEnvironment } from './external_environment';
 export { IFileSystem } from './file_system';
 export * from './io';
 export { parse } from './parse';

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -71,7 +71,7 @@ export class ShellImpl implements IShellWorker {
 
     // Environment variables.
     Object.entries(options.environment).forEach(([name, value]) => {
-      if (value === null) {
+      if (value === undefined) {
         this._context.environment.delete(name);
       } else {
         this._context.environment.set(name, value);

--- a/test/serve/external_command.ts
+++ b/test/serve/external_command.ts
@@ -7,6 +7,7 @@ export async function externalCommand(context: IExternalContext): Promise<number
 
   if (args.includes('environment')) {
     context.environment.set('TEST_VAR', '23');
+    context.environment.delete('TEST_VAR2');
   }
 
   if (args.includes('name')) {

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -9,7 +9,7 @@ export interface IShellSetup {
 export interface IOptions {
   color?: boolean;
   aliases?: { [key: string]: string };
-  environment?: { [key: string]: string | null };
+  environment?: { [key: string]: string | undefined };
   externalCommands?: IExternalCommand.IOptions[];
   initialDirectories?: string[];
   initialFiles?: IShell.IFiles;


### PR DESCRIPTION
Improve `ExternalEnvironment` which are the environment variables passed to external commands, by supporting the deletion of environment variables and only copying back to the webworker environment those environment variables that have been deleted or changed, not all of them.

Fixes #179.