### PR TITLE
Support setting environment variables in cockle-config-in.json

### DIFF
--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -527,7 +527,7 @@ export class ShellImpl implements IShellWorker {
 
     // Initialise environment variables.
     if (Object.hasOwn(cockleConfig, 'environment')) {
-       for (const [key, v] of Object.entries(cockleConfig.environment)) {
+      for (const [key, v] of Object.entries(cockleConfig.environment)) {
         const value = v as string;
         if (value.length > 0) {
           this.environment.set(key, value);

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -524,6 +524,16 @@ export class ShellImpl implements IShellWorker {
         }
       }
     }
+
+    // Initialise environment variables.
+    if (Object.hasOwn(cockleConfig, 'environment')) {
+       for (const [key, v] of Object.entries(cockleConfig.environment)) {
+        const value = v as string;
+        if (value.length > 0) {
+          this.environment.set(key, value);
+        }
+      }
+    }
   }
 
   private async _outputPrompt(): Promise<void> {

--- a/src/tools/prepare_wasm.ts
+++ b/src/tools/prepare_wasm.ts
@@ -91,7 +91,8 @@ const inputSchema = zod
         })
         .strict()
     ),
-    aliases: zod.record(zod.string(), zod.string())
+    aliases: zod.optional(zod.record(zod.string(), zod.string())),
+    environment: zod.optional(zod.record(zod.string(), zod.string()))
   })
   .strict();
 inputSchema.parse(cockleConfig);
@@ -239,7 +240,8 @@ const outputSchema = zod
         })
         .strict()
     ),
-    aliases: zod.record(zod.string(), zod.string())
+    aliases: zod.optional(zod.record(zod.string(), zod.string())),
+    environment: zod.optional(zod.record(zod.string(), zod.string()))
   })
   .strict();
 outputSchema.parse(cockleConfig);

--- a/test/cockle-config-in.json
+++ b/test/cockle-config-in.json
@@ -23,5 +23,8 @@
   },
   "aliases": {
     "vi": "vim"
+  },
+  "environment": {
+    "ENV_VAR_FROM_COCKLE_CONFIG": "xyz123"
   }
 }

--- a/test/integration-tests/command/alias.test.ts
+++ b/test/integration-tests/command/alias.test.ts
@@ -22,4 +22,9 @@ test.describe('alias command', () => {
     const output = await shellLineSimpleN(page, ['alias abc="ls -alF"', 'alias | grep abc']);
     expect(output[1]).toMatch("\r\nabc='ls -alF'\r\n");
   });
+
+  test('should set alias from cockle-config-in.json', async ({ page }) => {
+    const output = await shellLineSimple(page, 'alias vi');
+    expect(output).toMatch("alias vi\r\nvi='vim'\r\n")
+  });
 });

--- a/test/integration-tests/command/alias.test.ts
+++ b/test/integration-tests/command/alias.test.ts
@@ -25,6 +25,6 @@ test.describe('alias command', () => {
 
   test('should set alias from cockle-config-in.json', async ({ page }) => {
     const output = await shellLineSimple(page, 'alias vi');
-    expect(output).toMatch("alias vi\r\nvi='vim'\r\n")
+    expect(output).toMatch("alias vi\r\nvi='vim'\r\n");
   });
 });

--- a/test/integration-tests/command/cockle-config-command.test.ts
+++ b/test/integration-tests/command/cockle-config-command.test.ts
@@ -24,7 +24,7 @@ test.describe('cockle-config command', () => {
       '│ package │ type │ version │ build string │ source                                       │'
     );
     expect(lines[4]).toMatch(
-      '│ grep    │ wasm │ 3.11    │ ha2cbc09_6   │ https://repo.prefix.dev/emscripten-forge-dev │'
+      '│ grep    │ wasm │ 3.11    │ h4e94343_7   │ https://repo.prefix.dev/emscripten-forge-dev │'
     );
 
     const output1 = await shellLineSimple(page, 'cockle-config package xyz123');

--- a/test/integration-tests/command/env.test.ts
+++ b/test/integration-tests/command/env.test.ts
@@ -14,6 +14,6 @@ test.describe('env command', () => {
 
   test('should set from cockle-config-in.json', async ({ page }) => {
     const output = await shellLineSimple(page, 'env | grep ENV_VAR_FROM_COCKLE_CONFIG');
-    expect(output).toMatch("\r\nENV_VAR_FROM_COCKLE_CONFIG=xyz123\r\n")
+    expect(output).toMatch('\r\nENV_VAR_FROM_COCKLE_CONFIG=xyz123\r\n');
   });
 });

--- a/test/integration-tests/command/env.test.ts
+++ b/test/integration-tests/command/env.test.ts
@@ -11,4 +11,9 @@ test.describe('env command', () => {
     const output = await shellLineSimple(page, 'env MYENV="ls -alF"|grep MYENV');
     expect(output).toMatch(/env MYENV="ls -alF"|grep MYENV\r\nMYENV=ls -alF\r\n/);
   });
+
+  test('should set from cockle-config-in.json', async ({ page }) => {
+    const output = await shellLineSimple(page, 'env | grep ENV_VAR_FROM_COCKLE_CONFIG');
+    expect(output).toMatch("\r\nENV_VAR_FROM_COCKLE_CONFIG=xyz123\r\n")
+  });
 });


### PR DESCRIPTION
Support setting environment variables in `cockle-config-in.json`. Closes #117.