### PR TITLE
Fix tests for vim 9.2

### DIFF
--- a/test/integration-tests/command/vim.test.ts
+++ b/test/integration-tests/command/vim.test.ts
@@ -4,7 +4,7 @@ import { shellLineSimple, test } from '../utils';
 test.describe('vim command', () => {
   test('should output version', async ({ page }) => {
     const output = await shellLineSimple(page, 'vim --version');
-    expect(output).toMatch(/^vim --version\r\nVIM - Vi IMproved 9.1/);
+    expect(output).toMatch(/^vim --version\r\nVIM - Vi IMproved 9.2/);
   });
 
   const stdinOptions = ['sab', 'sw'];


### PR DESCRIPTION
Fix tests for `vim` 9.2, just released on emscripten-forge.