### PR TITLE
List all playwright tests, even if they all pass

### DIFF
--- a/test/integration-tests/playwright.config.ts
+++ b/test/integration-tests/playwright.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './integration-tests',
+  testDir: './',
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: [['html', { open: 'never' }]],
+  reporter: [['list']],
   use: {
     baseURL: 'http://localhost:8000',
     trace: 'on-first-retry'

--- a/test/package.json
+++ b/test/package.json
@@ -12,9 +12,8 @@
         "postbuild": "node node_modules/@jupyterlite/cockle/lib/tools/prepare_wasm.js --copy assets",
         "serve": "rspack serve",
         "test": "npm run test:unit && npm run test:integration",
-        "test:integration": "playwright test",
-        "test:integration:ui": "playwright test --ui",
-        "test:integration:report": "playwright show-report",
+        "test:integration": "cd integration-tests && playwright test",
+        "test:integration:ui": "cd integration-tests && playwright test --ui",
         "test:unit": "jest"
     },
     "devDependencies": {


### PR DESCRIPTION
Trying out listing all playwright tests that are run, even if they all pass. It works for me locally although the output is bit busy, let's see what it looks like in CI.