### PR TITLE
Add `shellId` to all run and tab complete `Context` classes

### DIFF
--- a/demo/serve/external_command.ts
+++ b/demo/serve/external_command.ts
@@ -53,6 +53,10 @@ export async function externalCommand(context: IExternalRunContext): Promise<num
     }
   }
 
+  if (args.includes('shellId')) {
+    context.stdout.write(`shellId: ${context.shellId}\n`);
+  }
+
   if (args.includes('exitCode')) {
     return ExitCode.GENERAL_ERROR;
   }

--- a/demo/serve/external_command_tab.ts
+++ b/demo/serve/external_command_tab.ts
@@ -18,6 +18,7 @@ class TestArguments extends CommandArguments {
       'environment',
       'exitCode',
       'name',
+      'shellId',
       'stderr',
       'stdin',
       'stdout'
@@ -82,6 +83,10 @@ export async function externalRun(context: IExternalRunContext): Promise<number>
         stdout.write(chars.toUpperCase());
       }
     }
+  }
+
+  if (args.includes('shellId')) {
+    context.stdout.write(`shellId: ${context.shellId}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -78,6 +78,7 @@ export abstract class BaseShell implements IShell {
       name,
       args,
       environment: externalEnvironment,
+      shellId: this._shellId,
       stdin,
       stdout,
       stderr
@@ -104,7 +105,7 @@ export abstract class BaseShell implements IShell {
       return {};
     }
 
-    return await tabComplete({ name, args });
+    return await tabComplete({ name, args, shellId: this._shellId });
   }
 
   dispose(): void {

--- a/src/commands/javascript_command_runner.ts
+++ b/src/commands/javascript_command_runner.ts
@@ -27,13 +27,14 @@ export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
     }
 
     // Narrow context passed to JavaScript command so that we don't leak cockle internals.
-    const { args, environment, fileSystem, stdout, stderr } = context;
+    const { args, environment, fileSystem, shellId, stdout, stderr } = context;
     const stdin = new JavaScriptInput(context.stdin);
     const jsContext: IJavaScriptRunContext = {
       name,
       args,
       environment,
       fileSystem,
+      shellId,
       stdin,
       stdout,
       stderr
@@ -51,9 +52,9 @@ export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
     const jsModule = this.module.loader.getJavaScriptModule(this.packageName, this.moduleName);
     if (jsModule !== undefined && Object.prototype.hasOwnProperty.call(jsModule, 'tabComplete')) {
       if (jsModule.tabComplete !== undefined) {
-        const { name, args } = context;
+        const { name, args, shellId } = context;
         try {
-          return await jsModule.tabComplete({ name, args });
+          return await jsModule.tabComplete({ name, args, shellId });
         } catch (err) {
           // Do nothing, returns empty default below.
         }

--- a/src/context/external_context.ts
+++ b/src/context/external_context.ts
@@ -13,6 +13,7 @@ export interface IExternalRunContext {
   name: string;
   args: string[];
   environment: ExternalEnvironment;
+  shellId: string;
   stdin: IExternalInput;
   stdout: IExternalOutput;
   stderr: IExternalOutput;
@@ -27,4 +28,6 @@ export interface IExternalTabCompleteContext {
    * Command arguments. The last argument is the one to tab complete and may be an empty string.
    */
   args: string[];
+
+  shellId: string;
 }

--- a/src/context/javascript_context.ts
+++ b/src/context/javascript_context.ts
@@ -10,6 +10,7 @@ export interface IJavaScriptRunContext {
   args: string[];
   fileSystem: IFileSystem;
   environment: Environment;
+  shellId: string;
   stdin: IJavaScriptInput;
   stdout: IOutput;
   stderr: IOutput;
@@ -24,4 +25,6 @@ export interface IJavaScriptTabCompleteContext {
    * Command arguments. The last argument is the one to tab complete and may be an empty string.
    */
   args: string[];
+
+  shellId: string;
 }

--- a/src/context/run_context.ts
+++ b/src/context/run_context.ts
@@ -19,6 +19,7 @@ export interface IRunContext {
   aliases: Aliases;
   commandRegistry: CommandRegistry;
   history: History;
+  shellId: string;
   terminate: ITerminateCallback;
   stdin: IInput;
   stdout: IOutput;

--- a/src/context/tab_complete.ts
+++ b/src/context/tab_complete.ts
@@ -11,6 +11,8 @@ export interface ITabCompleteContext {
    */
   args: string[];
 
+  shellId: string;
+
   // The following are typed as optional so that an IJavaScriptTabCompleteContext can be passed
   // around as an ITabCompleteContext. In reality they are always set for built-in commands.
   // Need to do this better.

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -57,6 +57,7 @@ export class ShellImpl implements IShellWorker {
       ),
       environment: new Environment(options.color),
       history: new History(),
+      shellId: options.shellId,
       terminate: this.terminate.bind(this),
       stdin: this._dummyInput,
       stdout: this._dummyOutput,

--- a/src/tab_completer.ts
+++ b/src/tab_completer.ts
@@ -36,7 +36,13 @@ export class TabCompleter {
           args.push('');
         }
         const { commandRegistry, stdinContext } = this.context;
-        tabCompleteResult = await runner.tabComplete({ name, args, commandRegistry, stdinContext });
+        tabCompleteResult = await runner.tabComplete({
+          name,
+          args,
+          commandRegistry,
+          shellId: this.context.shellId,
+          stdinContext
+        });
       }
     }
 

--- a/test/integration-tests/command/external-command.test.ts
+++ b/test/integration-tests/command/external-command.test.ts
@@ -191,6 +191,19 @@ cmdName.forEach(cmdName => {
       const lines = output.split('\r\n');
       expect(lines[1]).toMatch(/^ABCDEFGHIJKLMNOPQRSTUVWXYZ/);
     });
+
+    test('should write shellId', async ({ page }) => {
+      const output = await page.evaluate(async cmdName => {
+        const { externalCommands, shellSetupEmpty } = globalThis.cockle;
+        const { shell, output } = await shellSetupEmpty({
+          externalCommands,
+          shellId: 'someShellId9876'
+        });
+        await shell.inputLine(`${cmdName} shellId`);
+        return output.text;
+      }, cmdName);
+      expect(output).toMatch('\r\nshellId: someShellId9876\r\n');
+    });
   });
 });
 
@@ -202,9 +215,9 @@ test.describe('tab complete js-tab command', () => {
       await terminalInput(shell, ['e', 'x', 't', '\t', 't', '\t', '\t']);
       return output.text;
     });
-    expect(output).toMatch(
-      /^external-tab \r\ncolor {8}exitCode {5}stderr {7}stdout\r\nenvironment {2}name {9}stdin\r\n/
-    );
+    const lines = output.split('\r\n');
+    expect(lines[1]).toEqual('color        exitCode     shellId      stdin');
+    expect(lines[2]).toEqual('environment  name         stderr       stdout');
   });
 
   test('should match the single possible starting with letter n', async ({ page }) => {
@@ -217,11 +230,11 @@ test.describe('tab complete js-tab command', () => {
     expect(output).toMatch(/^external-tab name $/);
   });
 
-  test('should complete common start string s', async ({ page }) => {
+  test('should complete common start string st', async ({ page }) => {
     const output = await page.evaluate(async cmdName => {
       const { externalCommands, shellSetupEmpty, terminalInput } = globalThis.cockle;
       const { shell, output } = await shellSetupEmpty({ externalCommands });
-      await terminalInput(shell, ['e', 'x', 't', '\t', 't', '\t', 's', '\t']);
+      await terminalInput(shell, ['e', 'x', 't', '\t', 't', '\t', 's', 't', '\t']);
       return output.text;
     });
     expect(output).toMatch(/^external-tab std$/);

--- a/test/integration-tests/command/js-commands.test.ts
+++ b/test/integration-tests/command/js-commands.test.ts
@@ -201,14 +201,25 @@ cmdName.forEach(cmdName => {
       const lines = output.split('\r\n');
       expect(lines[1]).toMatch(/^ABCDEFGHIJKLMNOPQRSTUVWXYZ/);
     });
+
+    test('should write shellId', async ({ page }) => {
+      const output = await page.evaluate(async cmdName => {
+        const { shellSetupEmpty } = globalThis.cockle;
+        const { shell, output } = await shellSetupEmpty({ shellId: 'someShellId1234' });
+        await shell.inputLine(`${cmdName} shellId`);
+        return output.text;
+      }, cmdName);
+      expect(output).toMatch('\r\nshellId: someShellId1234\r\n');
+    });
   });
 });
 
 test.describe('tab complete js-tab command', () => {
   test('should show all positional arguments', async ({ page }) => {
-    expect(await shellInputsSimple(page, ['j', 's', '-', 't', 'a', '\t', '\t'])).toMatch(
-      /^js-tab \r\ncolor {8}exitCode {5}readfile {5}stdin {8}writefile\r\nenvironment {2}name {9}stderr {7}stdout\r\n/
-    );
+    const output = await shellInputsSimple(page, ['j', 's', '-', 't', 'a', '\t', '\t']);
+    const lines = output.split('\r\n');
+    expect(lines[1]).toEqual('color        exitCode     readfile     stderr       stdout');
+    expect(lines[2]).toEqual('environment  name         shellId      stdin        writefile');
   });
 
   test('should match the single possible starting with letter w', async ({ page }) => {
@@ -217,8 +228,8 @@ test.describe('tab complete js-tab command', () => {
     );
   });
 
-  test('should complete common start string s', async ({ page }) => {
-    expect(await shellInputsSimple(page, ['j', 's', '-', 't', 'a', '\t', 's', '\t'])).toMatch(
+  test('should complete common start string st', async ({ page }) => {
+    expect(await shellInputsSimple(page, ['j', 's', '-', 't', 'a', '\t', 's', 't', '\t'])).toMatch(
       /^js-tab std$/
     );
   });

--- a/test/serve/external_command.ts
+++ b/test/serve/external_command.ts
@@ -55,6 +55,10 @@ export async function externalCommand(context: IExternalRunContext): Promise<num
     }
   }
 
+  if (args.includes('shellId')) {
+    context.stdout.write(`shellId: ${context.shellId}\n`);
+  }
+
   if (args.includes('exitCode')) {
     return ExitCode.GENERAL_ERROR;
   }

--- a/test/serve/external_command_tab.ts
+++ b/test/serve/external_command_tab.ts
@@ -18,6 +18,7 @@ class TestArguments extends CommandArguments {
       'environment',
       'exitCode',
       'name',
+      'shellId',
       'stderr',
       'stdin',
       'stdout'
@@ -82,6 +83,10 @@ export async function externalRun(context: IExternalRunContext): Promise<number>
         stdout.write(chars.toUpperCase());
       }
     }
+  }
+
+  if (args.includes('shellId')) {
+    context.stdout.write(`shellId: ${context.shellId}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/test/util-js/lib/js-test.js
+++ b/test/util-js/lib/js-test.js
@@ -84,6 +84,9 @@ var Module = (function (exports) {
                 return ExitCode.GENERAL_ERROR;
             }
         }
+        if (args.includes('shellId')) {
+            context.stdout.write(`shellId: ${context.shellId}\n`);
+        }
         if (args.includes('exitCode')) {
             return ExitCode.GENERAL_ERROR;
         }

--- a/test/util-js/package-lock.json
+++ b/test/util-js/package-lock.json
@@ -16,7 +16,7 @@
         },
         "../..": {
             "name": "@jupyterlite/cockle",
-            "version": "0.1.3",
+            "version": "1.1.0",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -40,10 +40,11 @@
                 "eslint": "^8.56.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.1.3",
+                "eslint-plugin-sort": "^4.0.0",
                 "prettier": "^3.3.3",
                 "source-map-loader": "^5.0.0",
                 "ts-loader": "^9.5.1",
-                "typescript": "^5.4.5"
+                "typescript": "~5.5.4"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {

--- a/test/util-js/src/js-tab.ts
+++ b/test/util-js/src/js-tab.ts
@@ -17,6 +17,7 @@ class TestArguments extends CommandArguments {
       'exitCode',
       'name',
       'readfile',
+      'shellId',
       'stderr',
       'stdin',
       'stdout',
@@ -108,6 +109,10 @@ export async function run(context: IJavaScriptRunContext): Promise<number> {
       context.stderr.write(`Unable to open file ${filename} for writing`);
       return ExitCode.GENERAL_ERROR;
     }
+  }
+
+  if (args.includes('shellId')) {
+    context.stdout.write(`shellId: ${context.shellId}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/test/util-js/src/js-test.ts
+++ b/test/util-js/src/js-test.ts
@@ -86,6 +86,10 @@ export async function run(context: IJavaScriptRunContext): Promise<number> {
     }
   }
 
+  if (args.includes('shellId')) {
+    context.stdout.write(`shellId: ${context.shellId}\n`);
+  }
+
   if (args.includes('exitCode')) {
     return ExitCode.GENERAL_ERROR;
   }


### PR DESCRIPTION
Add `shellId`, the unique `string` ID of a `Shell`, to all run and tab complete `Context` classes. Both the external and javascript test/demo commands are modified to demonstrate this.

This is intended for use in external and javascript commands which have the same registered implementation for all shell objects but need to perform shell-specific operations, e.g. to cache something for a particular shell.