### PR TITLE
Don't run all workflows on forks

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   check_release:
+    if: github.event_name == 'pull_request' || github.repository_owner == 'jupyterlite'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.repository_owner == 'jupyterlite'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
Don't run all workflows on forks of this repo, those that require secret keys or deploy to github pages.