### PR TITLE
Use env var COCKLE_DARK_MODE to record if dark mode or not

### DIFF
--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -728,9 +728,9 @@ export class ShellImpl implements IShellWorker {
     // Set/delete environment variable.
     const envVarName = 'COCKLE_DARK_MODE';
     if (darkMode === undefined) {
-      this.environment.delete(envVarName)
+      this.environment.delete(envVarName);
     } else {
-      this.environment.set(envVarName, darkMode ? '1': '0');
+      this.environment.set(envVarName, darkMode ? '1' : '0');
     }
   }
 

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -512,7 +512,7 @@ test.describe('Shell', () => {
           throw Error('Unexpected dark/light mode value');
         }
 
-        expect(output[1]).toMatch(mode === 'dark' ? 'COCKLE_DARK_MODE=1' : 'COCKLE_DARK_MODE=0')
+        expect(output[1]).toMatch(mode === 'dark' ? 'COCKLE_DARK_MODE=1' : 'COCKLE_DARK_MODE=0');
       });
     });
   });


### PR DESCRIPTION
Use environment variables `COCKLE_DARK_MODE` to record if dark mode or not. If unknown then `COCKLE_DARK_MODE` will not exist.

This will allow commands to easily check if currently using dark mode or not without having to send control sequences to the terminal.