### PR TITLE
Pass optional dark/light mode boolean to `IShell.themeChange`

### DIFF
--- a/demo/assets/index.html
+++ b/demo/assets/index.html
@@ -9,8 +9,10 @@
   <div id="theme">
     <label for="theme-select">Theme:</label>
     <select name="theme" id="theme-select">
-      <option value="white-black">White on black</option>
-      <option value="black-white">Black on white</option>
+      <option value="white-black-dark">White on black (known dark mode)</option>
+      <option value="black-white-light">Black on white (known light mode)</option>
+      <option value="white-black-unknown">White on black (check if dark/light mode)</option>
+      <option value="black-white-unknown">Black on white (check if dark/light mode)</option>
     </select>
   </div>
 </body>

--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -78,14 +78,16 @@ export class Demo {
     this._term!.write(text);
   }
 
-  setTheme(foreground: string, background: string): void {
+  setTheme(foreground: string, background: string, mode: string): void {
     const theme = {
       ...this._term.options,
       foreground,
       background
     };
     this._term.options.theme = theme;
-    this._shell.themeChange();
+
+    const isDark = mode === 'light' ? false : mode === 'dark' ? true : undefined;
+    this._shell.themeChange(isDark);
   }
 
   private _targetDiv: HTMLElement;

--- a/demo/serve/index.ts
+++ b/demo/serve/index.ts
@@ -12,8 +12,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const themeSelect = document.getElementById('theme-select') as HTMLSelectElement;
   themeSelect?.addEventListener('change', (event: any) => {
-    const [foreground, background] = themeSelect.value.split('-');
-    demo.setTheme(foreground, background);
+    const [foreground, background, mode] = themeSelect.value.split('-');
+    demo.setTheme(foreground, background, mode);
   });
 
   await demo.start();

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -221,8 +221,8 @@ export abstract class BaseShell implements IShell {
     await this._remote!.start();
   }
 
-  async themeChange(): Promise<void> {
-    await this._remote?.themeChange();
+  async themeChange(isDark?: boolean): Promise<void> {
+    await this._remote?.themeChange(isDark);
   }
 
   private async _initialize(): Promise<void> {

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -125,8 +125,8 @@ export abstract class BaseShellWorker implements IShellWorker {
     }
   }
 
-  async themeChange(): Promise<void> {
-    await this._shellImpl?.themeChange();
+  async themeChange(isDark?: boolean): Promise<void> {
+    await this._shellImpl?.themeChange(isDark);
   }
 
   private _setWorkerIO(shortName: string): void {

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -9,7 +9,13 @@ export interface IShell extends IObservableDisposable {
   setSize(rows: number, columns: number): Promise<void>;
   shellId: string;
   start(): Promise<void>;
-  themeChange(): void;
+
+  /**
+   * Call just after theme change so the shell knows whether it is using dark or light mode.
+   * If the dark/light mode is not specified then the shell will ask the terminal what the
+   * background color is to determine it.
+   */
+  themeChange(isDark?: boolean): void;
 }
 
 export namespace IShell {

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -60,7 +60,7 @@ export interface IShellWorker extends IShellCommon {
     terminateCallback: IShellWorker.IProxyTerminateCallback
   ): void;
 
-  themeChange(): Promise<void>;
+  themeChange(isDark?: boolean): Promise<void>;
 }
 
 export namespace IShellWorker {

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -226,7 +226,9 @@ export class ShellImpl implements IShellWorker {
     this._options.terminateCallback();
   }
 
-  async themeChange(): Promise<void> {
+  async themeChange(isDark?: boolean): Promise<void> {
+    this._requestedDarkMode = isDark;
+
     if (this._themeStatus !== ThemeStatus.Ok) {
       // Already pending or changing, don't need to repeat.
       return;
@@ -396,6 +398,13 @@ export class ShellImpl implements IShellWorker {
       return;
     }
 
+    if (this._requestedDarkMode !== undefined) {
+      // Early return as we already know if dark/light mode.
+      this._setDarkMode(this._requestedDarkMode);
+      return;
+    }
+
+    // Need to determine if dark or light mode.
     this._themeStatus = ThemeStatus.Changing;
 
     await this._options.enableBufferedStdinCallback(true);
@@ -697,6 +706,7 @@ export class ShellImpl implements IShellWorker {
 
   private _commandLine: ICommandLine = { text: '', cursorIndex: 0 };
   private _darkMode?: boolean;
+  private _requestedDarkMode?: boolean;
   private _isRunning = false;
   private _themeStatus = ThemeStatus.PendingChange;
 


### PR DESCRIPTION
Sometimes in JupyterLab/Lite if the theme is changed it is known whether the theme is light or dark mode. To support this, adding an optional boolean argument to `IShell.themeChange`. If the theme mode is known then the `Shell` assumes that is correct. If the theme is not known (argument is `undefined`) then it checks the background color by asking the terminal as before.