### PR TITLE
Fix tab complete at dot in filename

### DIFF
--- a/src/tab_completer.ts
+++ b/src/tab_completer.ts
@@ -106,8 +106,10 @@ export class TabCompleter {
     }
 
     const endsWithSlash = tokenToComplete.endsWith('/');
-    const doubleDot = tokenToComplete.endsWith('..');
-    const singleDot = !doubleDot && tokenToComplete.endsWith('.');
+    const prev = [undefined, '/'];
+    const doubleDot = tokenToComplete.endsWith('..') && prev.includes(tokenToComplete.at(-3));
+    const singleDot =
+      !doubleDot && tokenToComplete.endsWith('.') && prev.includes(tokenToComplete.at(-2));
     const isDot = singleDot || doubleDot;
 
     if (doubleDot) {

--- a/test/integration-tests/tab_completer.test.ts
+++ b/test/integration-tests/tab_completer.test.ts
@@ -199,6 +199,39 @@ test.describe('TabCompleter', () => {
         /^ls \r\ndirA\/ {2}file1 {2}file2\r\n/
       );
     });
+
+    test('should complete at dot in filename', async ({ page }) => {
+      const options = {
+        initialFiles: { 'a.txt': '' }
+      };
+      expect(await shellInputsSimple(page, ['l', 's', ' ', 'a', '\t'], options)).toMatch(
+        /^ls a.txt $/
+      );
+      expect(await shellInputsSimple(page, ['l', 's', ' ', 'a', '.', '\t'], options)).toMatch(
+        /^ls a.txt $/
+      );
+      expect(await shellInputsSimple(page, ['l', 's', ' ', 'a', '.', 't', '\t'], options)).toMatch(
+        /^ls a.txt $/
+      );
+    });
+
+    test('should complete at two dots in filename', async ({ page }) => {
+      const options = {
+        initialFiles: { 'b..txt': '' }
+      };
+      expect(await shellInputsSimple(page, ['l', 's', ' ', 'b', '\t'], options)).toMatch(
+        /^ls b..txt $/
+      );
+      expect(await shellInputsSimple(page, ['l', 's', ' ', 'b', '.', '\t'], options)).toMatch(
+        /^ls b..txt $/
+      );
+      expect(await shellInputsSimple(page, ['l', 's', ' ', 'b', '.', '.', '\t'], options)).toMatch(
+        /^ls b..txt $/
+      );
+      expect(
+        await shellInputsSimple(page, ['l', 's', ' ', 'b', '.', '.', 't', '\t'], options)
+      ).toMatch(/^ls b..txt $/);
+    });
   });
 
   test.describe('tab complete builtin cd command', () => {


### PR DESCRIPTION
Fix tab completion of filenames just after one or more dots a filename. Fixes #247.