### PR TITLE
Update to lua 5.5.0 in tests

### DIFF
--- a/test/integration-tests/command/lua.test.ts
+++ b/test/integration-tests/command/lua.test.ts
@@ -4,7 +4,7 @@ import { shellLineSimple, shellLineSimpleN, test } from '../utils';
 test.describe('lua command', () => {
   test('should write to stdout', async ({ page }) => {
     const output = await shellLineSimple(page, 'lua -v');
-    expect(output).toMatch('Lua 5.4.8  Copyright (C) 1994-2025 Lua.org, PUC-Rio');
+    expect(output).toMatch('Lua 5.5.0  Copyright (C) 1994-2025 Lua.org, PUC-Rio');
   });
 
   test('should run lua script', async ({ page }) => {


### PR DESCRIPTION
Lua 5.5.0 has been released and will be used by default in tests.