### PR TITLE
Use termios ONOCR instead of allowAdjacentNewline

### DIFF
--- a/src/buffered_io/defs.ts
+++ b/src/buffered_io/defs.ts
@@ -11,7 +11,6 @@ export interface IMainIO extends IDisposable {
 }
 
 export interface IWorkerIO {
-  allowAdjacentNewline(set: boolean): void;
   canEnable(): Promise<void>;
   disable(): Promise<void>;
   enable(): Promise<void>;

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -526,7 +526,7 @@ export class ShellImpl implements IShellWorker {
     }
 
     await this._options.enableBufferedStdinCallback(true);
-    this._context.workerIO.allowAdjacentNewline(true);
+    this._context.workerIO.termios.setDefaultWasm();
 
     this.history.add(cmdText);
 
@@ -567,7 +567,7 @@ export class ShellImpl implements IShellWorker {
       exitCode = exitCode ?? ExitCode.GENERAL_ERROR;
       this.environment.set('?', `${exitCode}`);
 
-      this._context.workerIO.allowAdjacentNewline(false);
+      this._context.workerIO.termios.setDefaultShell();
       await this._options.enableBufferedStdinCallback(false);
     }
   }

--- a/src/termios.ts
+++ b/src/termios.ts
@@ -67,6 +67,10 @@ export interface ITermios {
 }
 
 export class Termios implements ITermios {
+  constructor() {
+    this.setDefaultShell();
+  }
+
   clone(): ITermios {
     return {
       c_iflag: this.c_iflag,
@@ -98,12 +102,6 @@ export class Termios implements ITermios {
     console.log(log.join('\n'));
   }
 
-  static newDefaultWasm(): Termios {
-    const ret = new Termios();
-    ret.setDefaultWasm();
-    return ret;
-  }
-
   set(iTermios: ITermios): void {
     this.c_iflag = iTermios.c_iflag;
     this.c_oflag = iTermios.c_oflag;
@@ -113,8 +111,19 @@ export class Termios implements ITermios {
     this.log('Termios set');
   }
 
+  /**
+   * Set termios settings to the default used in the shell outside of commands.
+   */
+  setDefaultShell(): void {
+    this.setDefaultWasm();
+    this.c_oflag |= OutputFlag.ONOCR;
+  }
+
+  /**
+   * Set termios settings to the default used in commands.
+   * This is taken from the default in emscripten-compiled code.
+   */
   setDefaultWasm(): void {
-    // Default termios from emscripten-compiled code.
     this.c_iflag = InputFlag.IUTF8 | InputFlag.IMAXBEL | InputFlag.IXON | InputFlag.ICRNL; // 25856 = 0x6500
     this.c_oflag = OutputFlag.OPOST | OutputFlag.ONLCR; // 5
     this.c_cflag = 191; // ignored
@@ -161,7 +170,6 @@ export class Termios implements ITermios {
       0,
       0
     ];
-    this.log('Termios setDefaultWasm');
   }
 
   c_iflag: InputFlag = 0 as InputFlag;

--- a/test/integration-tests/termios.test.ts
+++ b/test/integration-tests/termios.test.ts
@@ -15,7 +15,7 @@ test.describe('termios', () => {
           let cmdText = 'check_termios';
           if (flag !== 'default') {
             const { OutputFlag, Termios } = globalThis.cockle;
-            const termios = Termios.newDefaultWasm();
+            const termios = new Termios();
             const oflag =
               flag === 'enabled'
                 ? termios.c_oflag | OutputFlag.ONLCR


### PR DESCRIPTION
Use `termios` `ONOCR` output flag instead of the `allowAdjacentNewline` workaround. This requires the shell to run using slightly different `termios` settings than when running a command, so we switch between them when a command starts and stops.