### PR TITLE
Pass command name in IContext rather than as separate argument to run()

### DIFF
--- a/src/builtin/builtin_command.ts
+++ b/src/builtin/builtin_command.ts
@@ -17,10 +17,11 @@ export abstract class BuiltinCommand implements ICommandRunner {
 
   abstract get name(): string;
 
-  run(cmdName: string, context: IContext): Promise<number> {
-    if (cmdName !== this.name) {
+  run(context: IContext): Promise<number> {
+    const { name } = context;
+    if (name !== this.name) {
       // This should not happen.
-      throw new FindCommandError(cmdName);
+      throw new FindCommandError(name);
     }
     return this._run(context);
   }

--- a/src/commands/command_runner.ts
+++ b/src/commands/command_runner.ts
@@ -7,5 +7,5 @@ export interface ICommandRunner {
   get moduleName(): string;
   names(): string[];
   get packageName(): string;
-  run(cmdName: string, context: IContext): Promise<number>;
+  run(context: IContext): Promise<number>;
 }

--- a/src/commands/dynamically_loaded_command_runner.ts
+++ b/src/commands/dynamically_loaded_command_runner.ts
@@ -20,5 +20,5 @@ export abstract class DynamicallyLoadedCommandRunner implements ICommandRunner {
     return this.module.packageName;
   }
 
-  abstract run(cmdName: string, context: IContext): Promise<number>;
+  abstract run(context: IContext): Promise<number>;
 }

--- a/src/commands/external_command_runner.ts
+++ b/src/commands/external_command_runner.ts
@@ -21,15 +21,16 @@ export class ExternalCommandRunner implements ICommandRunner {
     return '';
   }
 
-  async run(cmdName: string, context: IContext): Promise<number> {
-    if (cmdName !== this.name) {
+  async run(context: IContext): Promise<number> {
+    const { name, args, environment, stdin, stdout, stderr } = context;
+
+    if (name !== this.name) {
       // This should not happen.
-      throw new FindCommandError(cmdName);
+      throw new FindCommandError(name);
     }
 
-    const { args, environment, stdin, stdout, stderr } = context;
     const { exitCode, environmentChanges } = await this.callExternalCommand(
-      this.name,
+      name,
       args,
       Object.fromEntries(environment),
       stdin.isTerminal(),
@@ -38,11 +39,11 @@ export class ExternalCommandRunner implements ICommandRunner {
     );
 
     if (environmentChanges !== undefined) {
-      Object.entries(environmentChanges).forEach(([name, value]) => {
-        if (value === undefined) {
-          environment.delete(name);
+      Object.entries(environmentChanges).forEach(([envName, envValue]) => {
+        if (envValue === undefined) {
+          environment.delete(envName);
         } else {
-          environment.set(name, value);
+          environment.set(envName, envValue);
         }
       });
     }

--- a/src/commands/javascript_command_runner.ts
+++ b/src/commands/javascript_command_runner.ts
@@ -9,21 +9,22 @@ export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
     super(module);
   }
 
-  async run(cmdName: string, context: IContext): Promise<number> {
+  async run(context: IContext): Promise<number> {
+    const { name } = context;
     const jsModule = this.module.loader.getJavaScriptModule(this.packageName, this.moduleName);
     if (jsModule === undefined) {
-      throw new FindCommandError(cmdName);
+      throw new FindCommandError(name);
     }
 
     if (!Object.prototype.hasOwnProperty.call(jsModule, 'run')) {
-      throw new LoadCommandError(cmdName);
+      throw new LoadCommandError(name);
     }
 
     // Narrow context passed to JavaScript command so that we don't leak cockle internals.
     const { args, environment, fileSystem, stdout, stderr } = context;
     const stdin = new JavaScriptInput(context.stdin);
     const jsContext: IJavaScriptContext = {
-      name: cmdName,
+      name,
       args,
       environment,
       fileSystem,
@@ -36,7 +37,7 @@ export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
       return await jsModule.run(jsContext);
     } catch (err) {
       console.error(`JavascriptCommandRunner: ${err}`);
-      throw new RunCommandError(cmdName);
+      throw new RunCommandError(name);
     }
   }
 }

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -13,6 +13,7 @@ import { CommandRegistry } from '../commands/command_registry';
  * Full context used to run builtin and WebAssembly commands.
  */
 export interface IContext {
+  name: string;
   args: string[];
   fileSystem: IFileSystem;
   environment: Environment;

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -50,6 +50,7 @@ export class ShellImpl implements IShellWorker {
 
     // Content within which commands are run.
     this._context = {
+      name: '',
       args: [],
       fileSystem: this._fileSystem,
       aliases: new Aliases(),
@@ -644,6 +645,7 @@ export class ShellImpl implements IShellWorker {
     // Set current properties of IContext.
     let args = commandNode.suffix.map(token => token.value);
     args = this._filenameExpansion(args);
+    this._context.name = name;
     this._context.args = args;
     this._context.stdin = input;
     this._context.stdout = output;
@@ -651,12 +653,13 @@ export class ShellImpl implements IShellWorker {
 
     let exitCode = -1;
     try {
-      exitCode = await runner.run(name, this._context);
+      exitCode = await runner.run(this._context);
     } finally {
       error.flush();
       output.flush();
 
       // Reset properties of IContext.
+      this._context.name = '';
       this._context.args = [];
       this._context.stdin = this._dummyInput;
       this._context.stdout = this._dummyOutput;


### PR DESCRIPTION
Move command name to `IContext` rather than passing as a separate arg to command `run` function.