### PR TITLE
Account for previous flags in tab completion possibles callback

### DIFF
--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -156,7 +156,7 @@ export abstract class CommandArguments {
    * Parse arguments to tab complete the final one.
    */
   private async _parseToTabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
-    const { args } = context;
+    let { args } = context;
     const { positional } = this;
     const subcommands = this.subcommands ?? {};
     let firstArg = true;
@@ -191,8 +191,14 @@ export abstract class CommandArguments {
             return { possibles: shortNamePossibles.concat(longNamePossibles) };
           }
         } else {
-          // Not final arg so parse as usual.
-          // In fact just ignore it, which is no good if it wants to consume further args.
+          // Usual parsing of short or long name argument.
+          if (arg.startsWith('--')) {
+            const longName = arg.slice(2);
+            args = this._findByLongName(longName).parse(arg, args);
+          } else {
+            const shortName = arg.slice(1);
+            args = this._findByShortName(shortName).parse(arg, args);
+          }
         }
       } else if (positional !== undefined) {
         // Jump straight to last argument as the preceding ones are independent of it.

--- a/src/commands/command_registry.ts
+++ b/src/commands/command_registry.ts
@@ -52,8 +52,8 @@ export class CommandRegistry {
     return this._map.get(name) ?? null;
   }
 
-  match(start: string): string[] {
-    return [...this._map.keys()].filter(name => name.startsWith(start)).sort();
+  match(start: string, commandType: CommandType = CommandType.All): string[] {
+    return this.commandNames(commandType).filter(name => name.startsWith(start));
   }
 
   registerBuiltinCommands(commands: any) {

--- a/test/integration-tests/tab_completer.test.ts
+++ b/test/integration-tests/tab_completer.test.ts
@@ -351,6 +351,38 @@ test.describe('TabCompleter', () => {
         /^cockle-config -h $/
       );
     });
+
+    test('should take into account already parsed arguments', async ({ page }) => {
+      // cockle-config command flags (-b, -e, -j, -w) are useful here.
+      const output0 = await shellInputsSimple(page, 'co\tc\t\t'.split(''));
+      expect(output0).toMatch('history');
+      expect(output0).toMatch('js-tab');
+      expect(output0).toMatch('sha256sum');
+
+      // -b
+      const output1 = await shellInputsSimple(page, 'co\tc\t-b \t'.split(''));
+      expect(output1).toMatch('history');
+      expect(output1).not.toMatch('js-tab');
+      expect(output1).not.toMatch('sha256sum');
+
+      // -j
+      const output2 = await shellInputsSimple(page, 'co\tc\t-j js-t\t'.split(''));
+      expect(output2).not.toMatch('history');
+      expect(output2).toMatch('js-tab');
+      expect(output2).not.toMatch('sha256sum');
+
+      // -w
+      const output3 = await shellInputsSimple(page, 'co\tc\t-w \t'.split(''));
+      expect(output3).not.toMatch('history');
+      expect(output3).not.toMatch('js-tab');
+      expect(output3).toMatch('sha256sum');
+
+      // -b -w
+      const output4 = await shellInputsSimple(page, 'co\tc\t-b -w \t'.split(''));
+      expect(output4).toMatch('history');
+      expect(output4).not.toMatch('js-tab');
+      expect(output4).toMatch('sha256sum');
+    });
   });
 
   test.describe('tab complete last command of multiple commands', () => {


### PR DESCRIPTION
When tab completing `PositionalArguments` take into account previously-parsed flags. The example below shows listing possible command names given previous flags of `-b` (built-in commands only) and `-w` (wasm commands only):

<img width="924" height="521" alt="Screenshot 2025-09-29 at 17 50 00" src="https://github.com/user-attachments/assets/aa9fdee0-3b78-4fe1-b56c-4b84ea7aec7f" />

This was noted as missing in the original PR #244 that added these flags.