### PR TITLE
Disable buffered IO before switching it

### DIFF
--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -303,6 +303,8 @@ export abstract class BaseShell implements IShell {
   }
 
   private _setMainIO(shortName: string): void {
+    const oldMainIO = this._mainIO;
+
     if (shortName === 'sab' && this._sharedArrayBufferMainIO !== undefined) {
       this._mainIO = this._sharedArrayBufferMainIO;
     } else if (shortName === 'sw' && this._serviceWorkerMainIO !== undefined) {
@@ -310,6 +312,9 @@ export abstract class BaseShell implements IShell {
     } else {
       throw new Error(`Cannot set MainIO to '${shortName}'`);
     }
+
+    // Disable old worker IO before switching it. This is a no-op if already disabled.
+    oldMainIO?.disable();
   }
 
   private _disposed = new Signal<this, void>(this);

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -128,6 +128,8 @@ export abstract class BaseShellWorker implements IShellWorker {
   }
 
   private _setWorkerIO(shortName: string): void {
+    const oldWorkerIO = this._workerIO;
+
     if (shortName === 'sab' && this._sharedArrayBufferWorkerIO !== undefined) {
       this._workerIO = this._sharedArrayBufferWorkerIO;
     } else if (shortName === 'sw' && this._serviceWorkerWorkerIO !== undefined) {
@@ -135,6 +137,9 @@ export abstract class BaseShellWorker implements IShellWorker {
     } else {
       throw new Error(`Cannot set WorkerIO to '${shortName}'`);
     }
+
+    // Disable old worker IO before switching it. This is a no-op if already disabled.
+    oldWorkerIO?.disable();
 
     this._shellImpl?.setWorkerIO(this._workerIO);
   }

--- a/src/buffered_io/main.ts
+++ b/src/buffered_io/main.ts
@@ -5,6 +5,10 @@ export abstract class MainIO implements IMainIO {
   constructor() {}
 
   async disable(): Promise<void> {
+    if (!this._enabled) {
+      return;
+    }
+
     this._enabled = false;
     this._clear();
   }

--- a/src/buffered_io/service_worker_main_io.ts
+++ b/src/buffered_io/service_worker_main_io.ts
@@ -12,6 +12,10 @@ export class ServiceWorkerMainIO extends MainIO implements IMainIO {
   }
 
   override async disable(): Promise<void> {
+    if (!this._enabled) {
+      return;
+    }
+
     // Send all remaining buffered characters as soon as possible via the supplied sendFunction.
     for (const ch of this._readBuffer) {
       this._sendStdinNow!(ch);

--- a/src/buffered_io/shared_array_buffer_main_io.ts
+++ b/src/buffered_io/shared_array_buffer_main_io.ts
@@ -18,6 +18,10 @@ export class SharedArrayBufferMainIO extends MainIO implements IMainIO {
   }
 
   override async disable(): Promise<void> {
+    if (!this._enabled) {
+      return;
+    }
+
     // Send all remaining buffered characters as soon as possible via the supplied sendFunction.
     this._disabling = true;
     if (this._readSentCount !== this._readCount) {

--- a/src/buffered_io/worker_io.ts
+++ b/src/buffered_io/worker_io.ts
@@ -11,6 +11,10 @@ export abstract class WorkerIO implements IWorkerIO {
   }
 
   async disable(): Promise<void> {
+    if (!this._enabled) {
+      return;
+    }
+
     this._enabled = false;
     this._clear();
     this._available?.resolve();

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -132,7 +132,9 @@ export class ShellImpl implements IShellWorker {
         const cmdText = this._currentLine;
         this._currentLine = '';
         this._cursorIndex = 0;
-        await this._runCommands(cmdText);
+        if (cmdText.length > 0) {
+          await this._runCommands(cmdText);
+        }
         await this._outputPrompt();
         break;
       }


### PR DESCRIPTION
Disable buffered IO before switching it using `cockle-config stdin <whatever>`. This is a bug fix as it was not explicitly disabled before this, although that did not cause any runtime problems. Also allow buffered IO `disable()` to be called even if it has not been enabled, in which case it is a no-op.