### PR TITLE
Allow `PositionalArguments` to return `pathType` as well as possible matches

### DIFF
--- a/demo/serve/external_command_tab.ts
+++ b/demo/serve/external_command_tab.ts
@@ -13,16 +13,18 @@ import {
 
 class TestArguments extends CommandArguments {
   positional = new PositionalArguments({
-    possibles: async (context: IExternalTabCompleteContext) => [
-      'color',
-      'environment',
-      'exitCode',
-      'name',
-      'shellId',
-      'stderr',
-      'stdin',
-      'stdout'
-    ]
+    tabComplete: async (context: IExternalTabCompleteContext) => ({
+      possibles: [
+        'color',
+        'environment',
+        'exitCode',
+        'name',
+        'shellId',
+        'stderr',
+        'stdin',
+        'stdout'
+      ]
+    })
   });
 }
 

--- a/src/argument.ts
+++ b/src/argument.ts
@@ -4,7 +4,7 @@
 
 import { ITabCompleteContext } from './context';
 import { GeneralError } from './error_exit_code';
-import { PathType } from './tab_complete';
+import { ITabCompleteResult, PathType } from './tab_complete';
 
 export abstract class Argument {
   constructor(
@@ -121,7 +121,7 @@ export namespace PositionalArguments {
      * The token for completion is context.args.at(-1) as it may be an empty string.
      * The possibles are subsequently filtered using startsWith(token-for-completion).
      */
-    possibles?: (context: ITabCompleteContext) => Promise<string[]>;
+    tabComplete?: (context: ITabCompleteContext) => Promise<ITabCompleteResult>;
   }
 }
 

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -205,9 +205,9 @@ export abstract class CommandArguments {
         if (positional instanceof PositionalPathArguments) {
           return { pathType: positional.options.pathType ?? PathType.Any };
         } else {
-          const possiblesCallback = positional.options.possibles;
-          if (possiblesCallback !== undefined) {
-            return { possibles: await possiblesCallback({ ...context, args: [arg, ...args] }) };
+          const tabCompleteCallback = positional.options.tabComplete;
+          if (tabCompleteCallback !== undefined) {
+            return await tabCompleteCallback({ ...context, args: [arg, ...args] });
           }
         }
       }

--- a/src/builtin/cockle_config_command.ts
+++ b/src/builtin/cockle_config_command.ts
@@ -16,33 +16,37 @@ class CommandSubcommand extends SubcommandArguments {
   javascript = new BooleanArgument('j', 'javascript', 'display only javascript commands');
   wasm = new BooleanArgument('w', 'wasm', 'display only wasm commands');
   positional = new PositionalArguments({
-    possibles: async (context: ITabCompleteContext) =>
-      context.commandRegistry
-        ? context.commandRegistry.match(context.args.at(-1) || '', optionsToCommandType(this))
-        : []
+    tabComplete: async (context: ITabCompleteContext) => ({
+      possibles:
+        context.commandRegistry?.match(context.args.at(-1) || '', optionsToCommandType(this)) ?? []
+    })
   });
 }
 
 class ModuleSubcommand extends SubcommandArguments {
   positional = new PositionalArguments({
-    possibles: async (context: ITabCompleteContext) =>
-      context.commandRegistry ? context.commandRegistry.allModules().map(module => module.name) : []
+    tabComplete: async (context: ITabCompleteContext) => ({
+      possibles: context.commandRegistry?.allModules().map(module => module.name) ?? []
+    })
   });
 }
 
 class PackageSubcommand extends SubcommandArguments {
   positional = new PositionalArguments({
-    possibles: async (context: ITabCompleteContext) => {
-      return context.commandRegistry ? [...context.commandRegistry.commandPackageMap.keys()] : [];
-    }
+    tabComplete: async (context: ITabCompleteContext) => ({
+      possibles: context.commandRegistry
+        ? [...context.commandRegistry.commandPackageMap.keys()]
+        : []
+    })
   });
 }
 
 class StdinSubcommand extends SubcommandArguments {
   positional = new PositionalArguments({
     max: 1,
-    possibles: async (context: ITabCompleteContext) =>
-      context.stdinContext ? context.stdinContext.shortNames : []
+    tabComplete: async (context: ITabCompleteContext) => ({
+      possibles: context.stdinContext?.shortNames ?? []
+    })
   });
 }
 

--- a/src/builtin/help_command.ts
+++ b/src/builtin/help_command.ts
@@ -11,8 +11,9 @@ class HelpArguments extends CommandArguments {
     "Show help for built-in commands. With no arguments, lists available builtins. With names, shows each command's help (equivalent to '<cmd> --help').";
   help = new BooleanArgument('h', 'help', 'display this help and exit');
   positional = new PositionalArguments({
-    possibles: async (context: ITabCompleteContext) =>
-      context.commandRegistry?.commandNames(CommandType.Builtin) ?? []
+    tabComplete: async (context: ITabCompleteContext) => ({
+      possibles: context.commandRegistry?.commandNames(CommandType.Builtin) ?? []
+    })
   });
 }
 

--- a/src/builtin/which_command.ts
+++ b/src/builtin/which_command.ts
@@ -10,7 +10,9 @@ class WhichArguments extends CommandArguments {
     'Locate built-in commands by name. Prints each given command if it exists, otherwise an error message.';
   help = new BooleanArgument('h', 'help', 'display this help and exit');
   positional = new PositionalArguments({
-    possibles: async (context: ITabCompleteContext) => context.commandRegistry?.commandNames() ?? []
+    tabComplete: async (context: ITabCompleteContext) => ({
+      possibles: context.commandRegistry?.commandNames() ?? []
+    })
   });
 }
 

--- a/test/serve/external_command_tab.ts
+++ b/test/serve/external_command_tab.ts
@@ -13,16 +13,18 @@ import {
 
 class TestArguments extends CommandArguments {
   positional = new PositionalArguments({
-    possibles: async (context: IExternalTabCompleteContext) => [
-      'color',
-      'environment',
-      'exitCode',
-      'name',
-      'shellId',
-      'stderr',
-      'stdin',
-      'stdout'
-    ]
+    tabComplete: async (context: IExternalTabCompleteContext) => ({
+      possibles: [
+        'color',
+        'environment',
+        'exitCode',
+        'name',
+        'shellId',
+        'stderr',
+        'stdin',
+        'stdout'
+      ]
+    })
   });
 }
 

--- a/test/util-js/lib/js-tab.js
+++ b/test/util-js/lib/js-tab.js
@@ -496,9 +496,9 @@ var Module = (function (exports) {
                         return { pathType: positional.options.pathType ?? PathType.Any };
                     }
                     else {
-                        const possiblesCallback = positional.options.possibles;
-                        if (possiblesCallback !== undefined) {
-                            return { possibles: await possiblesCallback({ ...context, args: [arg, ...args] }) };
+                        const tabCompleteCallback = positional.options.tabComplete;
+                        if (tabCompleteCallback !== undefined) {
+                            return await tabCompleteCallback({ ...context, args: [arg, ...args] });
                         }
                     }
                 }
@@ -520,18 +520,20 @@ var Module = (function (exports) {
      */
     class TestArguments extends CommandArguments {
         positional = new PositionalArguments({
-            possibles: async (context) => [
-                'color',
-                'environment',
-                'exitCode',
-                'name',
-                'readfile',
-                'shellId',
-                'stderr',
-                'stdin',
-                'stdout',
-                'writefile'
-            ]
+            tabComplete: async (context) => ({
+                possibles: [
+                    'color',
+                    'environment',
+                    'exitCode',
+                    'name',
+                    'readfile',
+                    'shellId',
+                    'stderr',
+                    'stdin',
+                    'stdout',
+                    'writefile'
+                ]
+            })
         });
     }
     async function run(context) {

--- a/test/util-js/src/js-tab.ts
+++ b/test/util-js/src/js-tab.ts
@@ -11,18 +11,20 @@ import { CommandArguments, ExitCode, PositionalArguments } from '@jupyterlite/co
 
 class TestArguments extends CommandArguments {
   positional = new PositionalArguments({
-    possibles: async (context: IJavaScriptTabCompleteContext) => [
-      'color',
-      'environment',
-      'exitCode',
-      'name',
-      'readfile',
-      'shellId',
-      'stderr',
-      'stdin',
-      'stdout',
-      'writefile'
-    ]
+    tabComplete: async (context: IJavaScriptTabCompleteContext) => ({
+      possibles: [
+        'color',
+        'environment',
+        'exitCode',
+        'name',
+        'readfile',
+        'shellId',
+        'stderr',
+        'stdin',
+        'stdout',
+        'writefile'
+      ]
+    })
   });
 }
 


### PR DESCRIPTION
`PositionalArguments` has a callback, currently called `possibles`, that is used in tab completion to return possible string matches. For possible path matches there is `PositionalPathArguments` instead. However, under certain circumstances we want to be able to dynamically determine if path or string matches are required based on, for example, previous positional arguments. There is a use case for this to run JupyterLite commands in the terminal where some arguments passed to the Lite command are strings (e.g. name of a theme) and some are paths (e.g. filename to open).

The solution is for the optional callback functions to return a full `ITabCompleteResult` which supports `pathType` and/or `possible` string matches. This is more consistent with other tab completion code in cockle.

This is technically a backwards-incompatible change of API for tab completion of external and javascript commands as the callback name has changed from `possibles` to `tabComplete` and the return type has changed to `ITabCompleteResult`. However this API is considered experimental and there are no examples of external/javascript commands in the wild using tab completion via this mechanism, so it is considered fine to leave the major version number unchanged and bump just the minor version when this code is released.