### PR TITLE
Add TrailingPathsOption

### DIFF
--- a/src/builtin/alias_command.ts
+++ b/src/builtin/alias_command.ts
@@ -5,7 +5,7 @@ import { IContext } from '../context';
 import { ExitCode } from '../exit_code';
 
 class AliasOptions extends Options {
-  trailingStrings = new TrailingStringsOption(0);
+  trailingStrings = new TrailingStringsOption();
 }
 
 export class AliasCommand extends BuiltinCommand {

--- a/src/builtin/cd_command.ts
+++ b/src/builtin/cd_command.ts
@@ -1,12 +1,12 @@
 import { BuiltinCommand } from './builtin_command';
-import { TrailingStringsOption } from './option';
+import { TrailingPathsOption } from './option';
 import { Options } from './options';
 import { IContext } from '../context';
 import { GeneralError } from '../error_exit_code';
 import { ExitCode } from '../exit_code';
 
 class CdOptions extends Options {
-  trailingStrings = new TrailingStringsOption(0);
+  trailingPaths = new TrailingPathsOption();
 }
 
 export class CdCommand extends BuiltinCommand {
@@ -17,7 +17,7 @@ export class CdCommand extends BuiltinCommand {
   protected async _run(context: IContext): Promise<number> {
     const { args } = context;
     const options = new CdOptions().parse(args);
-    const paths = options.trailingStrings.strings;
+    const paths = options.trailingPaths.strings;
 
     if (paths.length < 1) {
       // Do nothing. Should cd to home directory?

--- a/src/builtin/export_command.ts
+++ b/src/builtin/export_command.ts
@@ -5,7 +5,7 @@ import { IContext } from '../context';
 import { ExitCode } from '../exit_code';
 
 class ExportOptions extends Options {
-  trailingStrings = new TrailingStringsOption(0);
+  trailingStrings = new TrailingStringsOption();
 }
 
 export class ExportCommand extends BuiltinCommand {

--- a/src/builtin/option.ts
+++ b/src/builtin/option.ts
@@ -105,15 +105,12 @@ export class TrailingPathsOption extends TrailingStringsOption {
   }
 }
 
-
 export namespace TrailingStringsOption {
   export interface IOptions {
-    min?: number
+    min?: number;
   }
 }
 
 export namespace TrailingPathsOption {
-  export interface IOptions extends TrailingStringsOption.IOptions {
-
-  }
+  export interface IOptions extends TrailingStringsOption.IOptions {}
 }

--- a/src/builtin/option.ts
+++ b/src/builtin/option.ts
@@ -63,10 +63,10 @@ export class OptionalStringOption extends BooleanOption {
 // Greedily consumes all remaining options as strings.
 // Often used for file/directory paths.
 export class TrailingStringsOption extends Option {
-  constructor(readonly minCount: number = 1) {
+  constructor(readonly options: TrailingStringsOption.IOptions = {}) {
     super('', '', '');
-    if (minCount < 0) {
-      throw new GeneralError('Negative minCount in TrailingStringsOption.constructor');
+    if (options.min !== undefined && options.min < 0) {
+      throw new GeneralError('Negative min in TrailingStringsOption.constructor');
     }
   }
 
@@ -97,4 +97,23 @@ export class TrailingStringsOption extends Option {
   }
 
   private _strings: string[] = [];
+}
+
+export class TrailingPathsOption extends TrailingStringsOption {
+  constructor(readonly options: TrailingPathsOption.IOptions = {}) {
+    super(options);
+  }
+}
+
+
+export namespace TrailingStringsOption {
+  export interface IOptions {
+    min?: number
+  }
+}
+
+export namespace TrailingPathsOption {
+  export interface IOptions extends TrailingStringsOption.IOptions {
+
+  }
 }

--- a/src/builtin/options.ts
+++ b/src/builtin/options.ts
@@ -34,8 +34,11 @@ export abstract class Options {
       }
     }
 
-    if (trailingStrings && trailingStrings.length < trailingStrings.minCount) {
-      throw new GeneralError('Insufficient trailing strings options specified');
+    if (trailingStrings) {
+      const { min } = trailingStrings.options;
+      if (min !== undefined && trailingStrings.length < min) {
+        throw new GeneralError('Insufficient trailing strings options specified');
+      }
     }
 
     return this;
@@ -72,7 +75,9 @@ export abstract class Options {
   }
 
   private _getStrings(): TrailingStringsOption | null {
-    if ('trailingStrings' in this) {
+    if ('trailingPaths' in this) {
+      return this['trailingPaths'] as TrailingStringsOption;
+    } else if ('trailingStrings' in this) {
       return this['trailingStrings'] as TrailingStringsOption;
     } else {
       return null;

--- a/test/unit-tests/options.test.ts
+++ b/test/unit-tests/options.test.ts
@@ -12,11 +12,11 @@ class BooleanOptions extends Options {
 
 class TrailingOptions extends Options {
   flag = new BooleanOption('f', 'flag', 'some flag');
-  trailingStrings = new TrailingStringsOption(0);
+  trailingStrings = new TrailingStringsOption();
 }
 
 class AtLeastOneTrailingOptions extends Options {
-  trailingStrings = new TrailingStringsOption(1);
+  trailingStrings = new TrailingStringsOption({ min: 1 });
 }
 
 class OptStringOptions extends Options {


### PR DESCRIPTION
Add `TrailingPathsOption` for builtin and external commands, derived from `TrailingStringsOption`. Will be needed for tab-completion of such commands, which is not yet implemented.