### PR TITLE
Correctly setup tests for stdin via service worker

### DIFF
--- a/test/integration-tests/command/less.test.ts
+++ b/test/integration-tests/command/less.test.ts
@@ -17,7 +17,7 @@ test.describe('less command', () => {
           shell.inputLine('less file2'),
           terminalInput(shell, ['q']) // q key to exit.
         ]);
-      });
+      }, stdinOption);
       // If less does not close, test will timeout.
     });
   });

--- a/test/integration-tests/command/nano.test.ts
+++ b/test/integration-tests/command/nano.test.ts
@@ -15,7 +15,7 @@ test.describe('nano command', () => {
         const { shell } = await shellSetupEmpty({ color: true, stdinOption });
         const exit = '\x18'; // Ctrl-X
         await Promise.all([shell.inputLine('nano'), terminalInput(shell, [exit])]);
-      });
+      }, stdinOption);
       // If nano does not close, test will timeout.
     });
 
@@ -48,7 +48,7 @@ test.describe('nano command', () => {
         output.clear();
         await shell.inputLine('cat out');
         return output.text;
-      });
+      }, stdinOption);
       expect(output).toMatch(/^cat out\r\nabc\r\ndef\r\n/);
     });
 
@@ -66,7 +66,7 @@ test.describe('nano command', () => {
         output.clear();
         await shell.inputLine('cat file2');
         return output.text;
-      });
+      }, stdinOption);
       expect(output).toMatch(/^cat file2\r\nSome other file\r\nNew\r\nSecond line\r\n/);
     });
 
@@ -86,7 +86,7 @@ test.describe('nano command', () => {
         output.clear();
         await shell.inputLine('cat file2');
         return output.text;
-      });
+      }, stdinOption);
       expect(output).toMatch(/^cat file2\r\nSecond line\r\n/);
     });
   });

--- a/test/integration-tests/command/vim.test.ts
+++ b/test/integration-tests/command/vim.test.ts
@@ -15,7 +15,7 @@ test.describe('vim command', () => {
         const { shellSetupEmpty, terminalInput } = globalThis.cockle;
         const { shell } = await shellSetupEmpty({ color: true, stdinOption });
         await Promise.all([shell.inputLine('vim'), terminalInput(shell, ['\x1b', ':', 'q', '\r'])]);
-      });
+      }, stdinOption);
     });
 
     test(`should create new file using ${stdinOption}`, async ({ page }) => {
@@ -46,7 +46,7 @@ test.describe('vim command', () => {
         output.clear();
         await shell.inputLine('cat out');
         return output.text;
-      });
+      }, stdinOption);
       expect(output).toMatch(/^cat out\r\nhi QW\r\n/);
     });
 
@@ -61,7 +61,7 @@ test.describe('vim command', () => {
         output.clear();
         await shell.inputLine('cat file2');
         return output.text;
-      });
+      }, stdinOption);
       expect(output).toMatch(/^cat file2\r\nSome other file\r\nNew\r\nSecond line\r\n/);
     });
 
@@ -76,7 +76,7 @@ test.describe('vim command', () => {
         output.clear();
         await shell.inputLine('cat file2');
         return output.text;
-      });
+      }, stdinOption);
       expect(output).toMatch(/^cat file2\r\nSecond line\r\n/);
     });
 
@@ -100,7 +100,7 @@ test.describe('vim command', () => {
         output.clear();
         await shell.inputLine('cat out');
         return output.text;
-      });
+      }, stdinOption);
       expect(output).toMatch(/^cat out\r\naXYbc\r\ndef\r\n/);
     });
   });

--- a/test/integration-tests/command/wasm-commands.test.ts
+++ b/test/integration-tests/command/wasm-commands.test.ts
@@ -116,7 +116,7 @@ test.describe('wasm-test', () => {
           globalThis.cockle.terminalInput(shell, ['a', 'B', ' ', 'c', keys.EOT])
         ]);
         return output.text;
-      });
+      }, stdinOption);
       expect(output).toMatch(/^wasm-test stdin\r\naABB {2}cC\r\n/);
     });
   });

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -370,7 +370,7 @@ test.describe('Shell', () => {
             globalThis.cockle.terminalInput(shell, ['a', ' ', 'b', enter, 'c', EOT])
           ]);
           return output.text;
-        });
+        }, stdinOption);
         expect(output).toMatch(/^wc\r\na b\r\nc {6}1 {7}3 {7}5\r\n/);
       });
 
@@ -386,7 +386,7 @@ test.describe('Shell', () => {
             globalThis.cockle.terminalInput(shell, ['a', downArrow, 'b', EOT])
           ]);
           return output.text;
-        });
+        }, stdinOption);
         expect(output).toMatch('wc\r\na\x1B[Bb      0       1       5\r\n');
       });
 
@@ -407,7 +407,7 @@ test.describe('Shell', () => {
           ]);
           const ret1 = output.text;
           return [ret0, ret1];
-        });
+        }, stdinOption);
         expect(output[0]).toMatch(/^wc\r\na b\r\nc {6}1 {7}3 {7}5\r\n/);
         expect(output[1]).toMatch(/^wc\r\nde f {6}0 {7}2 {7}4\r\n/);
       });
@@ -443,7 +443,7 @@ test.describe('Shell', () => {
           output.clear();
           await shell.inputLine('cat out');
           return output.text;
-        });
+        }, stdinOption);
         expect(output).toMatch(/^cat out\r\nabcZz\r\n/);
       });
     });


### PR DESCRIPTION
Some of the synchronous stdin tests were erroneously using SharedArrayBuffer rather than the intended ServiceWorker, so here fixing those.