### PR TITLE
Add git2cpp to demo and tests

### DIFF
--- a/demo/cockle-config-in.json
+++ b/demo/cockle-config-in.json
@@ -23,5 +23,12 @@
   "aliases": {
     "git": "git2cpp",
     "vi": "vim"
+  },
+  "environment": {
+    "GIT_CORS_PROXY": "https://corsproxy.io/?url=",
+    "GIT_AUTHOR_NAME": "Jane Doe",
+    "GIT_AUTHOR_EMAIL": "jane.doe@blabla.com",
+    "GIT_COMMITTER_NAME": "Jane Doe",
+    "GIT_COMMITTER_EMAIL": "jane.doe@blabla.com"
   }
 }

--- a/test/cockle-config-in.json
+++ b/test/cockle-config-in.json
@@ -1,5 +1,6 @@
 {
   "packages": {
+    "git2cpp": {},
     "lua": {},
     "nano": {},
     "tree": {},
@@ -21,9 +22,15 @@
     "vim": {}
   },
   "aliases": {
+    "git": "git2cpp",
     "vi": "vim"
   },
   "environment": {
-    "ENV_VAR_FROM_COCKLE_CONFIG": "xyz123"
+    "ENV_VAR_FROM_COCKLE_CONFIG": "xyz123",
+    "GIT_CORS_PROXY": "https://corsproxy.io/?url=",
+    "GIT_AUTHOR_NAME": "Jane Doe",
+    "GIT_AUTHOR_EMAIL": "jane.doe@blabla.com",
+    "GIT_COMMITTER_NAME": "Jane Doe",
+    "GIT_COMMITTER_EMAIL": "jane.doe@blabla.com"
   }
 }

--- a/test/integration-tests/command/git2cpp.test.ts
+++ b/test/integration-tests/command/git2cpp.test.ts
@@ -1,0 +1,61 @@
+import { expect } from '@playwright/test';
+import { shellLineSimple, test } from '../utils';
+
+test.describe('git2cpp command', () => {
+  test('should write to stdout', async ({ page }) => {
+    const output = await shellLineSimple(page, 'git -v');
+    const lines = output.split('\r\n');
+    expect(lines[1]).toMatch('git2cpp version ');
+    expect(lines[1]).toMatch(' (libgit2 ');
+  });
+
+  test('should create and modify repo', async ({ page }) => {
+    // Simple init, add, commit, status, log workflow.
+    const output = await page.evaluate(async cmdName => {
+      const { shell, output } = await globalThis.cockle.shellSetupEmpty();
+
+      await shell.inputLine('git init .');
+      const text0 = output.textAndClear();
+      const exit0 = await shell.exitCode();
+
+      await shell.inputLine('echo Hello > file.txt');
+      await shell.inputLine('git add file.txt');
+      const text1 = output.textAndClear();
+      const exit1 = await shell.exitCode();
+
+      await shell.inputLine('git commit -m "My commit message"');
+      const text2 = output.textAndClear();
+      const exit2 = await shell.exitCode();
+
+      await shell.inputLine('git status');
+      const text3 = output.textAndClear();
+      const exit3 = await shell.exitCode();
+
+      await shell.inputLine('git log');
+      const text4 = output.textAndClear();
+      const exit4 = await shell.exitCode();
+
+      return [exit0, text0, exit1, text1, exit2, text2, exit3, text3, exit4, text4];
+    });
+
+    // git init
+    expect(output[0]).toBe(0);
+
+    // git add
+    expect(output[2]).toBe(0);
+
+    // git commit
+    expect(output[4]).toBe(0);
+
+    // git status
+    expect(output[6]).toBe(0);
+    expect(output[7]).toMatch('\r\nOn branch master\r\n');
+
+    // git log
+    expect(output[8]).toBe(0);
+    expect(output[9]).toMatch(/commit [0-9A-Fa-f]{40}/);
+    expect(output[9]).toMatch(/Author:\s+Jane Doe\s+jane.doe@blabla.com/);
+    expect(output[9]).toMatch(/Date:\s+/);
+    expect(output[9]).toMatch('My commit message');
+  });
+});


### PR DESCRIPTION
Add `git2cpp` to both the demo deployment and the integration tests. Initially just testing a relatively simple `git init`, `git add`, `git commit`, `git status`, `git log` workflow.