### PR TITLE
Set env vars COCKLE_SHELL_ID and COCKLE_BROWSING_CONTEXT_ID

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -5,8 +5,14 @@ import { ansi } from './ansi';
  * commands.
  */
 export class Environment extends Map<string, string> {
-  constructor(color: boolean) {
+  constructor(color: boolean, shellId: string, browsingContextId: string | undefined) {
     super();
+    if (shellId) {
+      this.set('COCKLE_SHELL_ID', shellId);
+    }
+    if (browsingContextId) {
+      this.set('COCKLE_BROWSING_CONTEXT_ID', browsingContextId);
+    }
     if (color) {
       this.set('PS1', ansi.styleGreen + 'js-shell:' + ansi.styleReset + ' ');
       this.set('TERM', 'xterm-256color');

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -56,7 +56,7 @@ export class ShellImpl implements IShellImpl {
         options.callExternalCommand,
         options.callExternalTabComplete
       ),
-      environment: new Environment(options.color),
+      environment: new Environment(options.color, options.shellId, options.browsingContextId),
       history: new History(),
       shellId: options.shellId,
       terminate: this.terminate.bind(this),

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -551,7 +551,7 @@ test.describe('Shell', () => {
     });
   });
 
-  test.describe('constructor options', () => {
+  test.describe('constructor', () => {
     test('should support setting aliases', async ({ page }) => {
       const output = await page.evaluate(async () => {
         const aliases = { my_alias: 'target --something' };
@@ -580,6 +580,19 @@ test.describe('Shell', () => {
         return await shell.exitCode();
       });
       expect(exitCode).toEqual(1);
+    });
+
+    test('should set env vars for shellId and browsingContextId', async ({ page }) => {
+      const output = await page.evaluate(async () => {
+        const { shellManager, shellSetupEmpty } = globalThis.cockle;
+        // Use ShellManager so that browsingContextId is set.
+        const { output, shell } = await shellSetupEmpty({ shellManager });
+        await shell.inputLine('env | sort | grep COCKLE');
+        return output.text;
+      });
+      const lines = output.split('\r\n');
+      expect(lines[1]).toMatch(/^COCKLE_BROWSING_CONTEXT_ID=/);
+      expect(lines[2]).toMatch(/^COCKLE_SHELL_ID=/);
     });
   });
 


### PR DESCRIPTION
Set env vars `COCKLE_SHELL_ID` and `COCKLE_BROWSING_CONTEXT_ID` from the `Shell` constructor options `shellId` and `browsingContextId`.