### PR TITLE
If too many tab complete options, use yes/no prompt to display them all

### DIFF
--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -81,7 +81,10 @@ export class ShellImpl implements IShellImpl {
       this._options.color ? ansi.styleReset : undefined
     );
 
-    this._tabCompleter = new TabCompleter(this._runContext, this._options.enableBufferedStdinCallback);
+    this._tabCompleter = new TabCompleter(
+      this._runContext,
+      this._options.enableBufferedStdinCallback
+    );
   }
 
   get aliases(): Aliases {

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -81,7 +81,7 @@ export class ShellImpl implements IShellImpl {
       this._options.color ? ansi.styleReset : undefined
     );
 
-    this._tabCompleter = new TabCompleter(this._runContext);
+    this._tabCompleter = new TabCompleter(this._runContext, this._options.enableBufferedStdinCallback);
   }
 
   get aliases(): Aliases {

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -83,7 +83,8 @@ export class ShellImpl implements IShellImpl {
 
     this._tabCompleter = new TabCompleter(
       this._runContext,
-      this._options.enableBufferedStdinCallback
+      this._options.enableBufferedStdinCallback,
+      this._options.termios
     );
   }
 

--- a/src/tab_completer.ts
+++ b/src/tab_completer.ts
@@ -214,7 +214,7 @@ export class TabCompleter {
     let ret = false;
     let haveResponse = false;
     while (!haveResponse) {
-      const read = await workerIO.readAsync(1, 0);
+      const read = await workerIO.readAsync(1, -1);
       if (read.length > 0) {
         const char = read[0];
         if (char === 121) {

--- a/src/tab_completer.ts
+++ b/src/tab_completer.ts
@@ -1,4 +1,5 @@
 import { ansi } from './ansi';
+import { IEnableBufferedStdinCallback } from './callback_internal';
 import type { ICommandLine } from './command_line';
 import type { IRunContext } from './context';
 import { CommandNode, parse } from './parse';
@@ -8,7 +9,13 @@ import type { RuntimeExports } from './types/wasm_module';
 import { longestStartsWith, toColumns } from './utils';
 
 export class TabCompleter {
-  constructor(readonly context: IRunContext) {}
+  /**
+   * Note: do not use context's stdin/stdout/stderr, use context.workerIO instead.
+   */
+  constructor(
+    readonly context: IRunContext,
+    readonly enableBufferedStdinCallback: IEnableBufferedStdinCallback
+  ) {}
 
   async complete(commandLine: ICommandLine): Promise<ICommandLine> {
     const text = commandLine.text.slice(0, commandLine.cursorIndex);
@@ -166,11 +173,61 @@ export class TabCompleter {
     suffix: string,
     possibles: string[]
   ): Promise<void> {
-    // Write all the possibles in columns across the terminal, and re-output the same command line.
+    // Write all the possibles completions in columns across the terminal, and re-output the same
+    // command line. Maybe prompt user first, if there are many possible completions.
     const { environment } = this.context;
     const lines = toColumns(possibles, environment.getNumber('COLUMNS') ?? 0);
-    const output = `\n${lines.join('\n')}\n${environment.getPrompt()}${commandLine.text}`;
-    this.context.workerIO.write(output + ansi.cursorLeft(suffix.length));
+
+    // Display immediately or prompt user to confirm first?
+    const termLines = environment.getNumber('LINES');
+    let showPossibles = true;
+    if (possibles.length > 99 || (termLines !== null && lines.length > termLines - 2)) {
+      showPossibles = await this._yesNoPrompt(
+        `Display all ${possibles.length} possibilities (y or n)?`
+      );
+    }
+
+    if (showPossibles) {
+      this.context.workerIO.write('\n' + lines.join('\n') + '\n');
+    } else {
+      this.context.workerIO.write('\n');
+    }
+
+    // Rewrite prompt and command line.
+    this.context.workerIO.write(
+      environment.getPrompt() + commandLine.text + ansi.cursorLeft(suffix.length)
+    );
+  }
+
+  /**
+   * Prompt the user
+   */
+  private async _yesNoPrompt(prompt: string): Promise<boolean> {
+    const { workerIO } = this.context;
+    workerIO.write('\n' + prompt);
+
+    await this.enableBufferedStdinCallback(true);
+    workerIO.termios.setRawMode();
+
+    let ret = false;
+    while (true) {
+      const read = await workerIO.readAsync(1, 0);
+      if (read.length > 0) {
+        const char = read[0];
+        if (char === 121) {
+          // 121='y'
+          ret = true;
+          break;
+        } else if ([3, 4, 110].includes(char)) {
+          // 3=ETX, 4=EOT, 110='n'
+          break;
+        }
+      }
+    }
+
+    workerIO.termios.setDefaultShell();
+    await this.enableBufferedStdinCallback(false);
+    return ret;
   }
 }
 

--- a/src/tab_completer.ts
+++ b/src/tab_completer.ts
@@ -6,6 +6,7 @@ import { CommandNode, parse } from './parse';
 import type { ITabCompleteResult } from './tab_complete';
 import { PathType } from './tab_complete';
 import type { RuntimeExports } from './types/wasm_module';
+import { Termios } from './termios';
 import { longestStartsWith, toColumns } from './utils';
 
 export class TabCompleter {
@@ -14,7 +15,8 @@ export class TabCompleter {
    */
   constructor(
     readonly context: IRunContext,
-    readonly enableBufferedStdinCallback: IEnableBufferedStdinCallback
+    readonly enableBufferedStdinCallback: IEnableBufferedStdinCallback,
+    readonly termios: Termios.Termios
   ) {}
 
   async complete(commandLine: ICommandLine): Promise<ICommandLine> {
@@ -207,7 +209,7 @@ export class TabCompleter {
     workerIO.write('\n' + prompt);
 
     await this.enableBufferedStdinCallback(true);
-    workerIO.termios.setRawMode();
+    this.termios.setRawMode();
 
     let ret = false;
     let haveResponse = false;
@@ -226,7 +228,7 @@ export class TabCompleter {
       }
     }
 
-    workerIO.termios.setDefaultShell();
+    this.termios.setDefaultShell();
     await this.enableBufferedStdinCallback(false);
     return ret;
   }

--- a/src/tab_completer.ts
+++ b/src/tab_completer.ts
@@ -1,12 +1,12 @@
 import { ansi } from './ansi';
-import { IEnableBufferedStdinCallback } from './callback_internal';
+import type { IEnableBufferedStdinCallback } from './callback_internal';
 import type { ICommandLine } from './command_line';
 import type { IRunContext } from './context';
 import { CommandNode, parse } from './parse';
 import type { ITabCompleteResult } from './tab_complete';
 import { PathType } from './tab_complete';
+import type { Termios } from './termios';
 import type { RuntimeExports } from './types/wasm_module';
-import { Termios } from './termios';
 import { longestStartsWith, toColumns } from './utils';
 
 export class TabCompleter {

--- a/src/tab_completer.ts
+++ b/src/tab_completer.ts
@@ -210,17 +210,18 @@ export class TabCompleter {
     workerIO.termios.setRawMode();
 
     let ret = false;
-    while (true) {
+    let haveResponse = false;
+    while (!haveResponse) {
       const read = await workerIO.readAsync(1, 0);
       if (read.length > 0) {
         const char = read[0];
         if (char === 121) {
           // 121='y'
           ret = true;
-          break;
+          haveResponse = true;
         } else if ([3, 4, 110].includes(char)) {
           // 3=ETX, 4=EOT, 110='n'
-          break;
+          haveResponse = true;
         }
       }
     }

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -735,4 +735,98 @@ test.describe('Shell', () => {
       expect(outputD).toHaveLength(2);
     });
   });
+
+  test.describe('tab complete with synchronous stdin prompt', () => {
+    // Initial files includes filename long enough to be over half terminal width so that tab
+    // complete possiblities are displayed in a single column, one file per line.
+    const initialFiles = {
+      a0_very_very_very_very_very_very_very_very_very_very_very_long_file_name: '',
+      a1: '',
+      a2: '',
+      a3: '',
+      a4: '',
+      a5: '',
+      a6: '',
+      a7: '',
+      a8: '',
+      a9: ''
+    };
+
+    test('check no prompt if enough terminal lines to display them all', async ({ page }) => {
+      const output = await page.evaluate(
+        async ({ initialFiles }) => {
+          const { shellSetupEmpty, terminalInput } = globalThis.cockle;
+          const { shell, output } = await shellSetupEmpty({ initialFiles });
+          await shell.inputLine('export LINES=12'); // 2 more than number of files
+          output.clear();
+          await terminalInput(shell, ['l', 's', ' ', 'a', '\t']);
+          return output.text;
+        },
+        { initialFiles }
+      );
+      const lines = output.split('\r\n');
+      expect(lines).toHaveLength(12);
+      expect(lines[0]).toEqual('ls a');
+      expect(lines[1]).toMatch(/^a0_very_very/);
+      expect(lines[10]).toEqual('a9');
+      expect(lines.at(-1)).toMatch(/ls a$/);
+    });
+
+    //const stdinOptions = ['sab', 'sw'];
+    const stdinOptions = ['sw'];
+    stdinOptions.forEach(stdinOption => {
+      test(`check prompt displayed and accepted using y via ${stdinOption}`, async ({ page }) => {
+        const output = await page.evaluate(
+          async ({ stdinOption, initialFiles }) => {
+            const { delay, shellSetupEmpty, terminalInput } = globalThis.cockle;
+            const { shell, output } = await shellSetupEmpty({ initialFiles, stdinOption });
+            await shell.inputLine('export LINES=11'); // 1 more than number of files
+            output.clear();
+            await Promise.all([
+              terminalInput(shell, ['l', 's', ' ', 'a', '\t']),
+              // Short delay for prompt to be displayed before responding to it.
+              delay(100).then(() => terminalInput(shell, ['y']))
+            ]);
+            return output.text;
+          },
+          { stdinOption, initialFiles }
+        );
+        const lines = output.split('\r\n');
+        expect(lines).toHaveLength(13);
+        expect(lines[0]).toEqual('ls a');
+        expect(lines[1]).toEqual('Display all 10 possibilities (y or n)?');
+        expect(lines[2]).toMatch(/^a0_very_very/);
+        expect(lines[11]).toEqual('a9');
+        expect(lines.at(-1)).toMatch(/ls a$/);
+      });
+
+      const rejectChars = ['n', '\x03', '\x04'];
+      rejectChars.forEach(rejectChar => {
+        test(`check prompt displayed and rejected using ${rejectChar} via ${stdinOption}`, async ({
+          page
+        }) => {
+          const output = await page.evaluate(
+            async ({ stdinOption, initialFiles, rejectChar }) => {
+              const { delay, shellSetupEmpty, terminalInput } = globalThis.cockle;
+              const { shell, output } = await shellSetupEmpty({ initialFiles, stdinOption });
+              await shell.inputLine('export LINES=11'); // 1 more than number of files
+              output.clear();
+              await Promise.all([
+                terminalInput(shell, ['l', 's', ' ', 'a', '\t']),
+                // Short delay for prompt to be displayed before responding to it.
+                delay(100).then(() => terminalInput(shell, [rejectChar]))
+              ]);
+              return output.text;
+            },
+            { stdinOption, initialFiles, rejectChar }
+          );
+          const lines = output.split('\r\n');
+          expect(lines).toHaveLength(3);
+          expect(lines[0]).toEqual('ls a');
+          expect(lines[1]).toEqual('Display all 10 possibilities (y or n)?');
+          expect(lines.at(-1)).toMatch(/ls a$/);
+        });
+      });
+    });
+  });
 });

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -774,7 +774,7 @@ test.describe('Shell', () => {
 
     const stdinOptions = ['sab', 'sw'];
     stdinOptions.forEach(stdinOption => {
-      test(`check prompt displayed and accepted using y via ${stdinOption}`, async ({ page }) => {
+      test(`check prompt accepted using y via ${stdinOption}`, async ({ page }) => {
         const output = await page.evaluate(
           async ({ stdinOption, initialFiles }) => {
             const { shellSetupEmpty, terminalInput } = globalThis.cockle;
@@ -800,7 +800,7 @@ test.describe('Shell', () => {
 
       const rejectChars = ['n', '\x03', '\x04'];
       rejectChars.forEach(rejectChar => {
-        test(`check prompt displayed and rejected using ${rejectChar} via ${stdinOption}`, async ({
+        test(`check prompt rejected using ascii ${rejectChar.charCodeAt(0)} via ${stdinOption}`, async ({
           page
         }) => {
           const output = await page.evaluate(

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -777,15 +777,14 @@ test.describe('Shell', () => {
       test(`check prompt displayed and accepted using y via ${stdinOption}`, async ({ page }) => {
         const output = await page.evaluate(
           async ({ stdinOption, initialFiles }) => {
-            const { delay, shellSetupEmpty, terminalInput } = globalThis.cockle;
+            const { shellSetupEmpty, terminalInput } = globalThis.cockle;
             const { shell, output } = await shellSetupEmpty({ initialFiles, stdinOption });
             await shell.inputLine('export LINES=11'); // 1 more than number of files
             output.clear();
-            await Promise.all([
-              terminalInput(shell, ['l', 's', ' ', 'a', '\t']),
-              // Short delay for prompt to be displayed before responding to it.
-              delay(100).then(() => terminalInput(shell, ['y']))
-            ]);
+
+            terminalInput(shell, ['l', 's', ' ', 'a', '\t']);
+            await output.contains('possibilities (y or n)?');
+            await terminalInput(shell, ['y']);
             return output.text;
           },
           { stdinOption, initialFiles }
@@ -806,15 +805,14 @@ test.describe('Shell', () => {
         }) => {
           const output = await page.evaluate(
             async ({ stdinOption, initialFiles, rejectChar }) => {
-              const { delay, shellSetupEmpty, terminalInput } = globalThis.cockle;
+              const { shellSetupEmpty, terminalInput } = globalThis.cockle;
               const { shell, output } = await shellSetupEmpty({ initialFiles, stdinOption });
               await shell.inputLine('export LINES=11'); // 1 more than number of files
               output.clear();
-              await Promise.all([
-                terminalInput(shell, ['l', 's', ' ', 'a', '\t']),
-                // Short delay for prompt to be displayed before responding to it.
-                delay(100).then(() => terminalInput(shell, [rejectChar]))
-              ]);
+
+              terminalInput(shell, ['l', 's', ' ', 'a', '\t']);
+              await output.contains('possibilities (y or n)?');
+              await terminalInput(shell, [rejectChar]);
               return output.text;
             },
             { stdinOption, initialFiles, rejectChar }

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -772,8 +772,7 @@ test.describe('Shell', () => {
       expect(lines.at(-1)).toMatch(/ls a$/);
     });
 
-    //const stdinOptions = ['sab', 'sw'];
-    const stdinOptions = ['sw'];
+    const stdinOptions = ['sab', 'sw'];
     stdinOptions.forEach(stdinOption => {
       test(`check prompt displayed and accepted using y via ${stdinOption}`, async ({ page }) => {
         const output = await page.evaluate(

--- a/test/serve/output_setup.ts
+++ b/test/serve/output_setup.ts
@@ -1,4 +1,5 @@
 import type { IOutputCallback } from '@jupyterlite/cockle';
+import { PromiseDelegate } from '@lumino/coreutils';
 
 /**
  * Provides outputCallback to mock a terminal.
@@ -11,11 +12,24 @@ export class MockTerminalOutput {
   callback: IOutputCallback = (output: string) => {
     if (this._started) {
       this._text = this._text + output;
+      if (this._containsPromise !== undefined && this._text.includes(this._containsText)) {
+        this._containsPromise.resolve(void 0);
+      }
     }
   };
 
   clear() {
     this._text = '';
+  }
+
+  // Return a promise which resolves when the output contains the specified text.
+  async contains(text: string): Promise<void> {
+    if (this._containsPromise !== undefined) {
+      this._containsPromise.reject(void 0);
+    }
+    this._containsPromise = new PromiseDelegate<void>();
+    this._containsText = text;
+    return this._containsPromise.promise;
   }
 
   start() {
@@ -32,6 +46,8 @@ export class MockTerminalOutput {
     return ret;
   }
 
+  private _containsPromise?: PromiseDelegate<void>;
+  private _containsText = '';
   private _started: boolean;
   private _text: string = '';
 }


### PR DESCRIPTION
If the are too many options to display when using tab completion, display a `yes/no` prompt to display all or none of them:

<img width="1065" alt="Screenshot 2025-07-07 at 16 16 00" src="https://github.com/user-attachments/assets/5ff8418a-b9ec-4c43-b316-a6847ecd758e" />

Too many here means > 99 (arbitrary threshold) or too many to display in the available terminal size. The terminal size can be hacked using `export LINES=<number>` and/or `export COLUMNS=<number>` to manually test this.

'y' is the only input that will cause all options to be displayed, `n`, Ctrl-C and Ctrl-D (ascii 3 and 4) will prevent the options being displayed.

Currently this only works if using the ServiceWorker for synchronous stdin, there is a bug in the SharedArrayBuffer implementation that sometimes causes the confirmation y/n key to be echoed to the next terminal prompt.

Closes #129.