### PR TITLE
Don't update env at end of wasm command

### DIFF
--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -152,11 +152,6 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
           }
         }
       }
-
-      if (Object.prototype.hasOwnProperty.call(wasm, 'getEnvStrings')) {
-        // Copy environment variables back from command.
-        context.environment.copyFromCommand(wasm.getEnvStrings!());
-      }
     }
 
     const end = Date.now();

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -17,19 +17,6 @@ export class Environment extends Map<string, string> {
   }
 
   /**
-   * Copy environment variables back from a command after it has run.
-   */
-  copyFromCommand(source: string[]) {
-    for (const str of source) {
-      const split = str.split('=');
-      const key = split.shift();
-      if (key && !this._ignore.has(key)) {
-        this.set(key, split.join('='));
-      }
-    }
-  }
-
-  /**
    * Copy environment variables into a command before it is run.
    */
   copyIntoCommand(target: { [key: string]: string }, isTerminal: boolean) {
@@ -76,7 +63,4 @@ export class Environment extends Map<string, string> {
       this.delete('LESS_COLUMNS');
     }
   }
-
-  // Keys to ignore when copying back from a command's env vars.
-  private _ignore: Set<string> = new Set(['USER', 'LOGNAME', 'HOME', 'LANG', '_']);
 }


### PR DESCRIPTION
Previously have been updating the environment at the end of a wasm command to propagate environment variables changes to the shell. This isn't correct of course, although it has been useful. So here avoiding the update, which means that wasm commands no longer need to export `getEnvStrings`.

Keeping environment updates for javascript and external commands as they are useful, but will probably have to disable these too eventually when we some equivalent of running command in separate processes.