### PR TITLE
Support pre-colouring of individual table item strings

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -4,6 +4,9 @@
 
 const ESC = '\x1B[';
 
+// eslint-disable-next-line no-control-regex
+const styleRegex = /\x1b\[[^m]*m/g;
+
 function clamp(n: number): number {
   return Math.min(Math.max(Math.round(n), 0), 255);
 }
@@ -22,6 +25,8 @@ export const ansi = {
   eraseSavedLines: ESC + '3J',
   eraseEndLine: ESC + 'K',
   eraseStartLine: ESC + '1K',
+
+  removeStyles: (str: string) => str.replace(styleRegex, ''),
 
   styleRGB: (r: number, g: number, b: number, foreground: boolean = true) => {
     const code = foreground ? '38' : '48';

--- a/src/layout/table.ts
+++ b/src/layout/table.ts
@@ -88,7 +88,7 @@ abstract class BaseTable {
       for (let i = 0; i < nColumns; i++) {
         line += this.verticalSpacer(i === 0 ? VerticalSpacerType.LEFT : VerticalSpacerType.INNER);
         const item = headerRow[i] ?? '';
-        line += item + ' '.repeat(this._columnWidths[i] - item.length);
+        line += item + ' '.repeat(this._columnWidths[i] - this._cleanString(item).length);
       }
       line += this.verticalSpacer(VerticalSpacerType.RIGHT);
       yield prefix + rtrim(line) + suffix;
@@ -108,7 +108,7 @@ abstract class BaseTable {
           const color = this.options.colorByColumn?.get(i);
           line += color !== undefined ? color + item + ansi.styleReset : item;
         }
-        line += ' '.repeat(this._columnWidths[i] - item.length);
+        line += ' '.repeat(this._columnWidths[i] - this._cleanString(item).length);
       }
       line += this.verticalSpacer(VerticalSpacerType.RIGHT);
       yield prefix + rtrim(line) + suffix;
@@ -150,8 +150,12 @@ abstract class BaseTable {
     }
   }
 
+  private _cleanString(str: string): string {
+    return ansi.removeStyles(str);
+  }
+
   private _updateColumnWidths(row: string[]) {
-    const widths = row.map(str => str.length);
+    const widths = row.map(str => this._cleanString(str).length);
     const n = Math.min(this._columnWidths.length, widths.length);
     for (let i = 0; i < n; i++) {
       this._columnWidths[i] = Math.max(this._columnWidths[i], widths[i]);

--- a/test/unit-tests/layout.test.ts
+++ b/test/unit-tests/layout.test.ts
@@ -1,3 +1,4 @@
+import { ansi } from '../../src/ansi';
 import type { IOutput } from '../../src/io';
 import { BorderTable, Table } from '../../src/layout';
 
@@ -150,7 +151,7 @@ describe('Table', () => {
     ]);
   });
 
-  test('output shouuld support prefix and suffix', () => {
+  test('output should support prefix and suffix', () => {
     const table = new Table();
     table.addHeaderRow(['h1', 'h2']);
     table.addRow(['r1', 'r2']);
@@ -158,6 +159,20 @@ describe('Table', () => {
     const output = new MockOutput();
     table.write(output, 'pre_', '_suf');
     expect(output.text).toEqual(['pre_h1  h2_suf', 'pre_──────_suf', 'pre_r1  r2_suf']);
+  });
+
+  test('should layout correctly if items are colored', () => {
+    const table = new Table();
+    table.addHeaderRow([ansi.styleBlue + 'h1' + ansi.styleReset, 'h2']);
+    table.addRow(['r1', ansi.styleBoldGreen + 'r2' + ansi.styleReset]);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual([
+      ansi.styleBlue + 'h1' + ansi.styleReset + '  h2\n',
+      '──────\n',
+      'r1  ' + ansi.styleBoldGreen + 'r2' + ansi.styleReset + '\n'
+    ]);
   });
 });
 
@@ -324,6 +339,22 @@ describe('BorderTable', () => {
       'pre_├────┼────┤_suf',
       'pre_│ r1 │ r2 │_suf',
       'pre_╰────┴────╯_suf'
+    ]);
+  });
+
+  test('should layout correctly if items are colored', () => {
+    const table = new BorderTable();
+    table.addHeaderRow([ansi.styleBlue + 'h1' + ansi.styleReset, 'h2']);
+    table.addRow(['r1', ansi.styleBoldGreen + 'r2' + ansi.styleReset]);
+
+    const output = new MockOutput();
+    table.write(output);
+    expect(output.text).toEqual([
+      '╭────┬────╮\n',
+      '│ ' + ansi.styleBlue + 'h1' + ansi.styleReset + ' │ h2 │\n',
+      '├────┼────┤\n',
+      '│ r1 │ ' + ansi.styleBoldGreen + 'r2' + ansi.styleReset + ' │\n',
+      '╰────┴────╯\n'
     ]);
   });
 });


### PR DESCRIPTION
Support pre-colouring of individual table item strings, so that the table column widths are calculated ignoring the colour code sequences and displayed using them.