### PR TITLE
Fix newline at top of terminal after clear command

### DIFF
--- a/src/buffered_io/worker_io.ts
+++ b/src/buffered_io/worker_io.ts
@@ -207,17 +207,26 @@ export abstract class WorkerIO implements IWorkerIO {
             isOpenBracket ? isLetter(ch) : ch === 7 || ch === 27
           );
 
-          if (index > 0) {
+          if (index >= 0) {
             const sequence = chars.slice(i, i + index + 3);
             ret.push(...sequence);
             i += index + 2;
 
             const asString = String.fromCharCode(...sequence);
-            if (!this._inAlternativeBuffer && asString === ansi.enableAlternativeBuffer) {
-              this._inAlternativeBuffer = true;
-            } else if (this._inAlternativeBuffer && asString === ansi.disableAlternativeBuffer) {
-              this._inAlternativeBuffer = false;
+
+            if (this._inAlternativeBuffer) {
+              if (asString === ansi.disableAlternativeBuffer) {
+                this._inAlternativeBuffer = false;
+              }
+            } else {
+              // !this._inAlternativeBuffer
+              if (asString === ansi.enableAlternativeBuffer) {
+                this._inAlternativeBuffer = true;
+              } else if (asString === ansi.cursorHome) {
+                this._writeColumn = 0;
+              }
             }
+
             continue; // No further processing of escape sequence.
           }
         } else if (nextChar !== undefined) {

--- a/test/integration-tests/command/clear.test.ts
+++ b/test/integration-tests/command/clear.test.ts
@@ -1,0 +1,10 @@
+import { expect } from '@playwright/test';
+import { shellLineSimple, test } from '../utils';
+
+test.describe('clear command', () => {
+  test('should emit terminal clear ansi sequence', async ({ page }) => {
+    const output = await shellLineSimple(page, 'clear');
+    // Note no newline after the clear, before the prompt.
+    expect(output).toMatch('clear\r\n\x1b[2J\x1b[3J\x1b[Hjs-shell:');
+  });
+});


### PR DESCRIPTION
Fix the erroneous display of a newline at the top of the terminal after running a `clear` command. Regression introduced in #255. Added an explicit test for it.

