### PR TITLE
Use PROXYFS from wasm command if available

### DIFF
--- a/src/types/wasm_module.d.ts
+++ b/src/types/wasm_module.d.ts
@@ -3,7 +3,7 @@
  * matches the version of emscripten (4.0.9) that is used for WebAssembly command packages.
  *
  * Modified to add extra optional functions and properties to WasmModule such as ENV and
- * getEnvStrings, and to add IWebAssemblyModule.
+ * to add IWebAssemblyModule.
  */
 
 // TypeScript bindings for emscripten-generated code.  Automatically generated at compile time.
@@ -429,8 +429,11 @@ declare class FSNode {
 }
 interface WasmModule {
   ENV?: { [key: string]: string };
+  ERRNO_CODES: any;
+  FS?: any;
+  PATH?: any;
+  PROXYFS?: any;
   TTY?: any;
-  getEnvStrings?(): string[];
 }
 
 export type MainModule = WasmModule & typeof RuntimeExports;

--- a/test/util-wasm/build.sh
+++ b/test/util-wasm/build.sh
@@ -9,7 +9,7 @@ for name in ${names[@]}; do
         -Os \
         -sALLOW_MEMORY_GROWTH=1 \
         -sEXIT_RUNTIME=1 \
-        -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY \
+        -sEXPORTED_RUNTIME_METHODS=FS,ENV,TTY \
         -sFORCE_FILESYSTEM=1 \
         -sMODULARIZE=1 \
         $name.c \


### PR DESCRIPTION
When running a WebAssembly command, use the `PROXYFS` exported from that command if it is available, and fallback to using the one from `cockle_fs`. This fixes an obscure problem running `git init` in the top-level `/drive` directory.