### PR TITLE
Make PositionalArguments.possibles async

### DIFF
--- a/demo/serve/external_command_tab.ts
+++ b/demo/serve/external_command_tab.ts
@@ -13,7 +13,7 @@ import {
 
 class TestArguments extends CommandArguments {
   positional = new PositionalArguments({
-    possibles: (context: IExternalTabCompleteContext) => [
+    possibles: async (context: IExternalTabCompleteContext) => [
       'color',
       'environment',
       'exitCode',
@@ -28,7 +28,7 @@ class TestArguments extends CommandArguments {
 export async function externalTabComplete(
   context: IExternalTabCompleteContext
 ): Promise<IExternalTabCompleteResult> {
-  return new TestArguments().tabComplete(context);
+  return await new TestArguments().tabComplete(context);
 }
 
 export async function externalRun(context: IExternalRunContext): Promise<number> {

--- a/src/argument.ts
+++ b/src/argument.ts
@@ -129,7 +129,7 @@ export namespace PositionalArguments {
      * The token for completion is context.args.at(-1) as it may be an empty string.
      * The possibles are subsequently filtered using startsWith(token-for-completion).
      */
-    possibles?: (context: ITabCompleteContext) => string[];
+    possibles?: (context: ITabCompleteContext) => Promise<string[]>;
   }
 }
 

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -191,7 +191,7 @@ export abstract class CommandArguments {
         } else {
           const possiblesCallback = positional.options.possibles;
           if (possiblesCallback !== undefined) {
-            return { possibles: possiblesCallback({ ...context, args: [arg, ...args] }) };
+            return { possibles: await possiblesCallback({ ...context, args: [arg, ...args] }) };
           }
         }
       }

--- a/src/builtin/cockle_config_command.ts
+++ b/src/builtin/cockle_config_command.ts
@@ -10,21 +10,21 @@ import { COCKLE_VERSION } from '../version';
 
 class CommandSubcommand extends SubcommandArguments {
   positional = new PositionalArguments({
-    possibles: (context: ITabCompleteContext) =>
+    possibles: async (context: ITabCompleteContext) =>
       context.commandRegistry ? context.commandRegistry.match(context.args.at(-1) || '') : []
   });
 }
 
 class ModuleSubcommand extends SubcommandArguments {
   positional = new PositionalArguments({
-    possibles: (context: ITabCompleteContext) =>
+    possibles: async (context: ITabCompleteContext) =>
       context.commandRegistry ? context.commandRegistry.allModules().map(module => module.name) : []
   });
 }
 
 class PackageSubcommand extends SubcommandArguments {
   positional = new PositionalArguments({
-    possibles: (context: ITabCompleteContext) => {
+    possibles: async (context: ITabCompleteContext) => {
       return context.commandRegistry ? [...context.commandRegistry.commandPackageMap.keys()] : [];
     }
   });
@@ -33,7 +33,7 @@ class PackageSubcommand extends SubcommandArguments {
 class StdinSubcommand extends SubcommandArguments {
   positional = new PositionalArguments({
     max: 1,
-    possibles: (context: ITabCompleteContext) =>
+    possibles: async (context: ITabCompleteContext) =>
       context.stdinContext ? context.stdinContext.shortNames : []
   });
 }

--- a/src/builtin/help_command.ts
+++ b/src/builtin/help_command.ts
@@ -10,7 +10,8 @@ class HelpArguments extends CommandArguments {
     "Show help for built-in commands. With no arguments, lists available builtins. With names, shows each command's help (equivalent to '<cmd> --help').";
   help = new BooleanArgument('h', 'help', 'display this help and exit');
   positional = new PositionalArguments({
-    possibles: (context: ITabCompleteContext) => context.commandRegistry?.builtinCommands() ?? []
+    possibles: async (context: ITabCompleteContext) =>
+      context.commandRegistry?.builtinCommands() ?? []
   });
 }
 

--- a/src/builtin/which_command.ts
+++ b/src/builtin/which_command.ts
@@ -10,7 +10,7 @@ class WhichArguments extends CommandArguments {
     'Locate built-in commands by name. Prints each given command if it exists, otherwise an error message.';
   help = new BooleanArgument('h', 'help', 'display this help and exit');
   positional = new PositionalArguments({
-    possibles: (context: ITabCompleteContext) => context.commandRegistry?.allCommands() ?? []
+    possibles: async (context: ITabCompleteContext) => context.commandRegistry?.allCommands() ?? []
   });
 }
 

--- a/test/serve/external_command_tab.ts
+++ b/test/serve/external_command_tab.ts
@@ -13,7 +13,7 @@ import {
 
 class TestArguments extends CommandArguments {
   positional = new PositionalArguments({
-    possibles: (context: IExternalTabCompleteContext) => [
+    possibles: async (context: IExternalTabCompleteContext) => [
       'color',
       'environment',
       'exitCode',
@@ -28,7 +28,7 @@ class TestArguments extends CommandArguments {
 export async function externalTabComplete(
   context: IExternalTabCompleteContext
 ): Promise<IExternalTabCompleteResult> {
-  return new TestArguments().tabComplete(context);
+  return await new TestArguments().tabComplete(context);
 }
 
 export async function externalRun(context: IExternalRunContext): Promise<number> {

--- a/test/util-js/src/js-tab.ts
+++ b/test/util-js/src/js-tab.ts
@@ -11,7 +11,7 @@ import { CommandArguments, ExitCode, PositionalArguments } from '@jupyterlite/co
 
 class TestArguments extends CommandArguments {
   positional = new PositionalArguments({
-    possibles: (context: IJavaScriptTabCompleteContext) => [
+    possibles: async (context: IJavaScriptTabCompleteContext) => [
       'color',
       'environment',
       'exitCode',


### PR DESCRIPTION
Make `PositionalArguments.possibles` async so that implementors of external commands can call async functions.