### PR TITLE
Support getting current window size from external and javascript commands

### DIFF
--- a/demo/serve/external_command.ts
+++ b/demo/serve/external_command.ts
@@ -57,6 +57,11 @@ export async function externalCommand(context: IExternalRunContext): Promise<num
     context.stdout.write(`shellId: ${context.shellId}\n`);
   }
 
+  if (args.includes('size')) {
+    const size = context.size();
+    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+  }
+
   if (args.includes('exitCode')) {
     return ExitCode.GENERAL_ERROR;
   }

--- a/demo/serve/external_command_tab.ts
+++ b/demo/serve/external_command_tab.ts
@@ -20,6 +20,7 @@ class TestArguments extends CommandArguments {
         'exitCode',
         'name',
         'shellId',
+        'size',
         'stderr',
         'stdin',
         'stdout'
@@ -89,6 +90,11 @@ export async function externalRun(context: IExternalRunContext): Promise<number>
 
   if (args.includes('shellId')) {
     context.stdout.write(`shellId: ${context.shellId}\n`);
+  }
+
+  if (args.includes('size')) {
+    const size = context.size();
+    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -86,6 +86,7 @@ export abstract class BaseShell implements IShell {
       stdin,
       stdout,
       stderr,
+      size: () => this.size,
       termios
     };
     const exitCode = await command(context);
@@ -213,11 +214,23 @@ export abstract class BaseShell implements IShell {
       return;
     }
 
+    if (rows < 0) {
+      rows = 0;
+    }
+    if (columns < 0) {
+      columns = 0;
+    }
+    this._size = [rows, columns];
+
     await this._remote!.setSize(rows, columns);
   }
 
   get shellId(): string {
     return this._shellId;
+  }
+
+  get size(): [number, number] {
+    return this._size;
   }
 
   async start(): Promise<void> {
@@ -355,6 +368,7 @@ export abstract class BaseShell implements IShell {
   private _ready = new PromiseDelegate<void>();
 
   private _shellId: string; // Unique identifier within a single browser tab.
+  private _size: [number, number] = [0, 0]; // [rows, columns]
   private _worker?: Worker;
   private _remote?: IRemoteShell;
   private _externalCommands = new Map<string, IExternalCommand.IOptions>();

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -125,9 +125,9 @@ export abstract class BaseShellWorker implements IShellWorker {
     }
   }
 
-  async setSize(rows: number, columns: number): Promise<void> {
+  setSize(rows: number, columns: number): void {
     if (this._shellImpl) {
-      await this._shellImpl.setSize(rows, columns);
+      this._shellImpl.setSize(rows, columns);
     }
   }
 

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -1,5 +1,5 @@
 /**
- * Callbacks used by a shell to call functions in the frontend.
+ * Callbacks visible in the frontend by Shell clients.
  */
 
 import { IDriveFSOptions } from './drive_fs';
@@ -16,4 +16,12 @@ export interface IOutputCallback {
  */
 export interface IInitDriveFSCallback {
   (options: IDriveFSOptions): void;
+}
+
+/**
+ * Return window size as [rows, columns] where rows and columns are integers >= 0.
+ * If the size is unknown they will be zero.
+ */
+export interface ISizeCallback {
+  (): [number, number];
 }

--- a/src/commands/javascript_command_runner.ts
+++ b/src/commands/javascript_command_runner.ts
@@ -27,7 +27,7 @@ export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
     }
 
     // Narrow context passed to JavaScript command so that we don't leak cockle internals.
-    const { args, environment, fileSystem, shellId, stdout, stderr, termios } = context;
+    const { args, environment, fileSystem, shellId, stdout, stderr, termios, size } = context;
     const stdin = new JavaScriptInput(context.stdin);
     const jsContext: IJavaScriptRunContext = {
       name,
@@ -38,6 +38,7 @@ export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
       stdin,
       stdout,
       stderr,
+      size,
       termios
     };
 

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -19,7 +19,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
   }
 
   async run(context: IRunContext): Promise<number> {
-    const { name, args, workerIO, fileSystem, stdin, stdout, stderr, termios } = context;
+    const { name, args, workerIO, fileSystem, stdin, stdout, stderr, termios, size } = context;
     const { wasmBaseUrl } = this.module.loader;
 
     const start = Date.now();
@@ -38,11 +38,8 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
       return 0;
     }
 
-    function getWindowSize(tty: any): [number, number] {
-      return [
-        context.environment.getNumber('LINES') ?? 24,
-        context.environment.getNumber('COLUMNS') ?? 80
-      ];
+    function getSize(tty: any): [number, number] {
+      return size();
     }
 
     function poll(stream: any, timeoutMs: number): number {
@@ -131,7 +128,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
             // Monkey patch get/set termios and get window size.
             module.TTY.default_tty_ops.ioctl_tcgets = getTermios;
             module.TTY.default_tty_ops.ioctl_tcsets = setTermios;
-            module.TTY.default_tty_ops.ioctl_tiocgwinsz = getWindowSize;
+            module.TTY.default_tty_ops.ioctl_tiocgwinsz = getSize;
 
             // May only need to be for some TTYs?
             module.TTY.stream_ops.poll = poll;

--- a/src/context/external_context.ts
+++ b/src/context/external_context.ts
@@ -3,6 +3,7 @@
  * This exists in the main UI thread unlike other contexts that exist in the webworker.
  */
 
+import { ISizeCallback } from '../callback';
 import { ExternalEnvironment } from '../external_environment';
 import { IExternalInput, IExternalOutput } from '../io';
 import { Termios } from '../termios';
@@ -18,6 +19,7 @@ export interface IExternalRunContext {
   stdin: IExternalInput;
   stdout: IExternalOutput;
   stderr: IExternalOutput;
+  size: ISizeCallback;
   termios: Termios.ITermios;
 }
 

--- a/src/context/javascript_context.ts
+++ b/src/context/javascript_context.ts
@@ -1,3 +1,4 @@
+import { ISizeCallback } from '../callback';
 import { Environment } from '../environment';
 import { IFileSystem } from '../file_system';
 import { IJavaScriptInput, IOutput } from '../io';
@@ -15,6 +16,7 @@ export interface IJavaScriptRunContext {
   stdin: IJavaScriptInput;
   stdout: IOutput;
   stderr: IOutput;
+  size: ISizeCallback;
   termios: Termios.ITermios;
 }
 

--- a/src/context/run_context.ts
+++ b/src/context/run_context.ts
@@ -1,6 +1,7 @@
 import { IStdinContext } from './stdin_context';
 import { Aliases } from '../aliases';
 import { IWorkerIO } from '../buffered_io';
+import { ISizeCallback } from '../callback';
 import { ITerminateCallback } from '../callback_internal';
 import { CommandModuleCache, CommandRegistry } from '../commands';
 import { Environment } from '../environment';
@@ -25,6 +26,7 @@ export interface IRunContext {
   stdin: IInput;
   stdout: IOutput;
   stderr: IOutput;
+  size: ISizeCallback;
   termios: Termios.ITermios;
   workerIO: IWorkerIO;
   commandModuleCache: CommandModuleCache;

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -56,7 +56,7 @@ interface IShellCommon {
   externalInput(maxChars: number | null): Promise<string>;
   externalOutput(text: string, isStderr: boolean): void;
   input(char: string): Promise<void>;
-  setSize(rows: number, columns: number): Promise<void>;
+  setSize(rows: number, columns: number): void;
   start(): Promise<void>;
   themeChange(isDark?: boolean): Promise<void>;
 }

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -57,6 +57,26 @@ export class Environment extends Map<string, string> {
     return this.has('TERM');
   }
 
+  setSize(rows: number, columns: number): void {
+    if (rows >= 1) {
+      const rowsString = rows.toString();
+      this.set('LINES', rowsString);
+      this.set('LESS_LINES', rowsString);
+    } else {
+      this.delete('LINES');
+      this.delete('LESS_LINES');
+    }
+
+    if (columns >= 1) {
+      const columnsString = columns.toString();
+      this.set('COLUMNS', columnsString);
+      this.set('LESS_COLUMNS', columnsString);
+    } else {
+      this.delete('COLUMNS');
+      this.delete('LESS_COLUMNS');
+    }
+  }
+
   // Keys to ignore when copying back from a command's env vars.
   private _ignore: Set<string> = new Set(['USER', 'LOGNAME', 'HOME', 'LANG', '_']);
 }

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -64,6 +64,7 @@ export class ShellImpl implements IShellImpl {
       stdin: this._dummyInput,
       stdout: this._dummyOutput,
       stderr: this._dummyOutput,
+      size: () => this.size,
       termios: options.termios,
       workerIO,
       commandModuleCache: this._commandModuleLoader.cache,
@@ -201,30 +202,17 @@ export class ShellImpl implements IShellImpl {
     this._runContext.workerIO.write(text);
   }
 
-  async setSize(rows: number, columns: number): Promise<void> {
-    const { environment } = this;
-
-    if (rows >= 1) {
-      const rowsString = rows.toString();
-      environment.set('LINES', rowsString);
-      environment.set('LESS_LINES', rowsString);
-    } else {
-      environment.delete('LINES');
-      environment.delete('LESS_LINES');
-    }
-
-    if (columns >= 1) {
-      const columnsString = columns.toString();
-      environment.set('COLUMNS', columnsString);
-      environment.set('LESS_COLUMNS', columnsString);
-    } else {
-      environment.delete('COLUMNS');
-      environment.delete('LESS_COLUMNS');
-    }
+  setSize(rows: number, columns: number): void {
+    this._size = [rows, columns];
+    this.environment.setSize(rows, columns);
   }
 
   setWorkerIO(workerIO: IWorkerIO) {
     this._runContext.workerIO = workerIO;
+  }
+
+  get size(): [number, number] {
+    return this._size;
   }
 
   async start(): Promise<void> {
@@ -757,6 +745,7 @@ export class ShellImpl implements IShellImpl {
   private _exitCode: number = 0;
   private _requestedDarkMode?: boolean;
   private _isRunning = false;
+  private _size: [number, number] = [0, 0]; // [rows, columns]
   private _themeStatus = ThemeStatus.PendingChange;
 
   private _commandModuleLoader: CommandModuleLoader;

--- a/test/integration-tests/command/external-command.test.ts
+++ b/test/integration-tests/command/external-command.test.ts
@@ -204,6 +204,24 @@ cmdName.forEach(cmdName => {
       }, cmdName);
       expect(output).toMatch('\r\nshellId: someShellId9876\r\n');
     });
+
+    test('should write size', async ({ page }) => {
+      const output = await page.evaluate(async cmdName => {
+        const { externalCommands, shellSetupEmpty } = globalThis.cockle;
+        const { shell, output } = await shellSetupEmpty({ externalCommands });
+        await shell.inputLine(`${cmdName} size`);
+        const ret0 = output.textAndClear();
+        shell.setSize(10, 20);
+        await shell.inputLine(`${cmdName} size`);
+        const ret1 = output.textAndClear();
+        shell.setSize(-1, -5);
+        await shell.inputLine(`${cmdName} size`);
+        return [ret0, ret1, output.text];
+      }, cmdName);
+      expect(output[0]).toMatch('\r\nsize: rows 24 x columns 80\r\n');
+      expect(output[1]).toMatch('\r\nsize: rows 10 x columns 20\r\n');
+      expect(output[2]).toMatch('\r\nsize: rows 0 x columns 0\r\n');
+    });
   });
 });
 
@@ -216,8 +234,8 @@ test.describe('tab complete js-tab command', () => {
       return output.text;
     });
     const lines = output.split('\r\n');
-    expect(lines[1]).toEqual('color        exitCode     shellId      stdin');
-    expect(lines[2]).toEqual('environment  name         stderr       stdout');
+    expect(lines[1]).toEqual('color        exitCode     shellId      stderr       stdout');
+    expect(lines[2]).toEqual('environment  name         size         stdin');
   });
 
   test('should match the single possible starting with letter n', async ({ page }) => {

--- a/test/integration-tests/command/js-commands.test.ts
+++ b/test/integration-tests/command/js-commands.test.ts
@@ -211,6 +211,24 @@ cmdName.forEach(cmdName => {
       }, cmdName);
       expect(output).toMatch('\r\nshellId: someShellId1234\r\n');
     });
+
+    test('should write size', async ({ page }) => {
+      const output = await page.evaluate(async cmdName => {
+        const { shellSetupEmpty } = globalThis.cockle;
+        const { shell, output } = await shellSetupEmpty();
+        await shell.inputLine(`${cmdName} size`);
+        const ret0 = output.textAndClear();
+        shell.setSize(12, 43);
+        await shell.inputLine(`${cmdName} size`);
+        const ret1 = output.textAndClear();
+        shell.setSize(-2, -7);
+        await shell.inputLine(`${cmdName} size`);
+        return [ret0, ret1, output.text];
+      }, cmdName);
+      expect(output[0]).toMatch('\r\nsize: rows 24 x columns 80\r\n');
+      expect(output[1]).toMatch('\r\nsize: rows 12 x columns 43\r\n');
+      expect(output[2]).toMatch('\r\nsize: rows 0 x columns 0\r\n');
+    });
   });
 });
 
@@ -218,8 +236,10 @@ test.describe('tab complete js-tab command', () => {
   test('should show all positional arguments', async ({ page }) => {
     const output = await shellInputsSimple(page, ['j', 's', '-', 't', 'a', '\t', '\t']);
     const lines = output.split('\r\n');
-    expect(lines[1]).toEqual('color        exitCode     readfile     stderr       stdout');
-    expect(lines[2]).toEqual('environment  name         shellId      stdin        writefile');
+    expect(lines[1]).toEqual(
+      'color        exitCode     readfile     size         stdin        writefile'
+    );
+    expect(lines[2]).toEqual('environment  name         shellId      stderr       stdout');
   });
 
   test('should match the single possible starting with letter w', async ({ page }) => {

--- a/test/serve/external_command.ts
+++ b/test/serve/external_command.ts
@@ -59,6 +59,11 @@ export async function externalCommand(context: IExternalRunContext): Promise<num
     context.stdout.write(`shellId: ${context.shellId}\n`);
   }
 
+  if (args.includes('size')) {
+    const size = context.size();
+    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+  }
+
   if (args.includes('exitCode')) {
     return ExitCode.GENERAL_ERROR;
   }

--- a/test/serve/external_command_tab.ts
+++ b/test/serve/external_command_tab.ts
@@ -20,6 +20,7 @@ class TestArguments extends CommandArguments {
         'exitCode',
         'name',
         'shellId',
+        'size',
         'stderr',
         'stdin',
         'stdout'
@@ -89,6 +90,11 @@ export async function externalRun(context: IExternalRunContext): Promise<number>
 
   if (args.includes('shellId')) {
     context.stdout.write(`shellId: ${context.shellId}\n`);
+  }
+
+  if (args.includes('size')) {
+    const size = context.size();
+    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/test/util-js/lib/js-tab.js
+++ b/test/util-js/lib/js-tab.js
@@ -543,6 +543,7 @@ var Module = (function (exports) {
                     'name',
                     'readfile',
                     'shellId',
+                    'size',
                     'stderr',
                     'stdin',
                     'stdout',
@@ -632,6 +633,10 @@ var Module = (function (exports) {
         }
         if (args.includes('shellId')) {
             context.stdout.write(`shellId: ${context.shellId}\n`);
+        }
+        if (args.includes('size')) {
+            const size = context.size();
+            context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
         }
         if (args.includes('exitCode')) {
             return ExitCode.GENERAL_ERROR;

--- a/test/util-js/lib/js-test.js
+++ b/test/util-js/lib/js-test.js
@@ -87,6 +87,10 @@ var Module = (function (exports) {
         if (args.includes('shellId')) {
             context.stdout.write(`shellId: ${context.shellId}\n`);
         }
+        if (args.includes('size')) {
+            const size = context.size();
+            context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+        }
         if (args.includes('exitCode')) {
             return ExitCode.GENERAL_ERROR;
         }

--- a/test/util-js/src/js-tab.ts
+++ b/test/util-js/src/js-tab.ts
@@ -19,6 +19,7 @@ class TestArguments extends CommandArguments {
         'name',
         'readfile',
         'shellId',
+        'size',
         'stderr',
         'stdin',
         'stdout',
@@ -115,6 +116,11 @@ export async function run(context: IJavaScriptRunContext): Promise<number> {
 
   if (args.includes('shellId')) {
     context.stdout.write(`shellId: ${context.shellId}\n`);
+  }
+
+  if (args.includes('size')) {
+    const size = context.size();
+    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/test/util-js/src/js-test.ts
+++ b/test/util-js/src/js-test.ts
@@ -90,6 +90,11 @@ export async function run(context: IJavaScriptRunContext): Promise<number> {
     context.stdout.write(`shellId: ${context.shellId}\n`);
   }
 
+  if (args.includes('size')) {
+    const size = context.size();
+    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+  }
+
   if (args.includes('exitCode')) {
     return ExitCode.GENERAL_ERROR;
   }


### PR DESCRIPTION
Store the terminal size explicitly in both `Shell` and `ShellImpl` and use these to obtain the source of truth for current size rather than the environment variables that can be changed by users. Allow external and javascript commands to obtain the current size via their `RunContext` objects via `context.size()` which is the equivalent of the C code
```c
ioctl(fileno(stdout), TIOCGWINSZ, &size);
```