### PR TITLE
Fix display of help for some builtin commands

### DIFF
--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -56,17 +56,16 @@ export abstract class CommandArguments {
 
   private *_help(): Generator<string> {
     // Dynamically create help text from arguments.
-    for (const [key, arg] of Object.entries(this)) {
-      if (key === 'subcommands') {
-        break;
+    for (const arg of Object.values(this)) {
+      if (arg instanceof Argument) {
+        const name = arg.prefixedName;
+        const spaces = Math.max(1, 12 - name.length);
+        yield `    ${name}${' '.repeat(spaces)}${arg.description}`;
       }
-      const name = arg.prefixedName;
-      const spaces = Math.max(1, 12 - name.length);
-      yield `    ${name}${' '.repeat(spaces)}${arg.description}`;
     }
 
-    if ('subcommands' in this) {
-      const subcommands = this['subcommands'] as object;
+    const { subcommands } = this;
+    if (subcommands !== undefined) {
       yield '';
       yield 'subcommands:';
       for (const sub of Object.values(subcommands)) {

--- a/src/builtin/history_command.ts
+++ b/src/builtin/history_command.ts
@@ -7,7 +7,7 @@ import { ITabCompleteResult } from '../tab_complete';
 
 class HistoryArguments extends CommandArguments {
   clear = new BooleanArgument('c', '', 'clear the history by deleting all of the entries');
-  help = new BooleanArgument('', 'help', 'display this help and exit');
+  help = new BooleanArgument('h', 'help', 'display this help and exit');
 }
 
 export class HistoryCommand extends BuiltinCommand {

--- a/test/integration-tests/command/cockle-config-command.test.ts
+++ b/test/integration-tests/command/cockle-config-command.test.ts
@@ -2,9 +2,23 @@ import { expect } from '@playwright/test';
 import { shellLineSimple, test } from '../utils';
 
 test.describe('cockle-config command', () => {
-  test('should show version', async ({ page }) => {
-    const output = await shellLineSimple(page, 'cockle-config -v');
-    expect(output).toMatch(/^cockle-config -v\r\ncockle \S+\r\n/);
+  ['-v', '--version'].forEach(option => {
+    test(`should show version using ${option}`, async ({ page }) => {
+      const output = await shellLineSimple(page, `cockle-config ${option}`);
+      expect(output).toMatch(/\r\ncockle \S+\r\n/);
+    });
+  });
+
+  ['-h', '--help'].forEach(option => {
+    test(`should show help using ${option}`, async ({ page }) => {
+      const output = await shellLineSimple(page, `cockle-config ${option}`);
+      // Match a few lines.
+      expect(output).toMatch(/\r\n\s*-h.*display this help and exit\r\n/);
+      expect(output).toMatch(/\r\n\s*-v.*show cockle version\r\n/);
+      expect(output).toMatch(/\r\nsubcommands:\r\n/);
+      expect(output).toMatch(/\r\n\s+module\s+show module information\r\n/);
+      expect(output).toMatch(/\r\n\s+stdin\s+synchronous stdin configuration\r\n/);
+    });
   });
 
   test('should run stdin subcommand', async ({ page }) => {


### PR DESCRIPTION
In PR #231 I broke the display of help for the builtin commands that currently support it (`cockle-config` and `history`). This fixes it and makes it more robust, and adds a new test to explicitly check it to avoid breaking it again in future.