### PR TITLE
Validate length of argument short and long names

### DIFF
--- a/src/argument.ts
+++ b/src/argument.ts
@@ -16,7 +16,9 @@ export abstract class Argument {
       throw new GeneralError(`Argument shortName ${shortName} must be a string of length 1`);
     }
     if (!(longName.length === 0 || longName.length > 1)) {
-      throw new GeneralError(`Argument longName ${longName} must be a string of length greater than 1`);
+      throw new GeneralError(
+        `Argument longName ${longName} must be a string of length greater than 1`
+      );
     }
   }
 

--- a/test/unit-tests/arguments.test.ts
+++ b/test/unit-tests/arguments.test.ts
@@ -51,8 +51,12 @@ describe('CommandArguments', () => {
   });
 
   test('should validate length of argument short and long names', () => {
-    expect(() => new BooleanArgument('ff', '', 'some flag')).toThrow(/Argument shortName ff must be a string of length 1/);
-    expect(() => new BooleanArgument('', 'f', 'some flag')).toThrow(/Argument longName f must be a string of length greater than 1/);
+    expect(() => new BooleanArgument('ff', '', 'some flag')).toThrow(
+      /Argument shortName ff must be a string of length 1/
+    );
+    expect(() => new BooleanArgument('', 'f', 'some flag')).toThrow(
+      /Argument longName f must be a string of length greater than 1/
+    );
   });
 
   test('should throw error on unrecognised argument', () => {


### PR DESCRIPTION
Validate length of argument short and long names used for commands. `shortName` should always be a single character, `longName` should always be more than one character.