### PR TITLE
Combine boolean argument short names

### DIFF
--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -190,7 +190,7 @@ export abstract class CommandArguments {
           if (arg.startsWith('--')) {
             return { possibles: longNamePossibles };
           } else if (arg.length > 2) {
-            return {}
+            return {};
           } else {
             const shortNamePossibles = Object.keys(this._shortNameArguments).map(x => '-' + x);
             return { possibles: shortNamePossibles.concat(longNamePossibles) };

--- a/test/integration-tests/command/cockle-config-command.test.ts
+++ b/test/integration-tests/command/cockle-config-command.test.ts
@@ -96,15 +96,15 @@ test.describe('cockle-config command', () => {
 
   test('should combine boolean shortName arguments in command subcommand', async ({ page }) => {
     let output0 = await shellLineSimple(page, 'cockle-config command -j -b');
-    output0 = output0.slice(output0.indexOf('\r\n'))
+    output0 = output0.slice(output0.indexOf('\r\n'));
 
-    let output1 = await shellLineSimple(page, 'cockle-config command -b -j');
+    const output1 = await shellLineSimple(page, 'cockle-config command -b -j');
     expect(output1.slice(output1.indexOf('\r\n'))).toEqual(output0);
 
-    let output2 = await shellLineSimple(page, 'cockle-config command -bj');
+    const output2 = await shellLineSimple(page, 'cockle-config command -bj');
     expect(output2.slice(output2.indexOf('\r\n'))).toEqual(output0);
 
-    let output3 = await shellLineSimple(page, 'cockle-config command -jb');
+    const output3 = await shellLineSimple(page, 'cockle-config command -jb');
     expect(output3.slice(output3.indexOf('\r\n'))).toEqual(output0);
   });
 });

--- a/test/integration-tests/tab_completer.test.ts
+++ b/test/integration-tests/tab_completer.test.ts
@@ -389,20 +389,20 @@ test.describe('TabCompleter', () => {
         const baseCmdLine = `cockle-config command ${args} `;
 
         const output0 = await shellInputsSimple(page, (baseCmdLine + 'j\t').split(''));
-        expect(output0).toEqual(baseCmdLine + 'js-t')
+        expect(output0).toEqual(baseCmdLine + 'js-t');
 
         const output1 = await shellInputsSimple(page, (baseCmdLine + 'js-t\t').split(''));
-        expect(output1).toMatch(baseCmdLine + 'js-t\r\njs-tab   js-test\r\n')
+        expect(output1).toMatch(baseCmdLine + 'js-t\r\njs-tab   js-test\r\n');
 
         const output2 = await shellInputsSimple(page, (baseCmdLine + 'h\t').split(''));
         // Note does not match `head` which is a wasm command.
-        expect(output2).toMatch(baseCmdLine + 'h\r\nhelp     history\r\n')
+        expect(output2).toMatch(baseCmdLine + 'h\r\nhelp     history\r\n');
 
         const output3 = await shellInputsSimple(page, (baseCmdLine + 'hi\t').split(''));
-        expect(output3).toEqual(baseCmdLine + 'history ')
+        expect(output3).toEqual(baseCmdLine + 'history ');
 
         const output4 = await shellInputsSimple(page, (baseCmdLine + 'b\t').split(''));
-        expect(output4).toEqual(baseCmdLine + 'b')
+        expect(output4).toEqual(baseCmdLine + 'b');
       });
     });
   });


### PR DESCRIPTION
Support combining multiple boolean argument short names. For example, the following are all now equivalent:
```
cockle-config command -b -j
cockle-config command -j -b
cockle-config command -bj
cockle-config command -jb
```
And any following tab completion will respect the flags already set.