### PR TITLE
Adding `--help` command for builtin command

### DIFF
--- a/src/builtin/alias_command.ts
+++ b/src/builtin/alias_command.ts
@@ -14,6 +14,21 @@ export class AliasCommand extends BuiltinCommand {
     return 'alias';
   }
 
+  get description(): string {
+    return 'Define or display aliases for commands.';
+  }
+
+  help(): string {
+    return `Usage: alias [name='value']...
+  
+  Define or display aliases for commands.
+  
+  Examples:
+    alias ll='ls -l'
+    alias          # List all aliases
+    alias ll       # Show the value of alias 'll'`;
+  }
+
   async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
     return await new AliasArguments().tabComplete(context);
   }

--- a/src/builtin/bool_commands.ts
+++ b/src/builtin/bool_commands.ts
@@ -7,6 +7,16 @@ export class TrueCommand extends BuiltinCommand {
     return 'true';
   }
 
+  get description(): string {
+    return 'Exit with a status code of 0 (success).';
+  }
+
+  help(): string {
+    return `Usage: true
+  
+  Exit with a status code of 0 (success).`;
+  }
+
   protected async _run(_: IRunContext): Promise<number> {
     return ExitCode.SUCCESS;
   }
@@ -15,6 +25,16 @@ export class TrueCommand extends BuiltinCommand {
 export class FalseCommand extends BuiltinCommand {
   get name(): string {
     return 'false';
+  }
+
+  get description(): string {
+    return 'Exit with a status code of 1 (failure).';
+  }
+
+  help(): string {
+    return `Usage: false
+  
+  Exit with a status code of 1 (failure).`;
   }
 
   protected async _run(_: IRunContext): Promise<number> {

--- a/src/builtin/builtin_command.ts
+++ b/src/builtin/builtin_command.ts
@@ -17,6 +17,11 @@ export abstract class BuiltinCommand implements ICommandRunner {
 
   abstract get name(): string;
 
+  abstract get description(): string;
+
+  help(): string {
+    return `Usage: ${this.name}\n\n${this.description}`;
+  }
   run(context: IRunContext): Promise<number> {
     const { name } = context;
     if (name !== this.name) {

--- a/src/builtin/cd_command.ts
+++ b/src/builtin/cd_command.ts
@@ -15,6 +15,16 @@ export class CdCommand extends BuiltinCommand {
     return 'cd';
   }
 
+  get description(): string {
+    return 'Change the current working directory.';
+  }
+
+  help(): string {
+    return `Options:
+    [path]   The target directory to change into.
+             If omitted, defaults to the home directory.`;
+  }
+
   async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
     return await new CdArguments().tabComplete(context);
   }

--- a/src/builtin/clear_command.ts
+++ b/src/builtin/clear_command.ts
@@ -8,6 +8,16 @@ export class ClearCommand extends BuiltinCommand {
     return 'clear';
   }
 
+  get description(): string {
+    return 'Clear the terminal screen.';
+  }
+
+  help(): string {
+    return `Usage: clear
+  
+  Clear the terminal screen.`;
+  }
+
   protected async _run(context: IRunContext): Promise<number> {
     const { stdout } = context;
     if (stdout.supportsAnsiEscapes()) {

--- a/src/builtin/cockle_config_command.ts
+++ b/src/builtin/cockle_config_command.ts
@@ -54,6 +54,20 @@ export class CockleConfigCommand extends BuiltinCommand {
     return 'cockle-config';
   }
 
+  get description(): string {
+    return 'Configure or view Cockle shell settings.';
+  }
+
+  help(): string {
+    return `Usage: cockle-config [key] [value]
+  
+  View or set configuration options for the Cockle shell.
+  
+  Examples:
+    cockle-config promptColor red
+    cockle-config                # Show current configuration`;
+  }
+
   async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
     return await new CockleConfigArguments().tabComplete(context);
   }

--- a/src/builtin/exit_command.ts
+++ b/src/builtin/exit_command.ts
@@ -7,6 +7,20 @@ export class ExitCommand extends BuiltinCommand {
     return 'exit';
   }
 
+  get description(): string {
+    return 'Exit the shell.';
+  }
+
+  help(): string {
+    return `Usage: exit [status]
+  
+  Exit the shell with an optional status code. Defaults to 0.
+  
+  Examples:
+    exit
+    exit 1`;
+  }
+
   protected async _run(context: IRunContext): Promise<number> {
     const { stdout, terminate } = context;
 

--- a/src/builtin/export_command.ts
+++ b/src/builtin/export_command.ts
@@ -14,6 +14,20 @@ export class ExportCommand extends BuiltinCommand {
     return 'export';
   }
 
+  get description(): string {
+    return 'Set environment variables.';
+  }
+
+  help(): string {
+    return `Usage: export NAME=VALUE
+  
+  Set environment variables.
+  
+  Examples:
+    export PATH=/usr/bin
+    export EDITOR=vim`;
+  }
+
   async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
     return await new ExportArguments().tabComplete(context);
   }

--- a/src/builtin/help_command.ts
+++ b/src/builtin/help_command.ts
@@ -1,0 +1,50 @@
+import { BuiltinCommand } from './builtin_command';
+import { IRunContext } from '../context';
+import { ExitCode } from '../exit_code';
+
+export class HelpCommand extends BuiltinCommand {
+  constructor(private readonly builtins: BuiltinCommand[]) {
+    super();
+  }
+
+  get name(): string {
+    return '--help';
+  }
+
+  get description(): string {
+    return 'Show general or command-specific help information.';
+  }
+
+  protected async _run(context: IRunContext): Promise<number> {
+    const args = context.args;
+
+    if (args.length > 0) {
+      const cmdName = args[0];
+      const command = this.builtins.find(cmd => cmd.name === cmdName);
+
+      if (!command) {
+        context.stdout.write(`Unknown command: ${cmdName}\n`);
+        return ExitCode.GENERAL_ERROR;
+      }
+
+      // Use command's custom help() if available and non-empty
+      const helpText = typeof command.help === 'function' ? command.help()?.trim() : '';
+
+      if (helpText) {
+        context.stdout.write(`${helpText}\n`);
+      } else {
+        context.stdout.write(`Usage: ${command.name} [options]\n`);
+        context.stdout.write(`${command.description}\n`);
+      }
+
+      return ExitCode.SUCCESS;
+    }
+
+    context.stdout.write('\nAvailable built-in commands:\n\n');
+    for (const builtin of this.builtins) {
+      context.stdout.write(`  ${builtin.name.padEnd(15)}${builtin.description}\n`);
+    }
+    context.stdout.write('\nUse "--help <command>" to get more information.\n');
+    return ExitCode.SUCCESS;
+  }
+}

--- a/src/builtin/history_command.ts
+++ b/src/builtin/history_command.ts
@@ -15,6 +15,16 @@ export class HistoryCommand extends BuiltinCommand {
     return 'history';
   }
 
+  get description(): string {
+    return 'Display previously entered commands.';
+  }
+
+  help(): string {
+    return `Usage: history
+  
+  Display a list of previously entered commands.`;
+  }
+
   async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
     return await new HistoryArguments().tabComplete(context);
   }

--- a/src/builtin/index.ts
+++ b/src/builtin/index.ts
@@ -10,3 +10,5 @@ export * from './exit_command';
 export * from './export_command';
 export * from './history_command';
 export * from './which_command';
+export * from './help_command';
+export * from './register_builtin_commands';

--- a/src/builtin/register_builtin_commands.ts
+++ b/src/builtin/register_builtin_commands.ts
@@ -1,0 +1,23 @@
+import { CommandRegistry } from '../commands/command_registry';
+import * as AllBuiltinCommands from './index';
+
+export function registerBuiltins(registry: CommandRegistry): void {
+  const builtins = [
+    new AllBuiltinCommands.AliasCommand(),
+    new AllBuiltinCommands.TrueCommand(),
+    new AllBuiltinCommands.FalseCommand(),
+    new AllBuiltinCommands.CockleConfigCommand(),
+    new AllBuiltinCommands.ExitCommand(),
+    new AllBuiltinCommands.ExportCommand(),
+    new AllBuiltinCommands.HistoryCommand(),
+    new AllBuiltinCommands.WhichCommand(),
+    new AllBuiltinCommands.CdCommand(),
+    new AllBuiltinCommands.ClearCommand()
+  ];
+
+  const helpCommand = new AllBuiltinCommands.HelpCommand(builtins);
+
+  for (const cmd of [...builtins, helpCommand]) {
+    registry.registerCommand(cmd);
+  }
+}

--- a/src/builtin/which_command.ts
+++ b/src/builtin/which_command.ts
@@ -8,6 +8,20 @@ export class WhichCommand extends BuiltinCommand {
     return 'which';
   }
 
+  get description(): string {
+    return 'Show the location of executables or built-in commands.';
+  }
+
+  help(): string {
+    return `Usage: which <command>
+  
+  Show the location of executables or built-in commands.
+  
+  Examples:
+    which ls
+    which cd`;
+  }
+
   async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
     const possibles = context.commandRegistry?.allCommands();
     return { possibles };

--- a/src/commands/command_registry.ts
+++ b/src/commands/command_registry.ts
@@ -82,6 +82,10 @@ export class CommandRegistry {
     );
   }
 
+  registerCommand(command: ICommandRunner) {
+    this._register(command);
+  }
+
   /**
    * Register a command runner under all of its names.
    */

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -27,6 +27,7 @@ import { CommandPackage } from './commands/command_package';
 import { CommandRegistry } from './commands/command_registry';
 import { TabCompleter } from './tab_completer';
 import { joinURL } from './utils';
+import { registerBuiltins } from './builtin/register_builtin_commands';
 
 /**
  * Shell implementation.
@@ -48,16 +49,19 @@ export class ShellImpl implements IShellWorker {
       mountpoint: options.mountpoint ?? '/drive'
     };
 
+    const registry = new CommandRegistry(
+      options.callExternalCommand,
+      options.callExternalTabComplete
+    );
+    registerBuiltins(registry);
+
     // Content within which commands are run.
     this._runContext = {
       name: '',
       args: [],
       fileSystem: this._fileSystem,
       aliases: new Aliases(),
-      commandRegistry: new CommandRegistry(
-        options.callExternalCommand,
-        options.callExternalTabComplete
-      ),
+      commandRegistry: registry,
       environment: new Environment(options.color),
       history: new History(),
       terminate: this.terminate.bind(this),


### PR DESCRIPTION

Added a `--help` command that lists all available built-in commands with a one-line description, helping users understand what commands the terminal provides and what each command does.

https://github.com/user-attachments/assets/3a1987ca-1e50-4660-b8a7-52eae862e6e5

Closes #114 