### PR TITLE
Support multiple extra channels via `COCKLE_WASM_EXTRA_CHANNEL`

### DIFF
--- a/src/tools/prepare_wasm.ts
+++ b/src/tools/prepare_wasm.ts
@@ -52,7 +52,8 @@ function getWasmPackageInfo(micromambaCmd: string, envPath: string): any {
 const COCKLE_WASM_EXTRA_CHANNEL = process.env.COCKLE_WASM_EXTRA_CHANNEL;
 if (COCKLE_WASM_EXTRA_CHANNEL !== undefined) {
   // Prepend so used first.
-  CHANNELS.unshift(COCKLE_WASM_EXTRA_CHANNEL);
+  const extraChannels = COCKLE_WASM_EXTRA_CHANNEL.split(":")
+  CHANNELS.unshift(...extraChannels);
 }
 
 // Base cockle config file from this repo.


### PR DESCRIPTION
The env var `COCKLE_WASM_EXTRA_CHANNEL` can be used when building the demo via `npm run build`, but currently only supports a single channel (e.g. a local directory). This PR allows multiple channels/directories to be specified in the same env var by using colons to separate them, for example:
```bash
cd demo
COCKLE_WASM_EXTRA_CHANNEL=/some/path/1:/some/path/2 npm run build
npm run serve
```