### PR TITLE
Fix exitCode after pipe

### DIFF
--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -632,7 +632,7 @@ export class ShellImpl implements IShellImpl {
           for (let i = 0; i < n; i++) {
             const input = i === 0 ? stdin : prevPipe!.input;
             const output = i < n - 1 ? (prevPipe = new Pipe()) : stdout;
-            await this._runCommand(commands[i], input, output, stderr);
+            exitCode = await this._runCommand(commands[i], input, output, stderr);
           }
         } else {
           // This should not occur.

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -96,6 +96,20 @@ test.describe('Shell', () => {
       expect(exitCodes).toEqual([0, 2]);
     });
 
+    test('pipe should set IShell.exitCode', async ({ page }) => {
+      const output = await page.evaluate(async cmdName => {
+        const { output, shell } = await globalThis.cockle.shellSetupSimple();
+        await shell.inputLine('cat file2 | wc');
+        const ret = [output.textAndClear(), await shell.exitCode()];
+        await shell.inputLine('cat unknown | wc');
+        return ret.concat([output.textAndClear(), await shell.exitCode()]);
+      });
+      expect(output[0]).toMatch('\r\n      1       5      27\r\n');
+      expect(output[1]).toBe(0);
+      expect(output[2]).toMatch('\r\ncat: unknown: No such file or directory\r\n');
+      expect(output[3]).toBe(0);
+    });
+
     test('should set $? (exit code)', async ({ page }) => {
       const output = await shellLineSimpleN(page, [
         // WASM command success.
@@ -604,7 +618,7 @@ test.describe('Shell', () => {
         await shell.inputLine('env | grep PS1');
         return await shell.exitCode();
       });
-      expect(exitCode).toEqual(1);
+      expect(exitCode).toEqual(0);
     });
 
     test('should set env vars for shellId and browsingContextId', async ({ page }) => {


### PR DESCRIPTION
Fix propagation of `exitCode` after use of pipe, such as for `cat months.txt | wc`. Previously this always returned an exit code of 1.