### PR TITLE
Show both short and long name options for builtin command help

### DIFF
--- a/src/argument.ts
+++ b/src/argument.ts
@@ -17,14 +17,6 @@ export abstract class Argument {
     return this._isSet;
   }
 
-  get name(): string {
-    return this.shortName ? this.shortName : this.longName;
-  }
-
-  get prefixedName(): string {
-    return this.shortName ? `-${this.shortName}` : `--${this.longName}`;
-  }
-
   /**
    * Parse remaining args and return those args not consumed.
    */

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -71,14 +71,14 @@ export abstract class CommandArguments {
           if (longName) {
             names += (shortName ? ', ' : '  ') + `--${longName}`;
           }
-          optionsTable.addRow([names, arg.description])
+          optionsTable.addRow([names, arg.description]);
         }
       }
     }
     if (optionsTable.rowCount > 0) {
-      yield ''
+      yield '';
       yield 'options:';
-      yield *optionsTable.lines('    ');
+      yield* optionsTable.lines('    ');
     }
 
     if (this.subcommands !== undefined) {
@@ -89,7 +89,7 @@ export abstract class CommandArguments {
       if (table.rowCount > 0) {
         yield '';
         yield 'subcommands:';
-        yield *table.lines('    ');
+        yield* table.lines('    ');
       }
     }
   }

--- a/src/builtin/alias_command.ts
+++ b/src/builtin/alias_command.ts
@@ -11,8 +11,7 @@ class AliasArguments extends CommandArguments {
 
     Otherwise, an alias is defined for each NAME whose VALUE is given.
     A trailing space in VALUE causes the next word to be checked for
-    alias substitution when the alias is expanded.
-    `;
+    alias substitution when the alias is expanded.`;
 
   positional = new PositionalArguments();
   help = new BooleanArgument('h', 'help', 'display this help and exit');

--- a/src/builtin/cockle_config_command.ts
+++ b/src/builtin/cockle_config_command.ts
@@ -40,7 +40,7 @@ class StdinSubcommand extends SubcommandArguments {
 
 class CockleConfigArguments extends CommandArguments {
   description =
-    'Inspect and optionally modify Cockle configuration. Without arguments prints all sections. Use subcommands to target specific areas (command, module, package, stdin).';
+    'Inspect and optionally modify Cockle configuration. Without arguments prints all sections. Use subcommands to target specific areas.';
   version = new BooleanArgument('v', 'version', 'show cockle version');
   help = new BooleanArgument('h', 'help', 'display this help and exit');
   subcommands = {

--- a/src/layout/table.ts
+++ b/src/layout/table.ts
@@ -54,8 +54,10 @@ abstract class BaseTable {
 
   /**
    * Generator for output lines, one at a time.
+   * @param prefix String to insert at beginning of each line, default ''.
+   * @param suffix String to append to end of each line, default ''.
    */
-  *lines(): Generator<string> {
+  *lines(prefix: string = '', suffix: string = ''): Generator<string> {
     const { sortByColumn } = this.options;
     if (sortByColumn !== undefined) {
       // Sort rows in place.
@@ -78,7 +80,7 @@ abstract class BaseTable {
 
     const topSpacer = this.horizontalSpacer(HorizontalSpacerType.TOP);
     if (topSpacer !== undefined) {
-      yield rtrim(topSpacer);
+      yield prefix  + rtrim(topSpacer) + suffix;
     }
 
     for (const headerRow of this._headerRows) {
@@ -89,12 +91,12 @@ abstract class BaseTable {
         line += item + ' '.repeat(this._columnWidths[i] - item.length);
       }
       line += this.verticalSpacer(VerticalSpacerType.RIGHT);
-      yield rtrim(line);
+      yield prefix + rtrim(line) + suffix;
     }
     if (this._headerRows.length > 0) {
       const middleSpacer = this.horizontalSpacer(HorizontalSpacerType.MIDDLE);
       if (middleSpacer !== undefined) {
-        yield rtrim(middleSpacer);
+        yield prefix + rtrim(middleSpacer) + suffix;
       }
     }
     for (const row of this._rows) {
@@ -109,12 +111,12 @@ abstract class BaseTable {
         line += ' '.repeat(this._columnWidths[i] - item.length);
       }
       line += this.verticalSpacer(VerticalSpacerType.RIGHT);
-      yield rtrim(line);
+      yield prefix + rtrim(line) + suffix;
     }
 
     const bottomSpacer = this.horizontalSpacer(HorizontalSpacerType.BOTTOM);
     if (bottomSpacer !== undefined) {
-      yield rtrim(bottomSpacer);
+      yield prefix + rtrim(bottomSpacer) + suffix;
     }
   }
 
@@ -125,6 +127,13 @@ abstract class BaseTable {
   protected abstract horizontalSpacer(type: HorizontalSpacerType): string | undefined;
 
   /**
+   * Returns number of rows in body of table. Does not include header rows.
+   */
+  get rowCount(): number {
+    return this._rows.length;
+  }
+
+  /**
    * Return vertical spacer, i.e. spacer between adjacent columns in the same row.
    */
   protected abstract verticalSpacer(type: VerticalSpacerType): string;
@@ -133,11 +142,11 @@ abstract class BaseTable {
    * Write table to output.
    * @param output Output to write to.
    * @param prefix String to insert at beginning of each line, default ''.
-   * @param suffix String to append to end of each line, default '\n.
+   * @param suffix String to append to end of each line, default '\n'.
    */
   write(output: IOutput, prefix: string = '', suffix: string = '\n') {
-    for (const line of this.lines()) {
-      output.write(prefix + line + suffix);
+    for (const line of this.lines(prefix, suffix)) {
+      output.write(line);
     }
   }
 

--- a/src/layout/table.ts
+++ b/src/layout/table.ts
@@ -80,7 +80,7 @@ abstract class BaseTable {
 
     const topSpacer = this.horizontalSpacer(HorizontalSpacerType.TOP);
     if (topSpacer !== undefined) {
-      yield prefix  + rtrim(topSpacer) + suffix;
+      yield prefix + rtrim(topSpacer) + suffix;
     }
 
     for (const headerRow of this._headerRows) {

--- a/test/integration-tests/command/help.test.ts
+++ b/test/integration-tests/command/help.test.ts
@@ -16,7 +16,7 @@ test.describe('built-in commands help coverage', () => {
     // Run each built-in command sequentially to check `--help` output
     for (const cmd of builtins) {
       const output = await shellLineSimple(page, `${cmd} --help`);
-      expect(output, `${cmd} --help should produce output`).toMatch(/\S/);
+      expect(output, `${cmd} --help should mention --help`).toMatch(/--help/);
       expect(output, `${cmd} --help should mention -h`).toMatch(/-h/);
     }
   });


### PR DESCRIPTION
Up to now been showing only short name options such as `-v` in builtin command help. Here adding long name options too such as `--version`. 

Also switched to using `Table` for display of help information for both options and subcommands, as this aligns columns automatically.