### PR TITLE
Use Arguments.tabComplete for builtin commands

### DIFF
--- a/src/builtin/bool_commands.ts
+++ b/src/builtin/bool_commands.ts
@@ -1,8 +1,9 @@
 import { BuiltinCommand } from './builtin_command';
 import { CommandArguments } from '../arguments';
 import { BooleanArgument } from '../argument';
-import { IRunContext } from '../context';
+import { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
+import { ITabCompleteResult } from '../tab_complete';
 
 class BoolStubArguments extends CommandArguments {
   help = new BooleanArgument('h', 'help', 'display this help and exit');
@@ -21,6 +22,10 @@ export class TrueCommand extends BuiltinCommand {
     return 'true';
   }
 
+  async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
+    return await new TrueArguments().tabComplete(context);
+  }
+
   protected async _run(context: IRunContext): Promise<number> {
     const args = new TrueArguments().parse(context.args);
     if (args.help.isSet) {
@@ -34,6 +39,10 @@ export class TrueCommand extends BuiltinCommand {
 export class FalseCommand extends BuiltinCommand {
   get name(): string {
     return 'false';
+  }
+
+  async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
+    return await new FalseArguments().tabComplete(context);
   }
 
   protected async _run(context: IRunContext): Promise<number> {

--- a/src/builtin/clear_command.ts
+++ b/src/builtin/clear_command.ts
@@ -2,8 +2,9 @@ import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument } from '../argument';
 import { CommandArguments } from '../arguments';
 import { ansi } from '../ansi';
-import { IRunContext } from '../context';
+import { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
+import { ITabCompleteResult } from '../tab_complete';
 
 class ClearArguments extends CommandArguments {
   description = 'Clear the terminal screen if ANSI escapes are supported.';
@@ -13,6 +14,10 @@ class ClearArguments extends CommandArguments {
 export class ClearCommand extends BuiltinCommand {
   get name(): string {
     return 'clear';
+  }
+
+  async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
+    return await new ClearArguments().tabComplete(context);
   }
 
   protected async _run(context: IRunContext): Promise<number> {

--- a/src/builtin/exit_command.ts
+++ b/src/builtin/exit_command.ts
@@ -1,20 +1,22 @@
 import { BuiltinCommand } from './builtin_command';
-import { IRunContext } from '../context';
-import { ExitCode } from '../exit_code';
 import { BooleanArgument } from '../argument';
 import { CommandArguments } from '../arguments';
+import { IRunContext, ITabCompleteContext } from '../context';
+import { ExitCode } from '../exit_code';
+import { ITabCompleteResult } from '../tab_complete';
 
 class ExitArguments extends CommandArguments {
-  description = `Exit the shell.
-    
-    Exits the shell with a status of N.  If N is omitted, the exit status
-    is that of the last command executed.`;
+  description = 'Exit the shell';
   help = new BooleanArgument('h', 'help', 'display this help and exit');
 }
 
 export class ExitCommand extends BuiltinCommand {
   get name(): string {
     return 'exit';
+  }
+
+  async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
+    return await new ExitArguments().tabComplete(context);
   }
 
   protected async _run(context: IRunContext): Promise<number> {

--- a/src/builtin/help_command.ts
+++ b/src/builtin/help_command.ts
@@ -9,7 +9,9 @@ class HelpArguments extends CommandArguments {
   description =
     "Show help for built-in commands. With no arguments, lists available builtins. With names, shows each command's help (equivalent to '<cmd> --help').";
   help = new BooleanArgument('h', 'help', 'display this help and exit');
-  positional = new PositionalArguments({ min: 0 });
+  positional = new PositionalArguments({
+    possibles: (context: ITabCompleteContext) => context.commandRegistry?.builtinCommands() ?? []
+  });
 }
 
 export class HelpCommand extends BuiltinCommand {
@@ -18,15 +20,7 @@ export class HelpCommand extends BuiltinCommand {
   }
 
   async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
-    const allBuiltins = context.commandRegistry?.builtinCommands() ?? [];
-
-    // Determine the current fragment the user is trying to complete.
-    const last = context.args.length > 0 ? context.args[context.args.length - 1] : '';
-    const filtered = allBuiltins.filter(cmd => cmd.startsWith(last));
-
-    return {
-      possibles: filtered
-    };
+    return await new HelpArguments().tabComplete(context);
   }
 
   protected async _run(context: IRunContext): Promise<number> {

--- a/src/builtin/history_command.ts
+++ b/src/builtin/history_command.ts
@@ -7,9 +7,9 @@ import { ITabCompleteResult } from '../tab_complete';
 
 class HistoryArguments extends CommandArguments {
   description = ` Display or manipulate the history list.
-    
+
     Display the history list with line numbers, prefixing each modified
-    entry with a '*'.  An argument of N lists only the last N entries.`;
+    entry with a '*'`;
   clear = new BooleanArgument('c', '', 'clear the history by deleting all of the entries');
   help = new BooleanArgument('h', 'help', 'display this help and exit');
 }

--- a/src/builtin/which_command.ts
+++ b/src/builtin/which_command.ts
@@ -9,7 +9,9 @@ class WhichArguments extends CommandArguments {
   description =
     'Locate built-in commands by name. Prints each given command if it exists, otherwise an error message.';
   help = new BooleanArgument('h', 'help', 'display this help and exit');
-  positional = new PositionalArguments({ min: 0 });
+  positional = new PositionalArguments({
+    possibles: (context: ITabCompleteContext) => context.commandRegistry?.allCommands() ?? []
+  });
 }
 
 export class WhichCommand extends BuiltinCommand {
@@ -18,8 +20,7 @@ export class WhichCommand extends BuiltinCommand {
   }
 
   async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
-    const possibles = context.commandRegistry?.allCommands();
-    return { possibles };
+    return await new WhichArguments().tabComplete(context);
   }
 
   protected async _run(context: IRunContext): Promise<number> {


### PR DESCRIPTION
Now that all built-in commands support display of help information, enable tab completion for all of them via their `Arguments` subclasses.