### PR TITLE
Table layout API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { IExternalCommand } from './external_command';
 export { ExternalEnvironment } from './external_environment';
 export { IFileSystem } from './file_system';
 export * from './io';
+export * from './layout';
 export { parse } from './parse';
 export { Shell } from './shell';
 export { ShellManager } from './shell_manager';

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -1,0 +1,1 @@
+export * from './table';

--- a/src/layout/table.ts
+++ b/src/layout/table.ts
@@ -1,0 +1,263 @@
+import { ansi } from '../ansi';
+import { IOutput } from '../io';
+import { rtrim } from '../utils';
+
+/**
+ * Type of horizontal spacer, such as between the header and rows.
+ */
+export enum HorizontalSpacerType {
+  TOP = 0,
+  MIDDLE = 1,
+  BOTTOM = 2
+}
+
+/**
+ * Type of vertical spacer used between adjacent columns in the same row.
+ */
+export enum VerticalSpacerType {
+  LEFT = 0,
+  INNER = 1,
+  RIGHT = 2
+}
+
+/**
+ * Abstract base class for table which displays a 2D grid of headers and rows with each column sized
+ * to fit its longest item. The number of columns is given by the maximum number of items in all
+ * rows ahd header rows; rows with fewer items are right-padded with empty strings. It does not
+ * care about terminal width or height, so may overrun in width and take up more than page.
+ */
+abstract class BaseTable {
+  constructor(readonly options: BaseTable.IOptions) {}
+
+  addHeaderRow(headerRow: string[]) {
+    this._headerRows.push(headerRow);
+    this._updateColumnWidths(headerRow);
+  }
+
+  addRow(row: string[]) {
+    this._rows.push(row);
+    this._updateColumnWidths(row);
+  }
+
+  /**
+   * Return a default colorByColumn map for clients that want to color columns but don't want to
+   * define their own.
+   */
+  static defaultColorByColumn(): Map<number, string> {
+    return new Map([
+      [1, ansi.styleBrightBlue],
+      [2, ansi.styleBrightPurple],
+      [3, ansi.styleGreen],
+      [4, ansi.styleYellow]
+    ]);
+  }
+
+  /**
+   * Generator for output lines, one at a time.
+   */
+  *lines(): Generator<string> {
+    const { sortByColumn } = this.options;
+    if (sortByColumn !== undefined) {
+      // Sort rows in place.
+      const compareColumn = (columnIndex: number, a: string[], b: string[]) => {
+        const sortColumn = sortByColumn[columnIndex];
+        if (a[sortColumn] < b[sortColumn]) {
+          return -1;
+        } else if (a[sortColumn] > b[sortColumn]) {
+          return 1;
+        } else if (sortByColumn.length > columnIndex + 1) {
+          // This column matches, sort by next column.
+          return compareColumn(columnIndex + 1, a, b);
+        }
+        return 0;
+      };
+      this._rows.sort((a, b) => compareColumn(0, a, b));
+    }
+
+    const nColumns = this._columnWidths.length;
+
+    const topSpacer = this.horizontalSpacer(HorizontalSpacerType.TOP);
+    if (topSpacer !== undefined) {
+      yield rtrim(topSpacer);
+    }
+
+    for (const headerRow of this._headerRows) {
+      let line = '';
+      for (let i = 0; i < nColumns; i++) {
+        line += this.verticalSpacer(i === 0 ? VerticalSpacerType.LEFT : VerticalSpacerType.INNER);
+        const item = headerRow[i] ?? '';
+        line += item + ' '.repeat(this._columnWidths[i] - item.length);
+      }
+      line += this.verticalSpacer(VerticalSpacerType.RIGHT);
+      yield rtrim(line);
+    }
+    if (this._headerRows.length > 0) {
+      const middleSpacer = this.horizontalSpacer(HorizontalSpacerType.MIDDLE);
+      if (middleSpacer !== undefined) {
+        yield rtrim(middleSpacer);
+      }
+    }
+    for (const row of this._rows) {
+      let line = '';
+      for (let i = 0; i < nColumns; i++) {
+        line += this.verticalSpacer(i === 0 ? VerticalSpacerType.LEFT : VerticalSpacerType.INNER);
+        const item = row[i] ?? '';
+        if (item) {
+          const color = this.options.colorByColumn?.get(i);
+          line += color !== undefined ? color + item + ansi.styleReset : item;
+        }
+        line += ' '.repeat(this._columnWidths[i] - item.length);
+      }
+      line += this.verticalSpacer(VerticalSpacerType.RIGHT);
+      yield rtrim(line);
+    }
+
+    const bottomSpacer = this.horizontalSpacer(HorizontalSpacerType.BOTTOM);
+    if (bottomSpacer !== undefined) {
+      yield rtrim(bottomSpacer);
+    }
+  }
+
+  /**
+   * Return horizontal spacer, such as between the header and rows, or undefined if there is no
+   * such spacer.
+   */
+  protected abstract horizontalSpacer(type: HorizontalSpacerType): string | undefined;
+
+  /**
+   * Return vertical spacer, i.e. spacer between adjacent columns in the same row.
+   */
+  protected abstract verticalSpacer(type: VerticalSpacerType): string;
+
+  /**
+   * Write table to output.
+   * @param output Output to write to.
+   * @param prefix String to insert at beginning of each line, default ''.
+   * @param suffix String to append to end of each line, default '\n.
+   */
+  write(output: IOutput, prefix: string = '', suffix: string = '\n') {
+    for (const line of this.lines()) {
+      output.write(prefix + line + suffix);
+    }
+  }
+
+  private _updateColumnWidths(row: string[]) {
+    const widths = row.map(str => str.length);
+    const n = Math.min(this._columnWidths.length, widths.length);
+    for (let i = 0; i < n; i++) {
+      this._columnWidths[i] = Math.max(this._columnWidths[i], widths[i]);
+    }
+    if (widths.length > n) {
+      this._columnWidths.push(...widths.slice(n));
+    }
+  }
+
+  protected _columnWidths: number[] = [];
+  private _headerRows: string[][] = [];
+  private _rows: string[][] = [];
+}
+
+/**
+ * Simple table with horizontal line between header and rows such as:
+ *
+ * header1  header2
+ * ────────────────
+ * aaaa     bbb
+ * cc       dd
+ */
+export class Table extends BaseTable {
+  constructor(options: Table.IOptions = {}) {
+    super(options);
+    const separatorSize = options.spacerSize ?? 2;
+    this._spacer = ' '.repeat(separatorSize);
+    this._spacersAtEnds = options.spacersAtEnds ?? false;
+  }
+
+  protected horizontalSpacer(type: HorizontalSpacerType): string | undefined {
+    if (type === HorizontalSpacerType.MIDDLE) {
+      const totalWidth =
+        this._columnWidths.reduce((acc, value) => acc + value) + this._totalSeparatorSize();
+      return '─'.repeat(totalWidth);
+    }
+    return undefined;
+  }
+
+  protected verticalSpacer(type: VerticalSpacerType): string {
+    if (type === VerticalSpacerType.INNER || this._spacersAtEnds) {
+      return this._spacer;
+    }
+    return '';
+  }
+
+  private _totalSeparatorSize(): number {
+    let nSpacers = this._columnWidths.length - 1;
+    if (this._spacersAtEnds) {
+      nSpacers += 2;
+    }
+    return nSpacers * this._spacer.length;
+  }
+
+  private _spacer: string;
+  private _spacersAtEnds: boolean;
+}
+
+/**
+ * Table with border such as:
+ *
+ * ╭─────────┬─────────╮",
+ * │ header1 │ header2 │",
+ * ├─────────┼─────────┤",
+ * │ aaaa    │ bbb     │",
+ * │ cc      │ d       │",
+ * ╰─────────┴─────────╯",
+ */
+export class BorderTable extends BaseTable {
+  constructor(options: BorderTable.IOptions = {}) {
+    super(options);
+  }
+
+  protected horizontalSpacer(type: HorizontalSpacerType): string | undefined {
+    const spacerChars = (type: HorizontalSpacerType) => {
+      switch (type) {
+        case HorizontalSpacerType.TOP:
+          return '╭┬╮';
+        case HorizontalSpacerType.MIDDLE:
+          return '├┼┤';
+        case HorizontalSpacerType.BOTTOM:
+          return '╰┴╯';
+      }
+    };
+    const chars = spacerChars(type);
+    return chars[0] + this._columnWidths.map(w => '─'.repeat(w + 2)).join(chars[1]) + chars[2];
+  }
+
+  protected verticalSpacer(type: VerticalSpacerType): string {
+    if (type === VerticalSpacerType.LEFT) {
+      return '│ ';
+    } else if (type === VerticalSpacerType.RIGHT) {
+      return ' │';
+    }
+    return ' │ ';
+  }
+}
+
+export namespace BaseTable {
+  export interface IOptions {
+    colorByColumn?: Map<number, string>;
+    sortByColumn?: number[]; // Indices of columns to sort by.
+    // TODO: add column justification.
+  }
+}
+
+export namespace Table {
+  export interface IOptions extends BaseTable.IOptions {
+    spacerSize?: number; // Default is 2
+    spacersAtEnds?: boolean; // Default is false
+  }
+}
+
+export namespace BorderTable {
+  export interface IOptions extends BaseTable.IOptions {
+    // TODO: border style such as rounded, square, double lines, etc?
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import { ansi } from './ansi';
-
 export async function delay(milliseconds: number = 10): Promise<void> {
   await new Promise(f => setTimeout(f, milliseconds));
 }
@@ -29,6 +27,13 @@ export function longestStartsWith(strings: string[], startIndex: number = 0): st
     index++;
   }
   return toMatch.slice(0, index);
+}
+
+/**
+ * Trim whitespace from end of string.
+ */
+export function rtrim(text: string): string {
+  return text.replace(/\s+$/, '');
 }
 
 /**
@@ -69,84 +74,4 @@ export function toColumns(strings: string[], columnWidth: number): string[] {
     lines.push(line);
   }
   return lines;
-}
-
-/**
- *
- */
-export function* toTable(
-  strings: string[][],
-  nHeaderRows: number,
-  simple: boolean = false,
-  colorMap: Map<number, string> | null = null
-): Generator<string> {
-  // Should check each input line has the same number of items.
-  // nHeaderRows <= nrows
-
-  const nrows = strings.length;
-  const ncols = strings[0].length;
-
-  // Get column widths
-  const widths = strings.map(row => row.map(str => str.length));
-  const colWidths = Array(ncols).fill(0);
-  for (let i = 0; i < nrows; i++) {
-    for (let j = 0; j < ncols; j++) {
-      colWidths[j] = Math.max(colWidths[j], widths[i][j]);
-    }
-  }
-
-  function hLine(which: number): string {
-    // 0 <= which < 2
-    const starts = '╭├╰';
-    const mids = '┬┼┴';
-    const ends = '╮┤╯';
-    let line = starts[which];
-    for (let j = 0; j < ncols; j++) {
-      line += '─'.repeat(colWidths[j] + 2);
-      line += j < ncols - 1 ? mids[which] : ends[which];
-    }
-    return line;
-  }
-
-  if (!simple) {
-    yield hLine(0);
-  }
-
-  for (let i = 0; i < nrows; i++) {
-    const row = strings[i];
-    let line = simple ? '' : '│ ';
-    for (let j = 0; j < ncols; j++) {
-      const color = colorMap?.get(j) || null;
-      if (color) {
-        line += color + row[j] + ansi.styleReset;
-      } else {
-        line += row[j];
-      }
-      line += ' '.repeat(colWidths[j] - row[j].length);
-      if (simple) {
-        line += '  ';
-      } else if (j === ncols - 1) {
-        line += ' │';
-      } else {
-        line += ' │ ';
-      }
-    }
-    yield line;
-
-    if (i === nHeaderRows - 1) {
-      if (simple) {
-        let line = '';
-        for (let j = 0; j < ncols; j++) {
-          line += '─'.repeat(colWidths[j]) + '  ';
-        }
-        yield line;
-      } else if (i !== nrows - 1) {
-        yield hLine(1);
-      }
-    }
-  }
-
-  if (!simple) {
-    yield hLine(2);
-  }
 }

--- a/test/unit-tests/layout.test.ts
+++ b/test/unit-tests/layout.test.ts
@@ -1,0 +1,325 @@
+import { BorderTable, Table } from '../../src/layout';
+import { IOutput } from '../../src/io';
+
+class MockOutput implements IOutput {
+  constructor(supportsAnsiEscapes: boolean = false) {
+    this._supportsAnsiEscapes = supportsAnsiEscapes;
+  }
+
+  flush() {}
+
+  supportsAnsiEscapes(): boolean {
+    return this._supportsAnsiEscapes;
+  }
+
+  write(text: string): void {
+    this.text.push(text);
+  }
+
+  private _supportsAnsiEscapes;
+  text: string[] = [];
+}
+
+describe('Table', () => {
+  test('should show header and normal rows', () => {
+    const table = new Table();
+    table.addHeaderRow(['h1', 'h2']);
+    table.addRow(['r1', 'r2']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual(['h1  h2\n', '──────\n', 'r1  r2\n']);
+  });
+
+  test('should not show horizontal spacer if no header', () => {
+    const table = new Table();
+    table.addRow(['r1', 'r2']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual(['r1  r2\n']);
+  });
+
+  test('should show spacer at ends', () => {
+    const table = new Table({ spacersAtEnds: true });
+    table.addHeaderRow(['h1', 'h2']);
+    table.addRow(['r1', 'r2']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual(['  h1  h2\n', '──────────\n', '  r1  r2\n']);
+  });
+
+  test('should support separatorSize', () => {
+    const table = new Table({ spacerSize: 3, spacersAtEnds: true });
+    table.addHeaderRow(['h1', 'h2']);
+    table.addRow(['r1', 'r2']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual(['   h1   h2\n', '─────────────\n', '   r1   r2\n']);
+  });
+
+  test('should use max width for each column', () => {
+    const table = new Table();
+    table.addHeaderRow(['h', 'longHeader']);
+    table.addRow(['longRow', 'r']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual(['h        longHeader\n', '───────────────────\n', 'longRow  r\n']);
+  });
+
+  test('should sort by single column', () => {
+    const table = new Table({ sortByColumn: [1] });
+    table.addRow(['a', 'z']);
+    table.addRow(['c', 'x']);
+    table.addRow(['b', 'y']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual(['c  x\n', 'b  y\n', 'a  z\n']);
+  });
+
+  test('should sort by multiple columns', () => {
+    const table = new Table({ sortByColumn: [1, 0] });
+    table.addRow(['n', 'z']);
+    table.addRow(['c', 'y']);
+    table.addRow(['b', 'y']);
+    table.addRow(['n', 'x']);
+
+    const output = new MockOutput();
+    table.write(output, '');
+    expect(output.text).toEqual(['n  x\n', 'b  y\n', 'c  y\n', 'n  z\n']);
+  });
+
+  test('should support multiple header rows', () => {
+    const table = new Table();
+    table.addHeaderRow(['h1', 'h2']);
+    table.addHeaderRow(['h3', 'h4']);
+    table.addRow(['r1', 'r2']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual(['h1  h2\n', 'h3  h4\n', '──────\n', 'r1  r2\n']);
+  });
+
+  test('should support missing items in headers and rows', () => {
+    const table = new Table();
+    table.addHeaderRow(['h1']);
+    table.addHeaderRow(['h3', 'h4']);
+    table.addRow(['r1', 'r2']);
+    table.addRow(['r3']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual(['h1\n', 'h3  h4\n', '──────\n', 'r1  r2\n', 'r3\n']);
+  });
+
+  test('should support colored columns but not headers', () => {
+    const table = new Table({ colorByColumn: Table.defaultColorByColumn() });
+    table.addHeaderRow(['h1', 'h2', 'h3']);
+    table.addRow(['r1', 'r2', 'r3']);
+
+    const output = new MockOutput(true);
+    table.write(output);
+    expect(output.text).toEqual([
+      'h1  h2  h3\n',
+      '──────────\n',
+      'r1  \x1B[0;94mr2\x1B[1;0m  \x1B[0;95mr3\x1B[1;0m\n'
+    ]);
+  });
+
+  test('should not color empty cells', () => {
+    const table = new Table({ colorByColumn: Table.defaultColorByColumn() });
+    table.addHeaderRow(['h1', 'h2', 'h3']);
+    table.addRow(['r1', 'r2', 'r3']);
+    table.addRow(['r4']);
+
+    const output = new MockOutput(true);
+    table.write(output, '');
+    expect(output.text).toEqual([
+      'h1  h2  h3\n',
+      '──────────\n',
+      'r1  \x1B[0;94mr2\x1B[1;0m  \x1B[0;95mr3\x1B[1;0m\n',
+      'r4\n'
+    ]);
+  });
+
+  test('output shouuld support prefix and suffix', () => {
+    const table = new Table();
+    table.addHeaderRow(['h1', 'h2']);
+    table.addRow(['r1', 'r2']);
+
+    const output = new MockOutput();
+    table.write(output, 'pre_', '_suf');
+    expect(output.text).toEqual(['pre_h1  h2_suf', 'pre_──────_suf', 'pre_r1  r2_suf']);
+  });
+});
+
+describe('BorderTable', () => {
+  test('should show header and normal rows', () => {
+    const table = new BorderTable();
+    table.addHeaderRow(['h1', 'h2']);
+    table.addRow(['r1', 'r2']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual([
+      '╭────┬────╮\n',
+      '│ h1 │ h2 │\n',
+      '├────┼────┤\n',
+      '│ r1 │ r2 │\n',
+      '╰────┴────╯\n'
+    ]);
+  });
+
+  test('should not show horizontal spacer if no header', () => {
+    const table = new BorderTable();
+    table.addRow(['r1', 'r2']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual(['╭────┬────╮\n', '│ r1 │ r2 │\n', '╰────┴────╯\n']);
+  });
+
+  test('should use max width for each column', () => {
+    const table = new BorderTable();
+    table.addHeaderRow(['h', 'longHeader']);
+    table.addRow(['longRow', 'r']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual([
+      '╭─────────┬────────────╮\n',
+      '│ h       │ longHeader │\n',
+      '├─────────┼────────────┤\n',
+      '│ longRow │ r          │\n',
+      '╰─────────┴────────────╯\n'
+    ]);
+  });
+
+  test('should sort by single column', () => {
+    const table = new BorderTable({ sortByColumn: [1] });
+    table.addRow(['a', 'z']);
+    table.addRow(['c', 'x']);
+    table.addRow(['b', 'y']);
+
+    const output = new MockOutput();
+    table.write(output, '');
+    expect(output.text).toEqual([
+      '╭───┬───╮\n',
+      '│ c │ x │\n',
+      '│ b │ y │\n',
+      '│ a │ z │\n',
+      '╰───┴───╯\n'
+    ]);
+  });
+
+  test('should sort by multiple columns', () => {
+    const table = new BorderTable({ sortByColumn: [1, 0] });
+    table.addRow(['n', 'z']);
+    table.addRow(['c', 'y']);
+    table.addRow(['b', 'y']);
+    table.addRow(['n', 'x']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual([
+      '╭───┬───╮\n',
+      '│ n │ x │\n',
+      '│ b │ y │\n',
+      '│ c │ y │\n',
+      '│ n │ z │\n',
+      '╰───┴───╯\n'
+    ]);
+  });
+
+  test('should support multiple header rows', () => {
+    const table = new BorderTable();
+    table.addHeaderRow(['h1', 'h2']);
+    table.addHeaderRow(['h3', 'h4']);
+    table.addRow(['r1', 'r2']);
+
+    const output = new MockOutput();
+    table.write(output, '');
+    expect(output.text).toEqual([
+      '╭────┬────╮\n',
+      '│ h1 │ h2 │\n',
+      '│ h3 │ h4 │\n',
+      '├────┼────┤\n',
+      '│ r1 │ r2 │\n',
+      '╰────┴────╯\n'
+    ]);
+  });
+
+  test('should support missing items in headers and rows', () => {
+    const table = new BorderTable();
+    table.addHeaderRow(['h1']);
+    table.addHeaderRow(['h3', 'h4']);
+    table.addRow(['r1', 'r2']);
+    table.addRow(['r3']);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual([
+      '╭────┬────╮\n',
+      '│ h1 │    │\n',
+      '│ h3 │ h4 │\n',
+      '├────┼────┤\n',
+      '│ r1 │ r2 │\n',
+      '│ r3 │    │\n',
+      '╰────┴────╯\n'
+    ]);
+  });
+
+  test('should support colored columns but not headers', () => {
+    const table = new BorderTable({ colorByColumn: BorderTable.defaultColorByColumn() });
+    table.addHeaderRow(['h1', 'h2', 'h3']);
+    table.addRow(['r1', 'r2', 'r3']);
+
+    const output = new MockOutput(true);
+    table.write(output);
+    expect(output.text).toEqual([
+      '╭────┬────┬────╮\n',
+      '│ h1 │ h2 │ h3 │\n',
+      '├────┼────┼────┤\n',
+      '│ r1 │ \x1B[0;94mr2\x1B[1;0m │ \x1B[0;95mr3\x1B[1;0m │\n',
+      '╰────┴────┴────╯\n'
+    ]);
+  });
+
+  test('should not color empty cells', () => {
+    const table = new BorderTable({ colorByColumn: BorderTable.defaultColorByColumn() });
+    table.addHeaderRow(['h1', 'h2', 'h3']);
+    table.addRow(['r1', 'r2', 'r3']);
+    table.addRow(['r4']);
+
+    const output = new MockOutput(true);
+    table.write(output);
+    expect(output.text).toEqual([
+      '╭────┬────┬────╮\n',
+      '│ h1 │ h2 │ h3 │\n',
+      '├────┼────┼────┤\n',
+      '│ r1 │ \x1B[0;94mr2\x1B[1;0m │ \x1B[0;95mr3\x1B[1;0m │\n',
+      '│ r4 │    │    │\n',
+      '╰────┴────┴────╯\n'
+    ]);
+  });
+
+  test('output should support prefix and suffix', () => {
+    const table = new BorderTable();
+    table.addHeaderRow(['h1', 'h2']);
+    table.addRow(['r1', 'r2']);
+
+    const output = new MockOutput();
+    table.write(output, 'pre_', '_suf');
+    expect(output.text).toEqual([
+      'pre_╭────┬────╮_suf',
+      'pre_│ h1 │ h2 │_suf',
+      'pre_├────┼────┤_suf',
+      'pre_│ r1 │ r2 │_suf',
+      'pre_╰────┴────╯_suf'
+    ]);
+  });
+});


### PR DESCRIPTION
This PR defines the API for table layouts that are used within `cockle` and are available for external commands. These are 2D gridded outputs with columns that autosize to their longest content. They can have headings, and they do not care about terminal width or height so can overrun.

There are simple tables of the form (`Table` class):
```bash
header1  header2
────────────────
aaaa     bbb
cc       dd
```

and tables with borders (`BorderTable` as already used in the `cockle-config` command):
```bash
╭─────────┬─────────╮
│ header1 │ header2 │
├─────────┼─────────┤
│ aaaa    │ bbb     │
│ cc      │ d       │
╰─────────┴─────────╯
```

Each of the constructors accepts class-specific `option: IOptions` to control aspects of the table, and these will be extended in due course. Currently all tables support coloring by column (not of headers), and sorting by one or more columns. `Table` supports configurable size of the spacer between columns, and spacers at the end so that the horizontal dividing line is longer than the headers and rows. 