### PR TITLE
Fix paste into terminal command exceeding buffer size

### DIFF
--- a/src/buffered_io/sab.ts
+++ b/src/buffered_io/sab.ts
@@ -8,9 +8,10 @@ export namespace SAB {
   // Possible values of REQUEST_INDEX:
   export const NO_REQUEST_VALUE = 0;
   export const REQUEST_VALUE = 1;
-  export const ABORT_VALUE = 2;
+  export const MORE_TO_FOLLOW_VALUE = 2;
+  export const ABORT_VALUE = 3;
 
-  export const maxChars: number = 64; // Max number of characters that can be stored in the buffer.
+  export const maxChars: number = 1000; // Number of characters that can be stored in the buffer.
 
   const maxTimeoutMs = 100000; // Treated as Infinity.
 

--- a/test/integration-tests/utils.ts
+++ b/test/integration-tests/utils.ts
@@ -9,7 +9,13 @@ export const test = base.extend({
   }
 });
 
-// Wrappers to call shell functions in browser context.
+export function sequenceOfLetters(n: number): string {
+  let ret = '';
+  for (let i = 0; i < n; i++) {
+    ret += String.fromCharCode(97 + (i % 26));
+  }
+  return ret;
+}
 
 // Input multiple characters, one at a time. Support multi-character ANSI escape sequences.
 export async function shellInputsSimpleN(


### PR DESCRIPTION
When using SharedArrayBuffer for synchronous `stdin` whilst running a command, pasting more text than the size of the SAB buffer caused an error. This fixes that by supporting passing more than one buffer length for a single `stdin` request. It is tested using `vim` for a synchronous request and `js-test` for an asynchronous one.

Also increasing the buffer size to 1000 characters.

Fixes #152.