### PR TITLE
Support subcommand options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ then open a browser at the specified URL:
 <img alt="Demo" src="demo.png" width="800px">
 
 The demo is served with cross-origin headers so that is supports synchronous `stdin` via both
-SharedArrayBuffer and ServiceWorker. Use `cockle-config -s` to check the current settings, and
-`cockle-config -s sw` to switch to using the ServiceWorker.
+SharedArrayBuffer and ServiceWorker. Use `cockle-config stdin` to check the current settings, and
+`cockle-config stdin sw` to switch to using the ServiceWorker.
 
 ---
 

--- a/src/builtin/cockle_config_command.ts
+++ b/src/builtin/cockle_config_command.ts
@@ -1,19 +1,37 @@
 import { BuiltinCommand } from './builtin_command';
-import { BooleanOption, OptionalStringOption } from './option';
-import { Options } from './options';
+import { BooleanOption, TrailingStringsOption } from './option';
+import { Options, Subcommand } from './options';
 import { IContext } from '../context';
 import { GeneralError } from '../error_exit_code';
 import { ExitCode } from '../exit_code';
 import { BorderTable } from '../layout';
 import { COCKLE_VERSION } from '../version';
 
+class CommandSubcommand extends Subcommand {
+  trailingStrings = new TrailingStringsOption();
+}
+
+class ModuleSubcommand extends Subcommand {
+  trailingStrings = new TrailingStringsOption();
+}
+
+class PackageSubcommand extends Subcommand {
+  trailingStrings = new TrailingStringsOption();
+}
+
+class StdinSubcommand extends Subcommand {
+  trailingStrings = new TrailingStringsOption({ max: 1 });
+}
+
 class CockleConfigOptions extends Options {
   version = new BooleanOption('v', 'version', 'show cockle version');
-  stdin = new OptionalStringOption('s', 'stdin', 'synchronous stdin configuration');
-  package = new OptionalStringOption('p', 'package', 'show package information');
-  module = new OptionalStringOption('m', 'module', 'show module information');
-  command = new OptionalStringOption('c', 'command', 'show command information');
   help = new BooleanOption('h', 'help', 'display this help and exit');
+  subcommands = {
+    command: new CommandSubcommand('command', 'show command information'),
+    module: new ModuleSubcommand('module', 'show module information'),
+    package: new PackageSubcommand('package', 'show package information'),
+    stdin: new StdinSubcommand('stdin', 'synchronous stdin configuration')
+  };
 }
 
 export class CockleConfigCommand extends BuiltinCommand {
@@ -24,6 +42,7 @@ export class CockleConfigCommand extends BuiltinCommand {
   protected async _run(context: IContext): Promise<number> {
     const { args, environment, stdout } = context;
     const options = new CockleConfigOptions().parse(args);
+    const { subcommands } = options;
 
     if (options.help.isSet) {
       options.writeHelp(stdout);
@@ -39,17 +58,21 @@ export class CockleConfigCommand extends BuiltinCommand {
     if (showAll || options.version.isSet) {
       this._writeVersion(context);
     }
-    if (showAll || options.stdin.isSet) {
-      this._writeOrSetSyncStdinConfig(context, colorByColumn, options.stdin.string);
+    if (showAll || subcommands.stdin.isSet) {
+      this._writeOrSetSyncStdinConfig(
+        context,
+        colorByColumn,
+        subcommands.stdin.trailingStrings.strings.at(0)
+      );
     }
-    if (showAll || options.package.isSet) {
-      this._writePackageConfig(context, colorByColumn, options.package.string);
+    if (showAll || subcommands.package.isSet) {
+      this._writePackageConfig(context, colorByColumn, subcommands.package.trailingStrings.strings);
     }
-    if (showAll || options.module.isSet) {
-      this._writeModuleConfig(context, colorByColumn, options.module.string);
+    if (showAll || subcommands.module.isSet) {
+      this._writeModuleConfig(context, colorByColumn, subcommands.module.trailingStrings.strings);
     }
-    if (options.command.isSet) {
-      this._writeCommandConfig(context, colorByColumn, options.command.string);
+    if (subcommands.command.isSet) {
+      this._writeCommandConfig(context, colorByColumn, subcommands.command.trailingStrings.strings);
     }
 
     return ExitCode.SUCCESS;
@@ -58,37 +81,47 @@ export class CockleConfigCommand extends BuiltinCommand {
   private _writeCommandConfig(
     context: IContext,
     colorByColumn: Map<number, string> | undefined,
-    name: string | undefined
+    names: string[]
   ) {
     const { commandRegistry, stdout } = context;
-    const names = name === undefined ? commandRegistry.allCommands() : [name];
+
+    let commandNames = commandRegistry.allCommands();
+    if (names.length > 0) {
+      const missing = names.filter(name => !commandNames.includes(name));
+      if (missing.length > 0) {
+        throw new GeneralError(`Unknown command(s): ${missing.sort().join(' ')}`);
+      }
+      commandNames = names.sort();
+    }
 
     const table = new BorderTable({ colorByColumn, sortByColumn: [0] });
     table.addHeaderRow(['command', 'module']);
-    for (const name of names) {
+    for (const name of commandNames) {
       const runner = commandRegistry.get(name);
       if (runner === null) {
+        // Should never happen.
         throw new GeneralError(`Unknown command '${name}'`);
       }
       table.addRow([name, runner.moduleName]);
     }
-
     table.write(stdout);
   }
 
   private _writeModuleConfig(
     context: IContext,
     colorByColumn: Map<number, string> | undefined,
-    name: string | undefined
+    names: string[]
   ) {
     const { commandRegistry, commandModuleCache, stdout } = context;
 
     let modules = commandRegistry.allModules();
-    if (name !== undefined) {
-      modules = modules.filter(module => module.name === name);
-      if (modules.length === 0) {
-        throw new GeneralError(`Unknown module '${name}'`);
+    const moduleNames = modules.map(module => module.name);
+    if (names.length > 0) {
+      const missing = names.filter(name => !moduleNames.includes(name));
+      if (missing.length > 0) {
+        throw new GeneralError(`Unknown module(s): ${missing.sort().join(' ')}`);
       }
+      modules = modules.filter(module => names.includes(module.name));
     }
 
     const table = new BorderTable({ colorByColumn, sortByColumn: [0, 1] });
@@ -100,7 +133,6 @@ export class CockleConfigCommand extends BuiltinCommand {
         commandModuleCache.has(module.packageName, module.name) ? 'yes' : ''
       ]);
     }
-
     table.write(stdout);
   }
 
@@ -132,21 +164,23 @@ export class CockleConfigCommand extends BuiltinCommand {
   private _writePackageConfig(
     context: IContext,
     colorByColumn: Map<number, string> | undefined,
-    name: string | undefined
+    names: string[]
   ) {
     const { commandRegistry, stdout } = context;
 
-    let packages = [...commandRegistry.commandPackageMap.values()];
-    if (name !== undefined) {
-      packages = packages.filter(pkg => pkg.name === name);
-      if (packages.length === 0) {
-        throw new GeneralError(`Unknown package '${name}'`);
+    let packageNames = [...commandRegistry.commandPackageMap.keys()];
+    if (names.length > 0) {
+      const missing = names.filter(name => !packageNames.includes(name));
+      if (missing.length > 0) {
+        throw new GeneralError(`Unknown package(s): ${missing.sort().join(' ')}`);
       }
+      packageNames = names.sort();
     }
 
     const table = new BorderTable({ colorByColumn, sortByColumn: [0] });
-    table.addHeaderRow(['synchronous stdin', 'short name', 'available', 'enabled']);
-    for (const pkg of packages) {
+    table.addHeaderRow(['package', 'type', 'version', 'build string', 'source']);
+    for (const name of packageNames) {
+      const pkg = commandRegistry.commandPackageMap.get(name)!;
       table.addRow([
         pkg.name,
         pkg.wasm ? 'wasm' : 'js',

--- a/src/builtin/option.ts
+++ b/src/builtin/option.ts
@@ -65,8 +65,14 @@ export class OptionalStringOption extends BooleanOption {
 export class TrailingStringsOption extends Option {
   constructor(readonly options: TrailingStringsOption.IOptions = {}) {
     super('', '', '');
-    if (options.min !== undefined && options.min < 0) {
-      throw new GeneralError('Negative min in TrailingStringsOption.constructor');
+    const { max, min } = options;
+    if (min !== undefined) {
+      if (min < 0) {
+        throw new GeneralError('Negative min in TrailingStringsOption.constructor');
+      }
+      if (max !== undefined && max < min) {
+        throw new GeneralError('max must be greater than min in TrailingStringsOption.constructor');
+      }
     }
   }
 
@@ -108,6 +114,7 @@ export class TrailingPathsOption extends TrailingStringsOption {
 export namespace TrailingStringsOption {
   export interface IOptions {
     min?: number;
+    max?: number;
   }
 }
 

--- a/test/integration-tests/command/cockle-config-command.test.ts
+++ b/test/integration-tests/command/cockle-config-command.test.ts
@@ -1,0 +1,55 @@
+import { expect } from '@playwright/test';
+import { shellLineSimple, test } from '../utils';
+
+test.describe('cockle-config command', () => {
+  test('should show version', async ({ page }) => {
+    const output = await shellLineSimple(page, 'cockle-config -v');
+    expect(output).toMatch(/^cockle-config -v\r\ncockle \S+\r\n/);
+  });
+
+  test('should run stdin subcommand', async ({ page }) => {
+    const output = await shellLineSimple(page, 'cockle-config stdin');
+    const lines = output.split('\r\n');
+    expect(lines.length).toBe(8);
+    expect(lines[2]).toEqual('│ synchronous stdin   │ short name │ available │ enabled │');
+    expect(lines[4]).toEqual('│ shared array buffer │ sab        │ yes       │ yes     │');
+    expect(lines[5]).toEqual('│ service worker      │ sw         │           │         │');
+  });
+
+  test('should run package subcommand', async ({ page }) => {
+    const output = await shellLineSimple(page, 'cockle-config package grep');
+    const lines = output.split('\r\n');
+    expect(lines.length).toBe(7);
+    expect(lines[2]).toEqual(
+      '│ package │ type │ version │ build string │ source                                       │'
+    );
+    expect(lines[4]).toMatch(
+      '│ grep    │ wasm │ 3.11    │ ha2cbc09_6   │ https://repo.prefix.dev/emscripten-forge-dev │'
+    );
+
+    const output1 = await shellLineSimple(page, 'cockle-config package xyz123');
+    expect(output1).toMatch('\r\nError: Unknown package(s): xyz123\r\n');
+  });
+
+  test('should run module subcommand', async ({ page }) => {
+    const output = await shellLineSimple(page, 'cockle-config module fs');
+    const lines = output.split('\r\n');
+    expect(lines.length).toBe(7);
+    expect(lines[2]).toEqual('│ module │ package   │ cached │');
+    expect(lines[4]).toMatch('│ fs     │ cockle_fs │ yes    │');
+
+    const output1 = await shellLineSimple(page, 'cockle-config module mm123');
+    expect(output1).toMatch('\r\nError: Unknown module(s): mm123\r\n');
+  });
+
+  test('should run command subcommand', async ({ page }) => {
+    const output = await shellLineSimple(page, 'cockle-config command history');
+    const lines = output.split('\r\n');
+    expect(lines.length).toBe(7);
+    expect(lines[2]).toEqual('│ command │ module    │');
+    expect(lines[4]).toMatch('│ history │ <builtin> │');
+
+    const output1 = await shellLineSimple(page, 'cockle-config command c987');
+    expect(output1).toMatch('\r\nError: Unknown command(s): c987\r\n');
+  });
+});

--- a/test/integration-tests/command/external-command.test.ts
+++ b/test/integration-tests/command/external-command.test.ts
@@ -7,7 +7,7 @@ test.describe('external command', () => {
       const { externalCommand, shellSetupEmpty } = globalThis.cockle;
       const externalCommands = [{ name: 'external-cmd', command: externalCommand }];
       const { shell, output } = await shellSetupEmpty({ externalCommands });
-      await shell.inputLine('cockle-config -c');
+      await shell.inputLine('cockle-config command');
       return output.text;
     });
     expect(output).toMatch('│ external-cmd  │ <external>');

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -440,7 +440,7 @@ test.describe('Shell', () => {
 
   test.describe('synchronous stdin settings', () => {
     test('should only report SAB if not using shell manager', async ({ page }) => {
-      const output = await shellLineSimple(page, 'cockle-config -s');
+      const output = await shellLineSimple(page, 'cockle-config stdin');
       expect(output).toMatch(
         '│ shared array buffer │ sab        │ yes       │ yes     │\r\n' +
           '│ service worker      │ sw         │           │         │'
@@ -451,7 +451,7 @@ test.describe('Shell', () => {
       const output = await page.evaluate(async () => {
         const { shellManager, shellSetupEmpty } = globalThis.cockle;
         const { output, shell } = await shellSetupEmpty({ shellManager });
-        await shell.inputLine('cockle-config -s');
+        await shell.inputLine('cockle-config stdin');
         return output.text;
       });
       expect(output).toMatch(
@@ -464,7 +464,7 @@ test.describe('Shell', () => {
       const output = await page.evaluate(async () => {
         const { shellManager, shellSetupEmpty } = globalThis.cockle;
         const { output, shell } = await shellSetupEmpty({ shellManager });
-        await shell.inputLine('cockle-config -s sw');
+        await shell.inputLine('cockle-config stdin sw');
         return output.text;
       });
       expect(output).toMatch(
@@ -478,7 +478,7 @@ test.describe('Shell', () => {
     const stdinOptions = ['sab', 'sw'];
     stdinOptions.forEach(stdinOption => {
       test(`check parameterised stdinOption works for ${stdinOption}`, async ({ page }) => {
-        const output = await shellLineSimple(page, 'cockle-config -s', { stdinOption });
+        const output = await shellLineSimple(page, 'cockle-config stdin', { stdinOption });
         if (stdinOption === 'sab') {
           expect(output).toMatch(
             '│ shared array buffer │ sab        │ yes       │ yes     │\r\n' +

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -103,7 +103,7 @@ async function _shellSetupCommon(options: IOptions, level: number): Promise<IShe
 
   if (stdinOption) {
     // Set initial synchronous stdin option before enabling recording of output.
-    await inputLine(`cockle-config -s ${stdinOption}`);
+    await inputLine(`cockle-config stdin ${stdinOption}`);
   }
 
   output.start();


### PR DESCRIPTION
This PR adds support for subcommands in built-in, javascript and external commands. These have the form
```bash
command subcommand [subcommand-options]
```
They can be nested so it is possible to have subcommands of subcommands.

To demonstrate, I have changed the `cockle-config` command to use subcommands, for example `cockle-config -s` is now `cockle-config stdin` and `cockle-config -p` is now `cockle-config package`.

This will make more sense when we have tab completion implemented using the various `Option` classes.