### PR TITLE
Increase theme change timeout to 100 ms

### DIFF
--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -378,7 +378,7 @@ export class ShellImpl implements IShellWorker {
     // https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands
     this.output('\x1b]11;?\x07');
 
-    const timeoutMs = 10;
+    const timeoutMs = 100;
     const chars = await workerIO.readAsync(null, timeoutMs);
 
     workerIO.termios.setDefaultShell();


### PR DESCRIPTION
Increase theme change timeout from 10 ms to 100 ms. 10 ms is enough for the demo in this repo, but in the JupyterLite terminal it is possible for it to take up to 20 ms (on fast hardware) when changing the theme of all of JupyterLite. So be cautious here and increase the timeout to 100 ms.

Later we can consider if this needs to be configurable via `IShell.IOptions`.