### PR TITLE
Enforce type imports

### DIFF
--- a/demo/serve/defs.ts
+++ b/demo/serve/defs.ts
@@ -1,4 +1,4 @@
-import { IShellManager } from '@jupyterlite/cockle';
+import type { IShellManager } from '@jupyterlite/cockle';
 
 export namespace IDemo {
   export interface IOptions {

--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -1,7 +1,8 @@
-import { IShell, Shell } from '@jupyterlite/cockle';
+import type { IShell } from '@jupyterlite/cockle';
+import { Shell } from '@jupyterlite/cockle';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
-import { IDemo } from './defs';
+import type { IDemo } from './defs';
 import { externalCommand } from './external_command';
 import { externalRun, externalTabComplete } from './external_command_tab';
 import { externalTuiCommand } from './external_command_tui';

--- a/demo/serve/external_command.ts
+++ b/demo/serve/external_command.ts
@@ -1,4 +1,5 @@
-import { ansi, ExitCode, IExternalRunContext } from '@jupyterlite/cockle';
+import type { IExternalRunContext } from '@jupyterlite/cockle';
+import { ansi, ExitCode } from '@jupyterlite/cockle';
 
 export async function externalCommand(context: IExternalRunContext): Promise<number> {
   const { args } = context;

--- a/demo/serve/external_command_tab.ts
+++ b/demo/serve/external_command_tab.ts
@@ -1,15 +1,12 @@
 /**
  * The same functionality as external_command.ts but using Options with tab completion.
  */
-import {
-  ansi,
-  CommandArguments,
-  ExitCode,
+import type {
   IExternalRunContext,
   IExternalTabCompleteContext,
-  IExternalTabCompleteResult,
-  PositionalArguments
+  IExternalTabCompleteResult
 } from '@jupyterlite/cockle';
+import { ansi, CommandArguments, ExitCode, PositionalArguments } from '@jupyterlite/cockle';
 
 class TestArguments extends CommandArguments {
   positional = new PositionalArguments({

--- a/demo/serve/external_command_tui.ts
+++ b/demo/serve/external_command_tui.ts
@@ -1,4 +1,5 @@
-import { ansi, ExitCode, IExternalRunContext, Termios } from '@jupyterlite/cockle';
+import type { IExternalRunContext } from '@jupyterlite/cockle';
+import { ansi, ExitCode, Termios } from '@jupyterlite/cockle';
 
 export async function externalTuiCommand(context: IExternalRunContext): Promise<number> {
   const { name, stdin, stdout, termios } = context;

--- a/package.json
+++ b/package.json
@@ -85,6 +85,13 @@
             "eslint-plugin-sort"
         ],
         "rules": {
+            "@typescript-eslint/consistent-type-imports": [
+                "error",
+                {
+                    "prefer": "type-imports",
+                    "fixStyle": "separate-type-imports"
+                }
+            ],
             "@typescript-eslint/naming-convention": [
                 "error",
                 {

--- a/src/argument.ts
+++ b/src/argument.ts
@@ -2,9 +2,9 @@
  * Individual command argument classes.
  */
 
-import { ITabCompleteContext } from './context';
+import type { ITabCompleteContext } from './context';
 import { GeneralError } from './error_exit_code';
-import { ITabCompleteResult, PathType } from './tab_complete';
+import type { ITabCompleteResult, PathType } from './tab_complete';
 
 export abstract class Argument {
   constructor(

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -1,9 +1,11 @@
-import { Argument, PositionalArguments, PositionalPathArguments } from './argument';
-import { ITabCompleteContext } from './context';
+import type { PositionalArguments } from './argument';
+import { Argument, PositionalPathArguments } from './argument';
+import type { ITabCompleteContext } from './context';
 import { GeneralError } from './error_exit_code';
-import { IOutput } from './io';
+import type { IOutput } from './io';
 import { Table } from './layout';
-import { ITabCompleteResult, PathType } from './tab_complete';
+import type { ITabCompleteResult } from './tab_complete';
+import { PathType } from './tab_complete';
 
 /**
  * Arguments for a command, used by builtin, external and javascript commands.

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -1,24 +1,20 @@
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
-import { ISignal, Signal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
 import { proxy, wrap } from 'comlink';
 import { ansi } from './ansi';
-import {
-  IMainIO,
-  IStdinReply,
-  IStdinRequest,
-  ServiceWorkerMainIO,
-  SharedArrayBufferMainIO
-} from './buffered_io';
-import { IExternalRunContext } from './context';
-import { IShell } from './defs';
-import { IRemoteShell } from './defs_internal';
+import type { IMainIO, IStdinReply, IStdinRequest } from './buffered_io';
+import { ServiceWorkerMainIO, SharedArrayBufferMainIO } from './buffered_io';
+import type { IExternalRunContext } from './context';
+import type { IShell } from './defs';
+import type { IRemoteShell } from './defs_internal';
 import { DownloadTracker } from './download_tracker';
 import { ExitCode } from './exit_code';
-import { IExternalCommand, IExternalTabCompleteResult } from './external_command';
+import type { IExternalCommand, IExternalTabCompleteResult } from './external_command';
 import { ExternalEnvironment } from './external_environment';
 import { ExternalTermios } from './external_termios';
 import { ExternalInput, ExternalOutput } from './io';
-import { Termios } from './termios';
+import type { Termios } from './termios';
 
 /**
  * Abstract base class for Shell that external libraries use.

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -1,7 +1,8 @@
-import { IWorkerIO, ServiceWorkerWorkerIO, SharedArrayBufferWorkerIO } from './buffered_io';
+import type { IWorkerIO } from './buffered_io';
+import { ServiceWorkerWorkerIO, SharedArrayBufferWorkerIO } from './buffered_io';
 import { StdinContext } from './context';
-import { IShellWorker } from './defs_internal';
-import { IDriveFSOptions } from './drive_fs';
+import type { IShellWorker } from './defs_internal';
+import type { IDriveFSOptions } from './drive_fs';
 import { ShellImpl } from './shell_impl';
 import { Termios } from './termios';
 

--- a/src/buffered_io/defs.ts
+++ b/src/buffered_io/defs.ts
@@ -1,5 +1,5 @@
 import type { IDisposable } from '@lumino/disposable';
-import { IOutputCallback } from '../callback';
+import type { IOutputCallback } from '../callback';
 
 export interface IMainIO extends IDisposable {
   disable(): Promise<void>;

--- a/src/buffered_io/main_io.ts
+++ b/src/buffered_io/main_io.ts
@@ -1,6 +1,6 @@
 import { PromiseDelegate } from '@lumino/coreutils';
-import { IMainIO } from './defs';
-import { IOutputCallback } from '../callback';
+import type { IMainIO } from './defs';
+import type { IOutputCallback } from '../callback';
 import { delay } from '../utils';
 
 export abstract class MainIO implements IMainIO {

--- a/src/buffered_io/service_worker_main_io.ts
+++ b/src/buffered_io/service_worker_main_io.ts
@@ -1,4 +1,4 @@
-import { IMainIO, IStdinReply, IStdinRequest } from './defs';
+import type { IMainIO, IStdinReply, IStdinRequest } from './defs';
 import { MainIO } from './main_io';
 import { ServiceWorkerUtils } from './service_worker_utils';
 

--- a/src/buffered_io/service_worker_utils.ts
+++ b/src/buffered_io/service_worker_utils.ts
@@ -1,4 +1,4 @@
-import { IStdinReply, IStdinRequest } from './defs';
+import type { IStdinReply, IStdinRequest } from './defs';
 import { joinURL } from '../utils';
 
 export enum AsyncOrSync {

--- a/src/buffered_io/service_worker_worker_io.ts
+++ b/src/buffered_io/service_worker_worker_io.ts
@@ -1,8 +1,8 @@
-import { IWorkerIO } from './defs';
+import type { IWorkerIO } from './defs';
 import { ServiceWorkerUtils } from './service_worker_utils';
 import { WorkerIO } from './worker_io';
-import { IOutputCallback } from '../callback';
-import { Termios } from '../termios';
+import type { IOutputCallback } from '../callback';
+import type { Termios } from '../termios';
 
 export class ServiceWorkerWorkerIO extends WorkerIO implements IWorkerIO {
   constructor(

--- a/src/buffered_io/shared_array_buffer_main_io.ts
+++ b/src/buffered_io/shared_array_buffer_main_io.ts
@@ -1,4 +1,4 @@
-import { IMainIO } from './defs';
+import type { IMainIO } from './defs';
 import { MainIO } from './main_io';
 import { SAB } from './sab';
 

--- a/src/buffered_io/shared_array_buffer_worker_io.ts
+++ b/src/buffered_io/shared_array_buffer_worker_io.ts
@@ -1,8 +1,8 @@
-import { IWorkerIO } from './defs';
+import type { IWorkerIO } from './defs';
 import { SAB } from './sab';
 import { WorkerIO } from './worker_io';
-import { IOutputCallback } from '../callback';
-import { Termios } from '../termios';
+import type { IOutputCallback } from '../callback';
+import type { Termios } from '../termios';
 
 export class SharedArrayBufferWorkerIO extends WorkerIO implements IWorkerIO {
   constructor(

--- a/src/buffered_io/worker_io.ts
+++ b/src/buffered_io/worker_io.ts
@@ -1,7 +1,7 @@
 import { PromiseDelegate } from '@lumino/coreutils';
-import { IWorkerIO } from './defs';
+import type { IWorkerIO } from './defs';
 import { ansi } from '../ansi';
-import { IOutputCallback } from '../callback';
+import type { IOutputCallback } from '../callback';
 import { Termios } from '../termios';
 import { isLetter } from '../utils';
 

--- a/src/builtin/alias_command.ts
+++ b/src/builtin/alias_command.ts
@@ -1,9 +1,9 @@
 import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument, PositionalArguments } from '../argument';
 import { CommandArguments } from '../arguments';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 
 class AliasArguments extends CommandArguments {
   description = `Without arguments, 'alias' prints the list of aliases in the reusable

--- a/src/builtin/bool_commands.ts
+++ b/src/builtin/bool_commands.ts
@@ -1,9 +1,9 @@
 import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument } from '../argument';
 import { CommandArguments } from '../arguments';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 
 class BoolStubArguments extends CommandArguments {
   help = new BooleanArgument('h', 'help', 'display this help and exit');

--- a/src/builtin/builtin_command.ts
+++ b/src/builtin/builtin_command.ts
@@ -1,5 +1,6 @@
-import { CommandType, ICommandRunner } from '../commands';
-import { IRunContext } from '../context';
+import type { ICommandRunner } from '../commands';
+import { CommandType } from '../commands';
+import type { IRunContext } from '../context';
 import { FindCommandError } from '../error_exit_code';
 
 export abstract class BuiltinCommand implements ICommandRunner {

--- a/src/builtin/cd_command.ts
+++ b/src/builtin/cd_command.ts
@@ -1,10 +1,11 @@
 import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument, PositionalPathArguments } from '../argument';
 import { CommandArguments } from '../arguments';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { GeneralError } from '../error_exit_code';
 import { ExitCode } from '../exit_code';
-import { ITabCompleteResult, PathType } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
+import { PathType } from '../tab_complete';
 
 class CdArguments extends CommandArguments {
   description = `Change the shell working directory.

--- a/src/builtin/clear_command.ts
+++ b/src/builtin/clear_command.ts
@@ -2,9 +2,9 @@ import { BuiltinCommand } from './builtin_command';
 import { ansi } from '../ansi';
 import { BooleanArgument } from '../argument';
 import { CommandArguments } from '../arguments';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 
 class ClearArguments extends CommandArguments {
   description = 'Clear the terminal screen if ANSI escapes are supported.';

--- a/src/builtin/cockle_config_command.ts
+++ b/src/builtin/cockle_config_command.ts
@@ -2,11 +2,11 @@ import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument, PositionalArguments } from '../argument';
 import { CommandArguments, SubcommandArguments } from '../arguments';
 import { CommandType } from '../commands';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { GeneralError } from '../error_exit_code';
 import { ExitCode } from '../exit_code';
 import { BorderTable } from '../layout';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 import { COCKLE_VERSION } from '../version';
 
 class CommandSubcommand extends SubcommandArguments {

--- a/src/builtin/exit_command.ts
+++ b/src/builtin/exit_command.ts
@@ -1,9 +1,9 @@
 import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument } from '../argument';
 import { CommandArguments } from '../arguments';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 
 class ExitArguments extends CommandArguments {
   description = 'Exit the shell';

--- a/src/builtin/export_command.ts
+++ b/src/builtin/export_command.ts
@@ -1,9 +1,9 @@
 import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument, PositionalArguments } from '../argument';
 import { CommandArguments } from '../arguments';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 
 class ExportArguments extends CommandArguments {
   description = `Set export attribute for shell variables.

--- a/src/builtin/help_command.ts
+++ b/src/builtin/help_command.ts
@@ -2,9 +2,9 @@ import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument, PositionalArguments } from '../argument';
 import { CommandArguments } from '../arguments';
 import { CommandType } from '../commands';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 
 class HelpArguments extends CommandArguments {
   description =

--- a/src/builtin/history_command.ts
+++ b/src/builtin/history_command.ts
@@ -1,9 +1,9 @@
 import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument } from '../argument';
 import { CommandArguments } from '../arguments';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 
 class HistoryArguments extends CommandArguments {
   description = ` Display or manipulate the history list.

--- a/src/builtin/which_command.ts
+++ b/src/builtin/which_command.ts
@@ -1,9 +1,9 @@
 import { BuiltinCommand } from './builtin_command';
 import { BooleanArgument, PositionalArguments } from '../argument';
 import { CommandArguments } from '../arguments';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { ExitCode } from '../exit_code';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 
 class WhichArguments extends CommandArguments {
   description =

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -2,7 +2,7 @@
  * Callbacks visible in the frontend by Shell clients.
  */
 
-import { IDriveFSOptions } from './drive_fs';
+import type { IDriveFSOptions } from './drive_fs';
 
 /**
  * Send output string to be displayed in terminal.

--- a/src/callback_internal.ts
+++ b/src/callback_internal.ts
@@ -1,5 +1,5 @@
-import { IExternalTabCompleteResult } from './external_command';
-import { Termios } from './termios';
+import type { IExternalTabCompleteResult } from './external_command';
+import type { Termios } from './termios';
 
 /**
  * Internal callbacks used by a shell impl/worker to call functions in the shell.

--- a/src/commands/command_module.ts
+++ b/src/commands/command_module.ts
@@ -1,5 +1,5 @@
-import { CommandModuleLoader } from './command_module_loader';
-import { DynamicallyLoadedCommandRunner } from './dynamically_loaded_command_runner';
+import type { CommandModuleLoader } from './command_module_loader';
+import type { DynamicallyLoadedCommandRunner } from './dynamically_loaded_command_runner';
 import { JavascriptCommandRunner } from './javascript_command_runner';
 import { WasmCommandRunner } from './wasm_command_runner';
 

--- a/src/commands/command_module_cache.ts
+++ b/src/commands/command_module_cache.ts
@@ -1,5 +1,5 @@
-import { IJavaScriptModule } from '../types/javascript_module';
-import { IWebAssemblyModule } from '../types/wasm_module';
+import type { IJavaScriptModule } from '../types/javascript_module';
+import type { IWebAssemblyModule } from '../types/wasm_module';
 
 type CacheItem = IWebAssemblyModule | IJavaScriptModule;
 

--- a/src/commands/command_module_loader.ts
+++ b/src/commands/command_module_loader.ts
@@ -1,7 +1,7 @@
 import { CommandModuleCache } from './command_module_cache';
-import { IShellWorker } from '../defs_internal';
-import { IJavaScriptModule } from '../types/javascript_module';
-import { IWebAssemblyModule } from '../types/wasm_module';
+import type { IShellWorker } from '../defs_internal';
+import type { IJavaScriptModule } from '../types/javascript_module';
+import type { IWebAssemblyModule } from '../types/wasm_module';
 import { joinURL } from '../utils';
 
 /**

--- a/src/commands/command_package.ts
+++ b/src/commands/command_package.ts
@@ -1,4 +1,4 @@
-import { CommandModule } from './command_module';
+import type { CommandModule } from './command_module';
 
 /**
  * A dynamically-loaded package that contains one or more JavaScript/WebAssembly CommandModules.

--- a/src/commands/command_registry.ts
+++ b/src/commands/command_registry.ts
@@ -1,10 +1,10 @@
-import { CommandModule } from './command_module';
-import { CommandPackage } from './command_package';
-import { ICommandRunner } from './command_runner';
+import type { CommandModule } from './command_module';
+import type { CommandPackage } from './command_package';
+import type { ICommandRunner } from './command_runner';
 import { CommandType } from './command_type';
 import { ExternalCommandRunner } from './external_command_runner';
 import * as AllBuiltinCommands from '../builtin';
-import { ICallExternalCommand, ICallExternalTabComplete } from '../callback_internal';
+import type { ICallExternalCommand, ICallExternalTabComplete } from '../callback_internal';
 
 export class CommandRegistry {
   constructor(

--- a/src/commands/command_runner.ts
+++ b/src/commands/command_runner.ts
@@ -1,6 +1,6 @@
-import { CommandType } from './command_type';
-import { IRunContext, ITabCompleteContext } from '../context';
-import { ITabCompleteResult } from '../tab_complete';
+import type { CommandType } from './command_type';
+import type { IRunContext, ITabCompleteContext } from '../context';
+import type { ITabCompleteResult } from '../tab_complete';
 
 /**
  * Runs a single named command in a particular runtime context.

--- a/src/commands/dynamically_loaded_command_runner.ts
+++ b/src/commands/dynamically_loaded_command_runner.ts
@@ -1,7 +1,7 @@
-import { CommandModule } from './command_module';
-import { ICommandRunner } from './command_runner';
-import { CommandType } from './command_type';
-import { IRunContext } from '../context';
+import type { CommandModule } from './command_module';
+import type { ICommandRunner } from './command_runner';
+import type { CommandType } from './command_type';
+import type { IRunContext } from '../context';
 
 /**
  * Abstract base class for command runner that dynamically loads the command at runtime.

--- a/src/commands/external_command_runner.ts
+++ b/src/commands/external_command_runner.ts
@@ -1,9 +1,9 @@
-import { ICommandRunner } from './command_runner';
+import type { ICommandRunner } from './command_runner';
 import { CommandType } from './command_type';
-import { ICallExternalCommand, ICallExternalTabComplete } from '../callback_internal';
-import { IRunContext, ITabCompleteContext } from '../context';
+import type { ICallExternalCommand, ICallExternalTabComplete } from '../callback_internal';
+import type { IRunContext, ITabCompleteContext } from '../context';
 import { FindCommandError } from '../error_exit_code';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 
 export class ExternalCommandRunner implements ICommandRunner {
   constructor(

--- a/src/commands/javascript_command_runner.ts
+++ b/src/commands/javascript_command_runner.ts
@@ -1,10 +1,10 @@
-import { CommandModule } from './command_module';
+import type { CommandModule } from './command_module';
 import { CommandType } from './command_type';
 import { DynamicallyLoadedCommandRunner } from './dynamically_loaded_command_runner';
-import { IJavaScriptRunContext, IRunContext, ITabCompleteContext } from '../context';
+import type { IJavaScriptRunContext, IRunContext, ITabCompleteContext } from '../context';
 import { FindCommandError, LoadCommandError, RunCommandError } from '../error_exit_code';
 import { JavaScriptInput } from '../io';
-import { ITabCompleteResult } from '../tab_complete';
+import type { ITabCompleteResult } from '../tab_complete';
 
 export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
   constructor(readonly module: CommandModule) {

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -1,11 +1,11 @@
-import { CommandModule } from './command_module';
+import type { CommandModule } from './command_module';
 import { CommandType } from './command_type';
 import { DynamicallyLoadedCommandRunner } from './dynamically_loaded_command_runner';
-import { IRunContext } from '../context';
+import type { IRunContext } from '../context';
 import { FindCommandError } from '../error_exit_code';
 import { ExitCode } from '../exit_code';
-import { IOutput } from '../io';
-import { Termios } from '../termios';
+import type { IOutput } from '../io';
+import type { Termios } from '../termios';
 import type { MainModule } from '../types/wasm_module';
 import { joinURL } from '../utils';
 

--- a/src/context/external_context.ts
+++ b/src/context/external_context.ts
@@ -3,10 +3,10 @@
  * This exists in the main UI thread unlike other contexts that exist in the webworker.
  */
 
-import { ISizeCallback } from '../callback';
-import { ExternalEnvironment } from '../external_environment';
-import { IExternalInput, IExternalOutput } from '../io';
-import { Termios } from '../termios';
+import type { ISizeCallback } from '../callback';
+import type { ExternalEnvironment } from '../external_environment';
+import type { IExternalInput, IExternalOutput } from '../io';
+import type { Termios } from '../termios';
 
 /**
  * Context used to run an external command.

--- a/src/context/javascript_context.ts
+++ b/src/context/javascript_context.ts
@@ -1,8 +1,8 @@
-import { ISizeCallback } from '../callback';
-import { Environment } from '../environment';
-import { IFileSystem } from '../file_system';
-import { IJavaScriptInput, IOutput } from '../io';
-import { Termios } from '../termios';
+import type { ISizeCallback } from '../callback';
+import type { Environment } from '../environment';
+import type { IFileSystem } from '../file_system';
+import type { IJavaScriptInput, IOutput } from '../io';
+import type { Termios } from '../termios';
 
 /**
  * Mininal context used to run imported JavaScript commands.

--- a/src/context/run_context.ts
+++ b/src/context/run_context.ts
@@ -1,14 +1,14 @@
-import { IStdinContext } from './stdin_context';
-import { Aliases } from '../aliases';
-import { IWorkerIO } from '../buffered_io';
-import { ISizeCallback } from '../callback';
-import { ITerminateCallback } from '../callback_internal';
-import { CommandModuleCache, CommandRegistry } from '../commands';
-import { Environment } from '../environment';
-import { IFileSystem } from '../file_system';
-import { History } from '../history';
-import { IInput, IOutput } from '../io';
-import { Termios } from '../termios';
+import type { IStdinContext } from './stdin_context';
+import type { Aliases } from '../aliases';
+import type { IWorkerIO } from '../buffered_io';
+import type { ISizeCallback } from '../callback';
+import type { ITerminateCallback } from '../callback_internal';
+import type { CommandModuleCache, CommandRegistry } from '../commands';
+import type { Environment } from '../environment';
+import type { IFileSystem } from '../file_system';
+import type { History } from '../history';
+import type { IInput, IOutput } from '../io';
+import type { Termios } from '../termios';
 
 /**
  * Full context used to run builtin and WebAssembly commands.

--- a/src/context/stdin_context.ts
+++ b/src/context/stdin_context.ts
@@ -1,4 +1,4 @@
-import { ISetMainIOCallback } from '../callback_internal';
+import type { ISetMainIOCallback } from '../callback_internal';
 
 export interface IStdinContext {
   available(shortName: string): boolean;

--- a/src/context/tab_complete.ts
+++ b/src/context/tab_complete.ts
@@ -1,5 +1,5 @@
-import { CommandRegistry } from '../commands';
-import { IStdinContext } from '../context';
+import type { CommandRegistry } from '../commands';
+import type { IStdinContext } from '../context';
 
 /**
  * Context within which to call ICommandRunner.tabComplete().

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -1,7 +1,7 @@
 import type { IObservableDisposable } from '@lumino/disposable';
-import { IHandleStdin, IStdinReply, IStdinRequest } from './buffered_io';
-import { IOutputCallback } from './callback';
-import { IExternalCommand } from './external_command';
+import type { IHandleStdin, IStdinReply, IStdinRequest } from './buffered_io';
+import type { IOutputCallback } from './callback';
+import type { IExternalCommand } from './external_command';
 
 export interface IShell extends IObservableDisposable {
   /**

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -1,7 +1,7 @@
-import { ProxyMarked, Remote } from 'comlink';
-import { IWorkerIO } from './buffered_io';
-import { IInitDriveFSCallback, IOutputCallback } from './callback';
-import {
+import type { ProxyMarked, Remote } from 'comlink';
+import type { IWorkerIO } from './buffered_io';
+import type { IInitDriveFSCallback, IOutputCallback } from './callback';
+import type {
   ICallExternalCommand,
   ICallExternalTabComplete,
   IDownloadModuleCallback,
@@ -9,9 +9,9 @@ import {
   ISetMainIOCallback,
   ITerminateCallback
 } from './callback_internal';
-import { IStdinContext } from './context';
-import { IShell } from './defs';
-import { Termios } from './termios';
+import type { IStdinContext } from './context';
+import type { IShell } from './defs';
+import type { Termios } from './termios';
 
 /**
  * Representation of external commmand in the web worker, real external commands exists in the

--- a/src/download_tracker.ts
+++ b/src/download_tracker.ts
@@ -1,6 +1,6 @@
 import type { IDisposable } from '@lumino/disposable';
 import { ansi } from './ansi';
-import { IOutputCallback } from './callback';
+import type { IOutputCallback } from './callback';
 
 export class DownloadTracker implements IDisposable {
   constructor(

--- a/src/drive_fs.ts
+++ b/src/drive_fs.ts
@@ -1,4 +1,4 @@
-import { IFileSystem } from './file_system';
+import type { IFileSystem } from './file_system';
 
 export interface IDriveFSOptions {
   browsingContextId?: string;

--- a/src/external_command.ts
+++ b/src/external_command.ts
@@ -1,5 +1,5 @@
-import { IExternalRunContext, IExternalTabCompleteContext } from './context';
-import { ITabCompleteResult } from './tab_complete';
+import type { IExternalRunContext, IExternalTabCompleteContext } from './context';
+import type { ITabCompleteResult } from './tab_complete';
 
 /**
  * Run an external command from the Shell.

--- a/src/external_termios.ts
+++ b/src/external_termios.ts
@@ -1,4 +1,4 @@
-import { Termios } from './termios';
+import type { Termios } from './termios';
 
 export class ExternalTermios implements Termios.ITermios {
   constructor(

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,4 +1,4 @@
-import { IOutput } from './io/output';
+import type { IOutput } from './io/output';
 
 /**
  * Command history. Also maintains a current index in the history for scrolling through it.

--- a/src/io/buffered_output.ts
+++ b/src/io/buffered_output.ts
@@ -1,4 +1,4 @@
-import { IOutput } from './output';
+import type { IOutput } from './output';
 
 export abstract class BufferedOutput implements IOutput {
   get allContent(): string {

--- a/src/io/console_output.ts
+++ b/src/io/console_output.ts
@@ -1,4 +1,4 @@
-import { IOutput } from './output';
+import type { IOutput } from './output';
 
 export class ConsoleOutput implements IOutput {
   flush(): void {}

--- a/src/io/dummy_input.ts
+++ b/src/io/dummy_input.ts
@@ -1,4 +1,4 @@
-import { IInput } from './input';
+import type { IInput } from './input';
 
 /**
  * Dummy input that returns immediately on read request.

--- a/src/io/dummy_output.ts
+++ b/src/io/dummy_output.ts
@@ -1,4 +1,4 @@
-import { IOutput } from './output';
+import type { IOutput } from './output';
 
 /**
  * Dummy output that silently swallows all output.

--- a/src/io/external_output.ts
+++ b/src/io/external_output.ts
@@ -1,4 +1,4 @@
-import { IOutput } from './output';
+import type { IOutput } from './output';
 
 /**
  * Output used by an ExternalCommand, exists in the main UI not webworker.

--- a/src/io/file_input.ts
+++ b/src/io/file_input.ts
@@ -1,5 +1,5 @@
 import { InputAll } from './input_all';
-import { IFileSystem } from '../file_system';
+import type { IFileSystem } from '../file_system';
 
 export class FileInput extends InputAll {
   constructor(

--- a/src/io/file_output.ts
+++ b/src/io/file_output.ts
@@ -1,5 +1,5 @@
 import { BufferedOutput } from './buffered_output';
-import { IFileSystem } from '../file_system';
+import type { IFileSystem } from '../file_system';
 
 export class FileOutput extends BufferedOutput {
   constructor(

--- a/src/io/input_all.ts
+++ b/src/io/input_all.ts
@@ -1,4 +1,4 @@
-import { IInput } from './input';
+import type { IInput } from './input';
 
 export abstract class InputAll implements IInput {
   isTerminal(): boolean {

--- a/src/io/javascript_input.ts
+++ b/src/io/javascript_input.ts
@@ -1,4 +1,4 @@
-import { IInput } from './input';
+import type { IInput } from './input';
 
 export interface IJavaScriptInput {
   isTerminal(): boolean;

--- a/src/io/pipe_input.ts
+++ b/src/io/pipe_input.ts
@@ -1,5 +1,5 @@
 import { InputAll } from './input_all';
-import { Pipe } from './pipe';
+import type { Pipe } from './pipe';
 
 export class PipeInput extends InputAll {
   constructor(readonly pipe: Pipe) {

--- a/src/io/redirect_output.ts
+++ b/src/io/redirect_output.ts
@@ -1,5 +1,5 @@
 import { BufferedOutput } from './buffered_output';
-import { IOutput } from './output';
+import type { IOutput } from './output';
 
 export class RedirectOutput extends BufferedOutput {
   constructor(target: IOutput) {

--- a/src/io/terminal_input.ts
+++ b/src/io/terminal_input.ts
@@ -1,5 +1,5 @@
-import { IInput } from './input';
-import { IStdinAsyncCallback, IStdinCallback } from '../callback_internal';
+import type { IInput } from './input';
+import type { IStdinAsyncCallback, IStdinCallback } from '../callback_internal';
 
 export class TerminalInput implements IInput {
   constructor(

--- a/src/io/terminal_output.ts
+++ b/src/io/terminal_output.ts
@@ -1,5 +1,5 @@
-import { IOutput } from './output';
-import { IOutputCallback } from '../callback';
+import type { IOutput } from './output';
+import type { IOutputCallback } from '../callback';
 
 export class TerminalOutput implements IOutput {
   constructor(

--- a/src/layout/table.ts
+++ b/src/layout/table.ts
@@ -1,5 +1,5 @@
 import { ansi } from '../ansi';
-import { IOutput } from '../io';
+import type { IOutput } from '../io';
 import { rtrim } from '../utils';
 
 /**

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,6 +1,7 @@
-import { Aliases } from './aliases';
+import type { Aliases } from './aliases';
 import { GeneralError } from './error_exit_code';
-import { Token, tokenize } from './tokenize';
+import type { Token } from './tokenize';
+import { tokenize } from './tokenize';
 
 const endOfCommand = ';&';
 //const ignore_trailing = ";"

--- a/src/service_worker_manager.ts
+++ b/src/service_worker_manager.ts
@@ -1,5 +1,5 @@
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
-import { ShellManager } from './shell_manager';
+import type { ShellManager } from './shell_manager';
 import { COCKLE_VERSION } from './version';
 
 const DRIVE_API_PATH = '/cockle/service-worker';

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,5 +1,5 @@
 import { BaseShell } from './base_shell';
-import { IShell } from './defs';
+import type { IShell } from './defs';
 
 /**
  * Shell class that communicates with ShellWorker.

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -1,22 +1,21 @@
 import { Aliases } from './aliases';
 import { ansi } from './ansi';
-import { IWorkerIO } from './buffered_io';
-import { ICommandLine } from './command_line';
+import type { IWorkerIO } from './buffered_io';
+import type { ICommandLine } from './command_line';
 import { CommandModule, CommandModuleLoader, CommandPackage, CommandRegistry } from './commands';
-import { IRunContext } from './context';
-import { IShellImpl } from './defs_internal';
+import type { IRunContext } from './context';
+import type { IShellImpl } from './defs_internal';
 import { Environment } from './environment';
 import { ErrorExitCode, FindCommandError, GeneralError } from './error_exit_code';
 import { ExitCode } from './exit_code';
-import { IFileSystem } from './file_system';
+import type { IFileSystem } from './file_system';
 import { History } from './history';
+import type { IInput, IOutput } from './io';
 import {
   DummyInput,
   DummyOutput,
   FileInput,
   FileOutput,
-  IInput,
-  IOutput,
   Pipe,
   TerminalInput,
   TerminalOutput

--- a/src/shell_manager.ts
+++ b/src/shell_manager.ts
@@ -1,5 +1,5 @@
-import { IHandleStdin, IStdinReply, IStdinRequest } from './buffered_io';
-import { IShell, IShellManager } from './defs';
+import type { IHandleStdin, IStdinReply, IStdinRequest } from './buffered_io';
+import type { IShell, IShellManager } from './defs';
 import { ServiceWorkerManager } from './service_worker_manager';
 import { delay } from './utils';
 

--- a/src/shell_worker.ts
+++ b/src/shell_worker.ts
@@ -1,6 +1,6 @@
 import { expose } from 'comlink';
 import { BaseShellWorker } from './base_shell_worker';
-import { IDriveFSOptions } from './drive_fs';
+import type { IDriveFSOptions } from './drive_fs';
 
 /**
  * Default shell worker that does not use a DriveFS.

--- a/src/tab_completer.ts
+++ b/src/tab_completer.ts
@@ -1,9 +1,10 @@
 import { ansi } from './ansi';
-import { ICommandLine } from './command_line';
-import { IRunContext } from './context';
+import type { ICommandLine } from './command_line';
+import type { IRunContext } from './context';
 import { CommandNode, parse } from './parse';
-import { ITabCompleteResult, PathType } from './tab_complete';
-import { RuntimeExports } from './types/wasm_module';
+import type { ITabCompleteResult } from './tab_complete';
+import { PathType } from './tab_complete';
+import type { RuntimeExports } from './types/wasm_module';
 import { longestStartsWith, toColumns } from './utils';
 
 export class TabCompleter {

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -1,4 +1,4 @@
-import { Aliases } from './aliases';
+import type { Aliases } from './aliases';
 import { GeneralError } from './error_exit_code';
 
 const delimiters = ';&|><';

--- a/src/types/javascript_module.ts
+++ b/src/types/javascript_module.ts
@@ -1,5 +1,5 @@
-import { IJavaScriptRunContext, IJavaScriptTabCompleteContext } from '../context';
-import { ITabCompleteResult } from '../tab_complete';
+import type { IJavaScriptRunContext, IJavaScriptTabCompleteContext } from '../context';
+import type { ITabCompleteResult } from '../tab_complete';
 
 export interface IJavaScriptModule {
   run(context: IJavaScriptRunContext): Promise<number>;

--- a/test/integration-tests/utils.ts
+++ b/test/integration-tests/utils.ts
@@ -1,5 +1,5 @@
 import { type Page, test as base } from '@playwright/test';
-import { IOptions } from '../serve/shell_setup';
+import type { IOptions } from '../serve/shell_setup';
 
 // Override page fixture to navigate to specific page.
 export const test = base.extend({

--- a/test/serve/external_command.ts
+++ b/test/serve/external_command.ts
@@ -1,4 +1,5 @@
-import { ansi, ExitCode, IExternalRunContext } from '@jupyterlite/cockle';
+import type { IExternalRunContext } from '@jupyterlite/cockle';
+import { ansi, ExitCode } from '@jupyterlite/cockle';
 
 // External command with different bahaviour depending on supplied args, to test
 // external command functionality.

--- a/test/serve/external_command_tab.ts
+++ b/test/serve/external_command_tab.ts
@@ -1,15 +1,12 @@
 /**
  * The same functionality as external_command.ts but using Options with tab completion.
  */
-import {
-  ansi,
-  CommandArguments,
-  ExitCode,
+import type {
   IExternalRunContext,
   IExternalTabCompleteContext,
-  IExternalTabCompleteResult,
-  PositionalArguments
+  IExternalTabCompleteResult
 } from '@jupyterlite/cockle';
+import { ansi, CommandArguments, ExitCode, PositionalArguments } from '@jupyterlite/cockle';
 
 class TestArguments extends CommandArguments {
   positional = new PositionalArguments({

--- a/test/serve/input_setup.ts
+++ b/test/serve/input_setup.ts
@@ -1,4 +1,5 @@
-import { delay, Shell } from '@jupyterlite/cockle';
+import type { Shell } from '@jupyterlite/cockle';
+import { delay } from '@jupyterlite/cockle';
 
 /**
  * Helper to provide terminal input whilst a command is running.

--- a/test/serve/output_setup.ts
+++ b/test/serve/output_setup.ts
@@ -1,4 +1,4 @@
-import { IOutputCallback } from '@jupyterlite/cockle';
+import type { IOutputCallback } from '@jupyterlite/cockle';
 
 /**
  * Provides outputCallback to mock a terminal.

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -1,4 +1,5 @@
-import { IExternalCommand, IShell, Shell, ShellManager } from '@jupyterlite/cockle';
+import type { IExternalCommand, IShell } from '@jupyterlite/cockle';
+import { Shell, ShellManager } from '@jupyterlite/cockle';
 import { MockTerminalOutput } from './output_setup';
 
 export interface IShellSetup {

--- a/test/unit-tests/layout.test.ts
+++ b/test/unit-tests/layout.test.ts
@@ -1,4 +1,4 @@
-import { IOutput } from '../../src/io';
+import type { IOutput } from '../../src/io';
 import { BorderTable, Table } from '../../src/layout';
 
 class MockOutput implements IOutput {


### PR DESCRIPTION
Add linter rule to enforce import of types only where possible as in jupyterlite/terminal#82. Should result in smaller shipped web worker size.

Quite invasive changes but all in the import sections of files.