### PR TITLE
Use termios raw mode to get terminal background color

### DIFF
--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -197,9 +197,6 @@ export abstract class BaseShell implements IShell {
 
     await this.ready;
     await this._remote!.start();
-
-    // Initial check if dark mode or not.
-    await this.themeChange();
   }
 
   async themeChange(): Promise<void> {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -8,7 +8,7 @@ export class Environment extends Map<string, string> {
   constructor(color: boolean) {
     super();
     if (color) {
-      this.set('PS1', ansi.styleBoldGreen + 'js-shell:' + ansi.styleReset + ' ');
+      this.set('PS1', ansi.styleGreen + 'js-shell:' + ansi.styleReset + ' ');
       this.set('TERM', 'xterm-256color');
       this.set('TERMINFO', '/usr/local/share/terminfo'); // Needed for nano
     } else {

--- a/src/termios.ts
+++ b/src/termios.ts
@@ -172,6 +172,25 @@ export class Termios implements ITermios {
     ];
   }
 
+  setRawMode() {
+    // Assume is currently default shell termios.
+    this.c_iflag &= ~(
+      InputFlag.ISTRIP |
+      InputFlag.INLCR |
+      InputFlag.IGNCR |
+      InputFlag.ICRNL |
+      InputFlag.IXON
+    );
+    this.c_oflag &= ~OutputFlag.OPOST;
+    this.c_lflag &= ~(
+      LocalFlag.ECHO |
+      LocalFlag.ECHONL |
+      LocalFlag.ICANON |
+      LocalFlag.ISIG |
+      LocalFlag.IEXTEN
+    );
+  }
+
   c_iflag: InputFlag = 0 as InputFlag;
   c_oflag: OutputFlag = 0 as OutputFlag;
   c_cflag: number = 0;


### PR DESCRIPTION
Use `termios` raw mode to get terminal background color when determining if dark mode or not. This disables the echo of input to output that can cause output of unnecessary newlines. Also supporting dark mode of `undefined` if the identification fails, this currently behaves as though it is using light mode but could be made distinct in the future.