### PR TITLE
Avoid multiple concurrent theme change handlers

### DIFF
--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -157,7 +157,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
     }
 
     const end = Date.now();
-    console.log(`Cockle ${cmdName} load and run time ${end - start} ms`);
+    console.debug(`Cockle ${cmdName} load and run time ${end - start} ms`);
     return exitCode;
   }
 }

--- a/src/termios.ts
+++ b/src/termios.ts
@@ -99,7 +99,7 @@ export class Termios implements ITermios {
     log.push(`  c_cflag = ${this.c_cflag} 0x${this.c_cflag.toString(16)}`);
     log.push(enumHelper(LocalFlag, 'c_lflag', this.c_lflag));
     log.push(`  c_cc = ${this.c_cc}`);
-    console.log(log.join('\n'));
+    console.debug(log.join('\n'));
   }
 
   set(iTermios: ITermios): void {


### PR DESCRIPTION
Previously if multiple theme changes occurred during a long running command such as `vim`, more than one handler could run at the same time. This was seen in the `terminal`. Here avoiding this by using a new `enum` to track the status of theme changes and avoid two being handled at the same time.

Outputting debug timings to `console.debug`, and changed a few previous `console.log` calls to the same.