### PR TITLE
Perform tab completion in `Options` classes

### DIFF
--- a/src/builtin/alias_command.ts
+++ b/src/builtin/alias_command.ts
@@ -3,6 +3,7 @@ import { TrailingStringsOption } from './option';
 import { Options } from './options';
 import { IContext } from '../context';
 import { ExitCode } from '../exit_code';
+import { ITabCompleteContext, ITabCompleteResult } from '../tab_complete';
 
 class AliasOptions extends Options {
   trailingStrings = new TrailingStringsOption();
@@ -11,6 +12,10 @@ class AliasOptions extends Options {
 export class AliasCommand extends BuiltinCommand {
   get name(): string {
     return 'alias';
+  }
+
+  async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
+    return await new AliasOptions().tabComplete(context);
   }
 
   protected async _run(context: IContext): Promise<number> {

--- a/src/builtin/cd_command.ts
+++ b/src/builtin/cd_command.ts
@@ -7,7 +7,7 @@ import { ExitCode } from '../exit_code';
 import { ITabCompleteContext, ITabCompleteResult, PathMatch } from '../tab_complete';
 
 class CdOptions extends Options {
-  trailingPaths = new TrailingPathsOption();
+  trailingPaths = new TrailingPathsOption({ pathMatch: PathMatch.Directory });
 }
 
 export class CdCommand extends BuiltinCommand {
@@ -16,7 +16,7 @@ export class CdCommand extends BuiltinCommand {
   }
 
   async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
-    return { pathMatch: PathMatch.Directory };
+    return await new CdOptions().tabComplete(context);
   }
 
   protected async _run(context: IContext): Promise<number> {

--- a/src/builtin/export_command.ts
+++ b/src/builtin/export_command.ts
@@ -3,6 +3,7 @@ import { TrailingStringsOption } from './option';
 import { Options } from './options';
 import { IContext } from '../context';
 import { ExitCode } from '../exit_code';
+import { ITabCompleteContext, ITabCompleteResult } from '../tab_complete';
 
 class ExportOptions extends Options {
   trailingStrings = new TrailingStringsOption();
@@ -11,6 +12,10 @@ class ExportOptions extends Options {
 export class ExportCommand extends BuiltinCommand {
   get name(): string {
     return 'export';
+  }
+
+  async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
+    return await new ExportOptions().tabComplete(context);
   }
 
   protected async _run(context: IContext): Promise<number> {

--- a/src/builtin/history_command.ts
+++ b/src/builtin/history_command.ts
@@ -3,6 +3,7 @@ import { BooleanOption } from './option';
 import { Options } from './options';
 import { IContext } from '../context';
 import { ExitCode } from '../exit_code';
+import { ITabCompleteContext, ITabCompleteResult } from '../tab_complete';
 
 class HistoryOptions extends Options {
   clear = new BooleanOption('c', '', 'clear the history by deleting all of the entries');
@@ -12,6 +13,10 @@ class HistoryOptions extends Options {
 export class HistoryCommand extends BuiltinCommand {
   get name(): string {
     return 'history';
+  }
+
+  async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
+    return await new HistoryOptions().tabComplete(context);
   }
 
   protected async _run(context: IContext): Promise<number> {

--- a/src/builtin/option.ts
+++ b/src/builtin/option.ts
@@ -1,4 +1,5 @@
 import { GeneralError } from '../error_exit_code';
+import { ITabCompleteContext, PathMatch } from '../tab_complete';
 
 export abstract class Option {
   constructor(
@@ -115,9 +116,18 @@ export namespace TrailingStringsOption {
   export interface IOptions {
     min?: number;
     max?: number;
+
+    /**
+     * Function to return possible matches for tab completion.
+     * The token for completion is context.args.at(-1) as it may be an empty string.
+     * The possibles are subsequently filtered using startsWith(token-for-completion).
+     */
+    possibles?: (context: ITabCompleteContext) => string[];
   }
 }
 
 export namespace TrailingPathsOption {
-  export interface IOptions extends TrailingStringsOption.IOptions {}
+  export interface IOptions extends TrailingStringsOption.IOptions {
+    pathMatch?: PathMatch;
+  }
 }

--- a/src/builtin/options.ts
+++ b/src/builtin/options.ts
@@ -1,60 +1,30 @@
 /**
  * A collection of options for a builtin command.
  */
-import { Option, TrailingStringsOption } from './option';
+import { Option, TrailingPathsOption, TrailingStringsOption } from './option';
 import { GeneralError } from '../error_exit_code';
 import { IOutput } from '../io';
+import { ITabCompleteContext, ITabCompleteResult, PathMatch } from '../tab_complete';
 
 export abstract class Options {
   parse(args: string[]): this {
     // Use copy of args to avoid modifying caller's args.
-    let localArgs = args.slice();
-
-    const trailingStrings = this._getStrings();
-    const inTrailingStrings = false;
-
-    const subcommands: { [key: string]: Subcommand } = (this as any).subcommands ?? {};
-    let firstArg = true;
-
-    while (localArgs.length > 0) {
-      const arg = localArgs.shift()!;
-
-      if (firstArg && arg in subcommands) {
-        const subcommand = subcommands[arg];
-        subcommand.set();
-        subcommand.parse(localArgs);
-        break;
-      } else if (arg.startsWith('-') && arg.length > 1) {
-        if (inTrailingStrings) {
-          throw new GeneralError('Cannot have named option after parsing a trailing path');
-        }
-        if (arg.startsWith('--')) {
-          const longName = arg.slice(2);
-          localArgs = this._findByLongName(longName).parse(arg, localArgs);
-        } else {
-          const shortName = arg.slice(1);
-          localArgs = this._findByShortName(shortName).parse(arg, localArgs);
-        }
-      } else if (trailingStrings !== null) {
-        localArgs = trailingStrings.parse(arg, localArgs);
-      } else {
-        throw new GeneralError(`Unrecognised option: '${arg}'`);
-      }
-
-      firstArg = false;
-    }
-
-    if (trailingStrings) {
-      const { min, max } = trailingStrings.options;
-      if (min !== undefined && trailingStrings.length < min) {
-        throw new GeneralError('Insufficient trailing strings options specified');
-      }
-      if (max !== undefined && trailingStrings.length > max) {
-        throw new GeneralError('Too many trailing strings options specified');
-      }
-    }
-
+    this._parseToRun(args.slice());
     return this;
+  }
+
+  async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
+    // Use copy of args to avoid modifying caller's args.
+    const contextWithArgsCopy = {
+      ...context,
+      args: context.args.slice()
+    };
+
+    const result = await this._parseToTabComplete(contextWithArgsCopy);
+    if (result.possibles) {
+      result.possibles = result.possibles.filter(name => name.startsWith(context.args.at(-1)!));
+    }
+    return result;
   }
 
   writeHelp(output: IOutput): void {
@@ -65,26 +35,24 @@ export abstract class Options {
 
   //  private _findByLongName<T extends Options>(longName: string): Option {
   private _findByLongName(longName: string): Option {
-    let v: Option;
-    for (v of Object.values(this)) {
-      if (v.longName === longName) {
-        return v;
-      }
+    const longNameOptions = this._longNameOptions;
+    if (longName in longNameOptions) {
+      return longNameOptions[longName];
+    } else {
+      // Need better error reporting
+      throw new GeneralError(`No such longName option '${longName}'`);
     }
-    // Need better error reporting
-    throw new GeneralError(`No such longName option '${longName}'`);
   }
 
   //  private _findByShortName<T extends Options>(shortName: string): Option {
   private _findByShortName(shortName: string): Option {
-    let v: Option;
-    for (v of Object.values(this)) {
-      if (v.shortName === shortName) {
-        return v;
-      }
+    const shortNameOptions = this._shortNameOptions;
+    if (shortName in shortNameOptions) {
+      return shortNameOptions[shortName];
+    } else {
+      // Need better error reporting
+      throw new GeneralError(`No such shortName option '${shortName}'`);
     }
-    // Need better error reporting
-    throw new GeneralError(`No such shortName option '${shortName}'`);
   }
 
   private _getStrings(): TrailingStringsOption | null {
@@ -117,6 +85,130 @@ export abstract class Options {
         yield `    ${sub.name}${' '.repeat(spaces)}${sub.description}`;
       }
     }
+  }
+
+  private get _longNameOptions(): { [longName: string]: Option } {
+    const options = Object.values(this).filter(
+      opt => opt instanceof Option && 'longName' in opt && opt.longName.length > 0
+    );
+    return Object.fromEntries(options.map(opt => [opt.longName, opt]));
+  }
+
+  /**
+   * Parse arguments to run a command.
+   */
+  private _parseToRun(args: string[]): void {
+    const trailingStrings = this._getStrings();
+    let inTrailingStrings = false;
+
+    const subcommands: { [key: string]: Subcommand } = (this as any).subcommands ?? {};
+    let firstArg = true;
+
+    while (args.length > 0) {
+      const arg = args.shift()!;
+
+      if (firstArg && arg in subcommands) {
+        const subcommand = subcommands[arg];
+        subcommand.set();
+        subcommand.parse(args);
+        break;
+      } else if (arg.startsWith('-') && arg.length > 1) {
+        if (inTrailingStrings) {
+          throw new GeneralError('Cannot have named option after parsing a trailing path');
+        }
+        if (arg.startsWith('--')) {
+          const longName = arg.slice(2);
+          args = this._findByLongName(longName).parse(arg, args);
+        } else {
+          const shortName = arg.slice(1);
+          args = this._findByShortName(shortName).parse(arg, args);
+        }
+      } else if (trailingStrings !== null) {
+        inTrailingStrings = true;
+        args = trailingStrings.parse(arg, args);
+      } else {
+        throw new GeneralError(`Unrecognised option: '${arg}'`);
+      }
+
+      firstArg = false;
+    }
+
+    if (trailingStrings) {
+      const { min, max } = trailingStrings.options;
+      if (min !== undefined && trailingStrings.length < min) {
+        throw new GeneralError('Insufficient trailing strings options specified');
+      }
+      if (max !== undefined && trailingStrings.length > max) {
+        throw new GeneralError('Too many trailing strings options specified');
+      }
+    }
+  }
+
+  /**
+   * Parse arguments to tab complete the final one.
+   */
+  private async _parseToTabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
+    const { args } = context;
+    const trailingStrings = this._getStrings();
+    const subcommands: { [key: string]: Subcommand } = (this as any).subcommands ?? {};
+    let firstArg = true;
+
+    while (args.length > 0) {
+      const arg = args.shift()!;
+      const lastArg = args.length === 0;
+
+      if (firstArg && subcommands) {
+        if (lastArg) {
+          const possibles = Object.keys(subcommands).filter(name => name.startsWith(arg));
+          if (possibles.length > 0) {
+            return { possibles };
+          }
+        }
+
+        if (arg in subcommands) {
+          // Exact match, parse it.
+          const subcommand = subcommands[arg];
+          subcommand.set();
+          return subcommand._parseToTabComplete({ ...context, args: [arg, ...args] });
+        }
+      }
+
+      if (arg.startsWith('-')) {
+        if (lastArg) {
+          const longNamePossibles = Object.keys(this._longNameOptions).map(x => '--' + x);
+          if (arg.startsWith('--')) {
+            return { possibles: longNamePossibles };
+          } else {
+            const shortNamePossibles = Object.keys(this._shortNameOptions).map(x => '-' + x);
+            return { possibles: shortNamePossibles.concat(longNamePossibles) };
+          }
+        } else {
+          // Not final arg so parse as usual.
+          // In fact just ignore it, which is no good if it wants to consume further args.
+        }
+      } else if (trailingStrings !== null) {
+        // Jump straight to last argument as the preceding ones are independent of it.
+        if (trailingStrings instanceof TrailingPathsOption) {
+          return { pathMatch: trailingStrings.options.pathMatch ?? PathMatch.Any };
+        } else {
+          const possiblesCallback = trailingStrings.options.possibles;
+          if (possiblesCallback !== undefined) {
+            return { possibles: possiblesCallback({ ...context, args: [arg, ...args] }) };
+          }
+        }
+      }
+
+      firstArg = false;
+    }
+
+    return {};
+  }
+
+  private get _shortNameOptions(): { [shortName: string]: Option } {
+    const options = Object.values(this).filter(
+      opt => opt instanceof Option && 'shortName' in opt && opt.shortName.length > 0
+    );
+    return Object.fromEntries(options.map(opt => [opt.shortName, opt]));
   }
 }
 

--- a/src/tab_complete.ts
+++ b/src/tab_complete.ts
@@ -1,3 +1,6 @@
+import { CommandRegistry } from './commands/command_registry';
+import { IStdinContext } from './context/stdin_context';
+
 /**
  * Context within which to call ICommandRunner.tabComplete().
  */
@@ -6,6 +9,9 @@ export interface ITabCompleteContext {
    * Command arguments. The last argument is the one to tab complete and may be an empty string.
    */
   args: string[];
+
+  commandRegistry: CommandRegistry;
+  stdinContext: IStdinContext;
 }
 
 /**

--- a/src/tab_completer.ts
+++ b/src/tab_completer.ts
@@ -34,7 +34,8 @@ export class TabCompleter {
         if (!tokenToComplete) {
           args.push('');
         }
-        tabCompleteResult = await runner.tabComplete({ args });
+        const { commandRegistry, stdinContext } = this.context;
+        tabCompleteResult = await runner.tabComplete({ args, commandRegistry, stdinContext });
       }
     }
 

--- a/test/integration-tests/tab_completer.test.ts
+++ b/test/integration-tests/tab_completer.test.ts
@@ -250,5 +250,73 @@ test.describe('TabCompleter', () => {
         /^cockle-config x$/
       );
     });
+
+    test('should match stdin subcommand string options', async ({ page }) => {
+      expect(await shellInputsSimple(page, ['c', 'o', '\t ', 's', 't', '\t', '\t'])).toMatch(
+        /^cockle-config stdin s$/
+      );
+
+      expect(await shellInputsSimple(page, ['c', 'o', '\t ', 's', 't', '\t', 's', '\t'])).toMatch(
+        /^cockle-config stdin s\r\nsab {2}sw\r\n/
+      );
+
+      expect(
+        await shellInputsSimple(page, ['c', 'o', '\t ', 's', 't', '\t', 's', 'w', '\t'])
+      ).toMatch(/^cockle-config stdin sw $/);
+
+      expect(
+        await shellInputsSimple(page, ['c', 'o', '\t ', 's', 't', '\t', 's', 'a', '\t'])
+      ).toMatch(/^cockle-config stdin sab $/);
+    });
+
+    test('should match command subcommand string options', async ({ page }) => {
+      expect(await shellInputsSimple(page, ['c', 'o', '\t ', 'c', '\t', 'j', '\t'])).toMatch(
+        /^cockle-config command j\r\njoin {5}js-test\r\n/
+      );
+
+      expect(await shellInputsSimple(page, ['c', 'o', '\t ', 'c', '\t', 'j', 's', '\t'])).toMatch(
+        /^cockle-config command js-test $/
+      );
+    });
+
+    test('should match module subcommand string options', async ({ page }) => {
+      expect(await shellInputsSimple(page, ['c', 'o', '\t ', 'm', '\t', 'w', '\t'])).toMatch(
+        /^cockle-config module wasm-test $/
+      );
+    });
+
+    test('should match package subcommand string options', async ({ page }) => {
+      expect(await shellInputsSimple(page, ['c', 'o', '\t ', 'p', '\t', 'u', '\t'])).toMatch(
+        /^cockle-config package util-$/
+      );
+
+      expect(
+        await shellInputsSimple(page, ['c', 'o', '\t ', 'p', '\t', 'u', '\t', 'w', '\t'])
+      ).toMatch(/^cockle-config package util-wasm $/);
+    });
+
+    test('should show -- options', async ({ page }) => {
+      expect(await shellInputsSimple(page, ['c', 'o', '\t ', '-', '-', '\t'])).toMatch(
+        /^cockle-config --\r\n--help {5}--version\r\n/
+      );
+    });
+
+    test('should match a -- option', async ({ page }) => {
+      expect(await shellInputsSimple(page, ['c', 'o', '\t ', '-', '-', 'v', '\t'])).toMatch(
+        /^cockle-config --version $/
+      );
+    });
+
+    test('should show - options', async ({ page }) => {
+      expect(await shellInputsSimple(page, ['c', 'o', '\t ', '-', '\t'])).toMatch(
+        /^cockle-config -\r\n--help {5}--version {2}-h {9}-v\r\n/
+      );
+    });
+
+    test('should match a - option', async ({ page }) => {
+      expect(await shellInputsSimple(page, ['c', 'o', '\t ', '-', 'h', '\t'])).toMatch(
+        /^cockle-config -h $/
+      );
+    });
   });
 });


### PR DESCRIPTION
This moves the handling of tab completion for built-in commands to the `Options` classes, so that there is a generic solution based on the command options rather than each command having to implement its own logic. Here is an example of tab-completing a `cockle-config package` subcommand with a particular package name:

https://github.com/user-attachments/assets/27178501-2ff0-484e-884c-3d5ab223abbe

It also includes tab completion of `-x` and `--whatever` options, and of directories (not files) for `cd`.

To use this, a builtin command should implement a `tabComplete` function like:
```ts
async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
  return await new CockleConfigOptions().tabComplete(context);
}
```

Some `Option` classes accept callback functions to return the list of possible matches, this is how the various `cockle-config` subcommands (`command`, `module`, `package` and `stdin`) work.

This is not fully complete, and the implementation in `Options.tabComplete` is a little clumsy, but it serves to try it all out and test it.

The javascript and external commands could also use this system, but that will be in a separate PR.