### PR TITLE
Implement `poll` on `IInput`

### DIFF
--- a/src/buffered_io/defs.ts
+++ b/src/buffered_io/defs.ts
@@ -15,7 +15,7 @@ export interface IWorkerIO {
   enable(): Promise<void>;
   get enabled(): boolean;
   // Negative timeoutMs means wait forever (no/infinite timeout).
-  poll(timeoutMs: number): number;
+  pollInput(timeoutMs: number): boolean;
   read(maxChars: number | null): number[];
   // Negative timeoutMs means wait forever (infinite timeout).
   readAsync(maxChars: number | null, timeoutMs: number): Promise<number[]>;

--- a/src/buffered_io/worker_io.ts
+++ b/src/buffered_io/worker_io.ts
@@ -33,9 +33,9 @@ export abstract class WorkerIO implements IWorkerIO {
     return this._enabled;
   }
 
-  poll(timeoutMs: number): number {
+  pollInput(timeoutMs: number): boolean {
     if (!this._enabled) {
-      throw new Error('WorkerIO.poll when disabled');
+      throw new Error('WorkerIO.pollInput when disabled');
     }
 
     let readable = this._readBuffer.length > 0;
@@ -47,12 +47,7 @@ export abstract class WorkerIO implements IWorkerIO {
       readable = this._readBuffer.length > 0;
     }
 
-    // Constants.
-    const POLLIN = 1;
-    const POLLOUT = 4;
-
-    const writable = true;
-    return (readable ? POLLIN : 0) | (writable ? POLLOUT : 0);
+    return readable;
   }
 
   read(maxChars: number | null): number[] {

--- a/src/callback_internal.ts
+++ b/src/callback_internal.ts
@@ -39,6 +39,10 @@ export interface IEnableBufferedStdinCallback {
   (enable: boolean): Promise<void>;
 }
 
+export interface IPollCallback {
+  (timeoutMs: number): boolean;
+}
+
 /**
  * Callback for worker to set IMainIO, to switch between SharedArrayBuffer and ServiceWorker.
  */

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -43,7 +43,13 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
     }
 
     function poll(stream: any, timeoutMs: number): number {
-      return workerIO.poll(timeoutMs);
+      // Constants.
+      const POLLIN = 1;
+      const POLLOUT = 4;
+
+      const readable = stdin.poll(timeoutMs);
+      const writable = true;
+      return (readable ? POLLIN : 0) | (writable ? POLLOUT : 0);
     }
 
     function read(

--- a/src/io/dummy_input.ts
+++ b/src/io/dummy_input.ts
@@ -9,6 +9,10 @@ export class DummyInput implements IInput {
     return false;
   }
 
+  poll(timeoutMs: number): boolean {
+    return false;
+  }
+
   async readAsync(maxChars: number | null): Promise<number[]> {
     return [];
   }

--- a/src/io/input.ts
+++ b/src/io/input.ts
@@ -1,6 +1,8 @@
 export interface IInput {
   isTerminal(): boolean;
 
+  poll(timeoutMs: number): boolean;
+
   /**
    * Async read of up to maxChars.
    * This is used by TypeScript/JavaScript commands, both builtin and external.

--- a/src/io/input_all.ts
+++ b/src/io/input_all.ts
@@ -5,6 +5,11 @@ export abstract class InputAll implements IInput {
     return false;
   }
 
+  poll(timeoutMs: number): boolean {
+    // Ignore timeout as all content is already available.
+    return this._index < this.buffer.length;
+  }
+
   /**
    * Read and return the entire contents of this input. No special character is required to indicate
    * the end of the input, it is just the end of the string. Should only be called once per object.
@@ -16,13 +21,10 @@ export abstract class InputAll implements IInput {
   }
 
   read(maxChars: number | null): number[] {
-    if (this._buffer === undefined) {
-      this._buffer = this.readAll();
-      this._index = 0;
-    }
+    const { buffer } = this;
 
-    if (this._index < this._buffer.length) {
-      const char = this._buffer[this._index++];
+    if (this._index < buffer.length) {
+      const char = buffer[this._index++];
       const ret: number[] = [];
       for (let i = 0; i < char.length; i++) {
         ret.push(char.charCodeAt(i));
@@ -31,6 +33,14 @@ export abstract class InputAll implements IInput {
     } else {
       return [];
     }
+  }
+
+  private get buffer(): string {
+    if (this._buffer === undefined) {
+      this._buffer = this.readAll();
+      this._index = 0;
+    }
+    return this._buffer;
   }
 
   private _buffer?: string;

--- a/src/io/terminal_input.ts
+++ b/src/io/terminal_input.ts
@@ -1,14 +1,19 @@
 import type { IInput } from './input';
-import type { IStdinAsyncCallback, IStdinCallback } from '../callback_internal';
+import type { IPollCallback, IStdinAsyncCallback, IStdinCallback } from '../callback_internal';
 
 export class TerminalInput implements IInput {
   constructor(
+    readonly pollCallback: IPollCallback,
     readonly stdinCallback: IStdinCallback,
     readonly stdinAsyncCallback: IStdinAsyncCallback
   ) {}
 
   isTerminal(): boolean {
     return true;
+  }
+
+  poll(timeoutMs: number): boolean {
+    return this.pollCallback(timeoutMs);
   }
 
   async readAsync(maxChars: number | null): Promise<number[]> {

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -614,8 +614,9 @@ export class ShellImpl implements IShellImpl {
 
     let exitCode!: number;
     const stdin = new TerminalInput(
-      this._stdinCallback.bind(this),
-      this._stdinAsyncCallback.bind(this)
+      timeoutMs => this._runContext.workerIO.pollInput(timeoutMs),
+      maxChars => this._runContext.workerIO.read(maxChars),
+      maxChars => this._runContext.workerIO.readAsync(maxChars, -1) // -1 means infinite wait
     );
     const stdout = new TerminalOutput(this.output.bind(this));
     const stderr = this._stderr;
@@ -738,15 +739,6 @@ export class ShellImpl implements IShellImpl {
   private _setExitCode(exitCode: number) {
     this._exitCode = exitCode;
     this.environment.set('?', `${exitCode}`);
-  }
-
-  private _stdinCallback(maxChars: number | null): number[] {
-    return this._runContext.workerIO.read(maxChars);
-  }
-
-  private async _stdinAsyncCallback(maxChars: number | null): Promise<number[]> {
-    // timeoutMs of -1 for infinite wait.
-    return await this._runContext.workerIO.readAsync(maxChars, -1);
   }
 
   private _commandLine: ICommandLine = { text: '', cursorIndex: 0 };

--- a/test/integration-tests/command/cat.test.ts
+++ b/test/integration-tests/command/cat.test.ts
@@ -11,4 +11,14 @@ test.describe('cat command', () => {
     const lines = output[1].split('\r\n');
     expect(lines).toHaveLength(20002);
   });
+
+  test('should accept redirected input', async ({ page }) => {
+    const output = await shellLineSimple(page, 'cat < file2');
+    expect(output).toMatch(/^cat < file2\r\nSome other file\r\nSecond line\r\n/);
+  });
+
+  test('should accept input from pipe', async ({ page }) => {
+    const output = await shellLineSimple(page, 'cat file2 | cat');
+    expect(output).toMatch(/^cat file2 | cat\r\nSome other file\r\nSecond line\r\n/);
+  });
 });

--- a/test/integration-tests/command/nano.test.ts
+++ b/test/integration-tests/command/nano.test.ts
@@ -90,4 +90,14 @@ test.describe('nano command', () => {
       expect(output).toMatch(/^cat file2\r\nSecond line\r\n/);
     });
   });
+
+  test('should error on redirect stdin from file', async ({ page }) => {
+    const output = await shellLineSimple(page, 'nano < file2');
+    expect(output).toMatch('\r\nError opening terminal');
+  });
+
+  test('should error on stdin pipe', async ({ page }) => {
+    const output = await shellLineSimple(page, 'cat file2 | nano');
+    expect(output).toMatch('\r\nError opening terminal');
+  });
 });

--- a/test/integration-tests/command/vim.test.ts
+++ b/test/integration-tests/command/vim.test.ts
@@ -104,4 +104,14 @@ test.describe('vim command', () => {
       expect(output).toMatch(/^cat out\r\naXYbc\r\ndef\r\n/);
     });
   });
+
+  test('should error on redirect stdin from file', async ({ page }) => {
+    const output = await shellLineSimple(page, 'vim < file2');
+    expect(output).toMatch('\r\nVim: Warning: Input is not from a terminal\r\n');
+  });
+
+  test('should error on stdin pipe', async ({ page }) => {
+    const output = await shellLineSimple(page, 'cat file2 | vim');
+    expect(output).toMatch('\r\nVim: Warning: Input is not from a terminal\r\n');
+  });
 });


### PR DESCRIPTION
Currently `poll` is implemented only on `IWorkerIO`, so even if `stdin` is coming from a file `poll` will always access the terminal input from the main UI thread. Here it is moved to `IInput` and only `TerminalInput` accesses the `IWorkerIO` function. Also separating the polling of input and output so that the output check occurs in `WasmCommandRunner` - these always return `true` currently but this may change in the future.

There is no functional change here, but I've added a few extra tests to avoid future regressions in this area.