### PR TITLE
Rename `IExternalContext` as `IExternalRunContext`

### DIFF
--- a/demo/serve/external_command.ts
+++ b/demo/serve/external_command.ts
@@ -1,6 +1,6 @@
-import { ansi, ExitCode, IExternalContext } from '@jupyterlite/cockle';
+import { ansi, ExitCode, IExternalRunContext } from '@jupyterlite/cockle';
 
-export async function externalCommand(context: IExternalContext): Promise<number> {
+export async function externalCommand(context: IExternalRunContext): Promise<number> {
   const { args } = context;
 
   if (args.includes('environment')) {

--- a/demo/serve/external_command_tab.ts
+++ b/demo/serve/external_command_tab.ts
@@ -5,7 +5,7 @@ import {
   ansi,
   CommandArguments,
   ExitCode,
-  IExternalContext,
+  IExternalRunContext,
   IExternalTabCompleteContext,
   IExternalTabCompleteResult,
   PositionalArguments
@@ -31,7 +31,7 @@ export async function externalTabComplete(
   return new TestArguments().tabComplete(context);
 }
 
-export async function externalRun(context: IExternalContext): Promise<number> {
+export async function externalRun(context: IExternalRunContext): Promise<number> {
   const args = new TestArguments().parse(context.args).positional.strings;
 
   if (args.includes('environment')) {

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -9,7 +9,7 @@ import {
   ServiceWorkerMainIO,
   SharedArrayBufferMainIO
 } from './buffered_io';
-import { IExternalContext } from './context';
+import { IExternalRunContext } from './context';
 import { IShell } from './defs';
 import { IRemoteShell } from './defs_internal';
 import { DownloadTracker } from './download_tracker';
@@ -74,7 +74,7 @@ export abstract class BaseShell implements IShell {
       stderrSupportsAnsiEscapes
     );
 
-    const context: IExternalContext = {
+    const context: IExternalRunContext = {
       name,
       args,
       environment: externalEnvironment,

--- a/src/context/external_context.ts
+++ b/src/context/external_context.ts
@@ -9,7 +9,7 @@ import { IExternalInput, IExternalOutput } from '../io';
 /**
  * Context used to run an external command.
  */
-export interface IExternalContext {
+export interface IExternalRunContext {
   name: string;
   args: string[];
   environment: ExternalEnvironment;

--- a/src/external_command.ts
+++ b/src/external_command.ts
@@ -1,11 +1,11 @@
-import { IExternalContext, IExternalTabCompleteContext } from './context';
+import { IExternalRunContext, IExternalTabCompleteContext } from './context';
 import { ITabCompleteResult } from './tab_complete';
 
 /**
  * Run an external command from the Shell.
  */
 export interface IExternalCommand {
-  (context: IExternalContext): Promise<number>;
+  (context: IExternalRunContext): Promise<number>;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export { BaseShellWorker } from './base_shell_worker';
 export { IHandleStdin, IStdinReply, IStdinRequest } from './buffered_io';
 export { IOutputCallback } from './callback';
 export {
-  IExternalContext,
+  IExternalRunContext,
   IExternalTabCompleteContext,
   IJavaScriptRunContext,
   IJavaScriptTabCompleteContext

--- a/test/serve/external_command.ts
+++ b/test/serve/external_command.ts
@@ -1,8 +1,8 @@
-import { ansi, ExitCode, IExternalContext } from '@jupyterlite/cockle';
+import { ansi, ExitCode, IExternalRunContext } from '@jupyterlite/cockle';
 
 // External command with different bahaviour depending on supplied args, to test
 // external command functionality.
-export async function externalCommand(context: IExternalContext): Promise<number> {
+export async function externalCommand(context: IExternalRunContext): Promise<number> {
   const { args } = context;
 
   if (args.includes('environment')) {

--- a/test/serve/external_command_tab.ts
+++ b/test/serve/external_command_tab.ts
@@ -5,7 +5,7 @@ import {
   ansi,
   CommandArguments,
   ExitCode,
-  IExternalContext,
+  IExternalRunContext,
   IExternalTabCompleteContext,
   IExternalTabCompleteResult,
   PositionalArguments
@@ -31,7 +31,7 @@ export async function externalTabComplete(
   return new TestArguments().tabComplete(context);
 }
 
-export async function externalRun(context: IExternalContext): Promise<number> {
+export async function externalRun(context: IExternalRunContext): Promise<number> {
   const args = new TestArguments().parse(context.args).positional.strings;
 
   if (args.includes('environment')) {


### PR DESCRIPTION
Rename `IExternalContext` as `IExternalRunContext` inline with other `*RunContext` interfaces. This will be a breaking change for downstream libraries using external commands.