### PR TITLE
Always pass TERM env var to wasm commands

### DIFF
--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -124,7 +124,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
 
           if (ENV !== undefined) {
             // Copy environment variables into command.
-            context.environment.copyIntoCommand(module.ENV!, stdout.isTerminal());
+            context.environment.copyIntoCommand(module.ENV!);
           }
 
           if (TTY !== undefined) {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -25,11 +25,9 @@ export class Environment extends Map<string, string> {
   /**
    * Copy environment variables into a command before it is run.
    */
-  copyIntoCommand(target: { [key: string]: string }, isTerminal: boolean) {
+  copyIntoCommand(target: { [key: string]: string }) {
     for (const [key, value] of this.entries()) {
-      if (isTerminal || key !== 'TERM') {
-        target[key] = value;
-      }
+      target[key] = value;
     }
   }
 

--- a/test/integration-tests/command/less.test.ts
+++ b/test/integration-tests/command/less.test.ts
@@ -1,10 +1,49 @@
 import { expect } from '@playwright/test';
-import { shellLineSimple, test } from '../utils';
+import { shellLineSimple, shellLineSimpleN, test } from '../utils';
 
 test.describe('less command', () => {
   test('should output version', async ({ page }) => {
     const output = await shellLineSimple(page, 'less --version');
     expect(output).toMatch(/^less --version\r\nless \d{3} \(PCRE2 regular expressions\)\r\n/);
+  });
+
+  test('should write to file from named file', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { output, shell } = await globalThis.cockle.shellSetupSimple({ color: true });
+      await shell.inputLine('less file2 > out');
+      const exitCode = await shell.exitCode();
+      output.clear();
+      await shell.inputLine('cat out');
+      return [exitCode, output.text];
+    });
+    expect(output[0]).toBe(0);
+    expect(output[1]).toMatch('cat out\r\nSome other file\r\nSecond line\r\n');
+  });
+
+  test('should write to file from redirected stdin', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { output, shell } = await globalThis.cockle.shellSetupSimple({ color: true });
+      await shell.inputLine('less < file2 > out');
+      const exitCode = await shell.exitCode();
+      output.clear();
+      await shell.inputLine('cat out');
+      return [exitCode, output.text];
+    });
+    expect(output[0]).toBe(0);
+    expect(output[1]).toMatch('cat out\r\nSome other file\r\nSecond line\r\n');
+  });
+
+  test('should write to file from pipe', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { output, shell } = await globalThis.cockle.shellSetupSimple({ color: true });
+      await shell.inputLine('cat file2 | less > out');
+      const exitCode = await shell.exitCode();
+      output.clear();
+      await shell.inputLine('cat out');
+      return [exitCode, output.text];
+    });
+    expect(output[0]).toBe(0);
+    expect(output[1]).toMatch('cat out\r\nSome other file\r\nSecond line\r\n');
   });
 
   /*

--- a/test/integration-tests/command/less.test.ts
+++ b/test/integration-tests/command/less.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { shellLineSimple, shellLineSimpleN, test } from '../utils';
+import { shellLineSimple, test } from '../utils';
 
 test.describe('less command', () => {
   test('should output version', async ({ page }) => {


### PR DESCRIPTION
Always pass `TERM` env var to wasm commands, along with all of the others. Previously this was filtered out if `stdout` wasn't a terminal, but now that the wasm `isatty` works correctly via `_outputHandler` we can pass it.

This fixes a bug using `less months.txt > out` which reports `terminals database is inaccessible` if `TERM` is not defined.