### PR TITLE
Support filtering by command type in `cockle-config command`

### DIFF
--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -177,7 +177,7 @@ export abstract class CommandArguments {
           // Exact match, parse it.
           const subcommand = subcommands[arg];
           subcommand.set();
-          return subcommand._parseToTabComplete({ ...context, args: [arg, ...args] });
+          return await subcommand.tabComplete(context);
         }
       }
 

--- a/src/builtin/builtin_command.ts
+++ b/src/builtin/builtin_command.ts
@@ -1,8 +1,12 @@
-import { ICommandRunner } from '../commands';
+import { CommandType, ICommandRunner } from '../commands';
 import { IRunContext } from '../context';
 import { FindCommandError } from '../error_exit_code';
 
 export abstract class BuiltinCommand implements ICommandRunner {
+  get commandType(): CommandType {
+    return CommandType.Builtin;
+  }
+
   get moduleName(): string {
     return '<builtin>';
   }

--- a/src/builtin/help_command.ts
+++ b/src/builtin/help_command.ts
@@ -1,6 +1,7 @@
 import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument, PositionalArguments } from '../argument';
 import { CommandArguments } from '../arguments';
+import { CommandType } from '../commands';
 import { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
 import { ITabCompleteResult } from '../tab_complete';
@@ -11,7 +12,7 @@ class HelpArguments extends CommandArguments {
   help = new BooleanArgument('h', 'help', 'display this help and exit');
   positional = new PositionalArguments({
     possibles: async (context: ITabCompleteContext) =>
-      context.commandRegistry?.builtinCommands() ?? []
+      context.commandRegistry?.commandNames(CommandType.Builtin) ?? []
   });
 }
 
@@ -34,7 +35,7 @@ export class HelpCommand extends BuiltinCommand {
     }
 
     const targets = parsed.positional.strings;
-    const builtins = commandRegistry ? commandRegistry.builtinCommands() : [];
+    const builtins = commandRegistry ? commandRegistry.commandNames(CommandType.Builtin) : [];
 
     if (targets.length === 0) {
       stdout.write('Built-in commands:\n');

--- a/src/builtin/which_command.ts
+++ b/src/builtin/which_command.ts
@@ -10,7 +10,7 @@ class WhichArguments extends CommandArguments {
     'Locate built-in commands by name. Prints each given command if it exists, otherwise an error message.';
   help = new BooleanArgument('h', 'help', 'display this help and exit');
   positional = new PositionalArguments({
-    possibles: async (context: ITabCompleteContext) => context.commandRegistry?.allCommands() ?? []
+    possibles: async (context: ITabCompleteContext) => context.commandRegistry?.commandNames() ?? []
   });
 }
 
@@ -26,7 +26,7 @@ export class WhichCommand extends BuiltinCommand {
   protected async _run(context: IRunContext): Promise<number> {
     const { args, stdout } = context;
 
-    const allCommands = new Set(context.commandRegistry?.allCommands());
+    const allCommands = new Set(context.commandRegistry?.commandNames());
 
     const parsed = new WhichArguments().parse(context.args);
 

--- a/src/commands/command_registry.ts
+++ b/src/commands/command_registry.ts
@@ -1,8 +1,8 @@
 import { CommandModule } from './command_module';
 import { CommandPackage } from './command_package';
 import { ICommandRunner } from './command_runner';
+import { CommandType } from './command_type';
 import { ExternalCommandRunner } from './external_command_runner';
-import { BuiltinCommand } from '../builtin';
 import * as AllBuiltinCommands from '../builtin';
 import { ICallExternalCommand, ICallExternalTabComplete } from '../callback_internal';
 
@@ -12,15 +12,6 @@ export class CommandRegistry {
     readonly callExternalTabComplete: ICallExternalTabComplete
   ) {
     this.registerBuiltinCommands(AllBuiltinCommands);
-  }
-
-  /**
-   * Return sequence of all command names in alphabetical order.
-   */
-  allCommands(): string[] {
-    const commands = Array.from(this._map.keys());
-    commands.sort();
-    return commands;
   }
 
   /**
@@ -36,18 +27,21 @@ export class CommandRegistry {
   }
 
   /**
-   * Return sequence of built-in commands ordered by name.
+   * Return sequence of command names, optionally filtered by commandType.
    */
-  builtinCommands(): string[] {
-    const names: string[] = [];
-    for (const name of this._map.keys()) {
-      const runner = this._map.get(name);
-      if (runner instanceof BuiltinCommand) {
-        names.push(name);
-      }
+  commandNames(commandType: CommandType = CommandType.All): string[] {
+    if (commandType === CommandType.None) {
+      return [];
+    } else if (commandType === CommandType.All) {
+      // Avoid the filter below.
+      return Array.from(this._map.keys()).sort();
+    } else {
+      // Filter by commandType.
+      return Array.from(this._map)
+        .filter(([name, runner]) => (runner.commandType & commandType) > 0)
+        .map(([name, runner]) => name)
+        .sort();
     }
-    names.sort();
-    return names;
   }
 
   /**

--- a/src/commands/command_runner.ts
+++ b/src/commands/command_runner.ts
@@ -1,3 +1,4 @@
+import { CommandType } from './command_type';
 import { IRunContext, ITabCompleteContext } from '../context';
 import { ITabCompleteResult } from '../tab_complete';
 
@@ -5,6 +6,7 @@ import { ITabCompleteResult } from '../tab_complete';
  * Runs a single named command in a particular runtime context.
  */
 export interface ICommandRunner {
+  get commandType(): CommandType;
   get moduleName(): string;
   names(): string[];
   get packageName(): string;

--- a/src/commands/command_type.ts
+++ b/src/commands/command_type.ts
@@ -1,0 +1,12 @@
+/**
+ * Enum for command type, useful for filtering commands.
+ */
+export enum CommandType {
+  None = 0,
+  Unknown = 1 << 0,
+  Builtin = 1 << 1,
+  External = 1 << 2,
+  JavaScript = 1 << 3,
+  Wasm = 1 << 4,
+  All = Unknown | Builtin | External | JavaScript | Wasm
+}

--- a/src/commands/dynamically_loaded_command_runner.ts
+++ b/src/commands/dynamically_loaded_command_runner.ts
@@ -1,5 +1,6 @@
 import { CommandModule } from './command_module';
 import { ICommandRunner } from './command_runner';
+import { CommandType } from './command_type';
 import { IRunContext } from '../context';
 
 /**
@@ -7,6 +8,8 @@ import { IRunContext } from '../context';
  */
 export abstract class DynamicallyLoadedCommandRunner implements ICommandRunner {
   constructor(readonly module: CommandModule) {}
+
+  abstract get commandType(): CommandType;
 
   get moduleName(): string {
     return this.module.moduleName;

--- a/src/commands/external_command_runner.ts
+++ b/src/commands/external_command_runner.ts
@@ -1,4 +1,5 @@
 import { ICommandRunner } from './command_runner';
+import { CommandType } from './command_type';
 import { ICallExternalCommand, ICallExternalTabComplete } from '../callback_internal';
 import { IRunContext, ITabCompleteContext } from '../context';
 import { FindCommandError } from '../error_exit_code';
@@ -10,6 +11,10 @@ export class ExternalCommandRunner implements ICommandRunner {
     readonly callExternalCommand: ICallExternalCommand,
     readonly callExternalTabComplete: ICallExternalTabComplete | undefined
   ) {}
+
+  get commandType(): CommandType {
+    return CommandType.External;
+  }
 
   get moduleName() {
     return '<external>';

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ export * from './command_module';
 export * from './command_package';
 export * from './command_registry';
 export * from './command_runner';
+export * from './command_type';
 export * from './dynamically_loaded_command_runner';
 export * from './external_command_runner';
 export * from './javascript_command_runner';

--- a/src/commands/javascript_command_runner.ts
+++ b/src/commands/javascript_command_runner.ts
@@ -1,4 +1,5 @@
 import { CommandModule } from './command_module';
+import { CommandType } from './command_type';
 import { DynamicallyLoadedCommandRunner } from './dynamically_loaded_command_runner';
 import { IJavaScriptRunContext, IRunContext, ITabCompleteContext } from '../context';
 import { FindCommandError, LoadCommandError, RunCommandError } from '../error_exit_code';
@@ -8,6 +9,10 @@ import { ITabCompleteResult } from '../tab_complete';
 export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
   constructor(readonly module: CommandModule) {
     super(module);
+  }
+
+  get commandType(): CommandType {
+    return CommandType.JavaScript;
   }
 
   async run(context: IRunContext): Promise<number> {

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -1,4 +1,5 @@
 import { CommandModule } from './command_module';
+import { CommandType } from './command_type';
 import { DynamicallyLoadedCommandRunner } from './dynamically_loaded_command_runner';
 import { IRunContext } from '../context';
 import { FindCommandError } from '../error_exit_code';
@@ -11,6 +12,10 @@ import { joinURL } from '../utils';
 export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
   constructor(readonly module: CommandModule) {
     super(module);
+  }
+
+  get commandType(): CommandType {
+    return CommandType.Wasm;
   }
 
   async run(context: IRunContext): Promise<number> {

--- a/test/integration-tests/command/cockle-config-command.test.ts
+++ b/test/integration-tests/command/cockle-config-command.test.ts
@@ -66,4 +66,31 @@ test.describe('cockle-config command', () => {
     const output1 = await shellLineSimple(page, 'cockle-config command c987');
     expect(output1).toMatch('\r\nError: Unknown command(s): c987\r\n');
   });
+
+  test('should filter on command type in command subcommand', async ({ page }) => {
+    const output0 = await shellLineSimple(page, 'cockle-config command');
+    expect(output0).toMatch(/│ clear\s+│ <builtin>\s+│/);
+    expect(output0).toMatch(/│ js-tab\s+│ js-tab\s+│/);
+    expect(output0).toMatch(/│ ls\s+│ coreutils\s+│/);
+
+    const output1 = await shellLineSimple(page, 'cockle-config command --builtin');
+    expect(output1).toMatch(/│ clear\s+│ <builtin>\s+│/);
+    expect(output1).not.toMatch(/│ js-tab\s+│ js-tab\s+│/);
+    expect(output1).not.toMatch(/│ ls\s+│ coreutils\s+│/);
+
+    const output2 = await shellLineSimple(page, 'cockle-config command --javascript');
+    expect(output2).not.toMatch(/│ clear\s+│ <builtin>\s+│/);
+    expect(output2).toMatch(/│ js-tab\s+│ js-tab\s+│/);
+    expect(output2).not.toMatch(/│ ls\s+│ coreutils\s+│/);
+
+    const output3 = await shellLineSimple(page, 'cockle-config command --wasm');
+    expect(output3).not.toMatch(/│ clear\s+│ <builtin>\s+│/);
+    expect(output3).not.toMatch(/│ js-tab\s+│ js-tab\s+│/);
+    expect(output3).toMatch(/│ ls\s+│ coreutils\s+│/);
+
+    const output4 = await shellLineSimple(page, 'cockle-config command -j -b');
+    expect(output4).toMatch(/│ clear\s+│ <builtin>\s+│/);
+    expect(output4).toMatch(/│ js-tab\s+│ js-tab\s+│/);
+    expect(output4).not.toMatch(/│ ls\s+│ coreutils\s+│/);
+  });
 });

--- a/test/integration-tests/command/help.test.ts
+++ b/test/integration-tests/command/help.test.ts
@@ -3,15 +3,14 @@ import { shellLineSimple, test } from '../utils';
 
 test.describe('built-in commands help coverage', () => {
   test('every built-in command has --help output', async ({ page }) => {
-    // Get list of built-ins from `help`
-    const helpOutput = await shellLineSimple(page, 'help');
-    const builtins = helpOutput
-      .split('\n')
-      .filter(line => /^\s+\S/.test(line))
-      .map(line => line.trim())
-      .filter(cmd => cmd !== 'help');
+    // Get list of built-ins from `cockle-config command --builtin`
+    const output = await shellLineSimple(page, 'cockle-config command --builtin');
+    const builtins = output
+      .split('\r\n')
+      .slice(4, -2) // Remove table header and footer.
+      .map(x => x.split('│').at(1)?.trim()); // Take first column.
 
-    expect(builtins.length).toBeGreaterThan(0);
+    expect(builtins.length).toEqual(11);
 
     // Run each built-in command sequentially to check `--help` output
     for (const cmd of builtins) {


### PR DESCRIPTION
Support filtering by command type in `cockle-config command`, such as by using `cockle-config command --builtin`:

<img width="528" height="452" alt="Screenshot 2025-09-01 at 14 01 19" src="https://github.com/user-attachments/assets/1003fec1-6895-4efb-a7df-6a264705f746" />

The filtering is done in `CommandRegistry` using an `enum` of bit fields, allowing us to combine similar functions into one.

I have also modified the built-in command help test to use this `cockle-config`.

Tab completion of command names after typing `cockle-config command --builtin` still lists all command names rather than just the built-in ones. This would be nice to have but will involve passing more information around to the tab completion callbacks, so is deferred until later.