### PR TITLE
Fix `less` reading from pipe and redirected input file

### DIFF
--- a/src/buffered_io/worker_io.ts
+++ b/src/buffered_io/worker_io.ts
@@ -40,6 +40,7 @@ export abstract class WorkerIO implements IWorkerIO {
 
     let readable = this._readBuffer.length > 0;
     // Negative timeoutMs means wait forever (infinite timeout).
+    // Zero timeout means return immediately.
     if (!readable && timeoutMs !== 0) {
       const chars = this._getStdin(timeoutMs);
       this._postRead(chars);
@@ -87,8 +88,8 @@ export abstract class WorkerIO implements IWorkerIO {
     }
 
     // Negative timeoutMs means wait forever (infinite timeout).
+    // Zero timeout means return immediately.
     while (!this._canReturnNow()) {
-      //const chars = this._getStdin(-1);
       const chars = await this._getStdinAsync(timeoutMs);
       this._postRead(chars);
       if (chars === '' && timeoutMs >= 0) {

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -21,7 +21,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
   async run(context: IRunContext): Promise<number> {
     const { name, args, workerIO, fileSystem, stdin, stdout, stderr, termios, size } = context;
     const { wasmBaseUrl } = this.module.loader;
-    const avoidInfinitePollTimeout = (name === "less");
+    const avoidInfinitePollTimeout = name === 'less';
 
     const start = Date.now();
     const wasmModule = this.module.loader.getWasmModule(this.packageName, this.moduleName);

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -21,6 +21,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
   async run(context: IRunContext): Promise<number> {
     const { name, args, workerIO, fileSystem, stdin, stdout, stderr, termios, size } = context;
     const { wasmBaseUrl } = this.module.loader;
+    const avoidInfinitePollTimeout = (name === "less");
 
     const start = Date.now();
     const wasmModule = this.module.loader.getWasmModule(this.packageName, this.moduleName);
@@ -47,7 +48,13 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
       const POLLIN = 1;
       const POLLOUT = 4;
 
-      const readable = stdin.poll(timeoutMs);
+      if (avoidInfinitePollTimeout && timeoutMs < 0) {
+        // `less` polls multiple file descriptors at the same time with infinite timeout which end
+        // up running sequentially here, workaround is for them to return immediately.
+        timeoutMs = 0;
+      }
+
+      const readable = stdin.finished ? workerIO.pollInput(timeoutMs) : stdin.poll(timeoutMs);
       const writable = true;
       return (readable ? POLLIN : 0) | (writable ? POLLOUT : 0);
     }
@@ -63,7 +70,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
         // No buffer to store in.
         return 0;
       }
-      let chars = stdin.read(length);
+      let chars = stdin.finished ? workerIO.read(length) : stdin.read(length);
       if (chars.length === 1 && chars[0] === 4) {
         chars = [];
       }
@@ -128,15 +135,21 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
           }
 
           if (TTY !== undefined) {
+            const { default_tty_ops, default_tty1_ops, stream_ops } = module.TTY;
+
             // Monkey patch get/set termios and get window size.
-            module.TTY.default_tty_ops.ioctl_tcgets = getTermios;
-            module.TTY.default_tty_ops.ioctl_tcsets = setTermios;
-            module.TTY.default_tty_ops.ioctl_tiocgwinsz = getSize;
+            default_tty_ops.ioctl_tcgets = getTermios;
+            default_tty_ops.ioctl_tcsets = setTermios;
+            default_tty_ops.ioctl_tiocgwinsz = getSize;
+
+            default_tty1_ops.ioctl_tcgets = getTermios;
+            default_tty1_ops.ioctl_tcsets = setTermios;
+            default_tty1_ops.ioctl_tiocgwinsz = getSize;
 
             // May only need to be for some TTYs?
-            module.TTY.stream_ops.poll = poll;
-            module.TTY.stream_ops.read = read;
-            module.TTY.stream_ops.write = write;
+            stream_ops.poll = poll;
+            stream_ops.read = read;
+            stream_ops.write = write;
           }
         }
       ],

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -57,19 +57,15 @@ export class Environment extends Map<string, string> {
     if (rows >= 1) {
       const rowsString = rows.toString();
       this.set('LINES', rowsString);
-      this.set('LESS_LINES', rowsString);
     } else {
       this.delete('LINES');
-      this.delete('LESS_LINES');
     }
 
     if (columns >= 1) {
       const columnsString = columns.toString();
       this.set('COLUMNS', columnsString);
-      this.set('LESS_COLUMNS', columnsString);
     } else {
       this.delete('COLUMNS');
-      this.delete('LESS_COLUMNS');
     }
   }
 }

--- a/src/io/dummy_input.ts
+++ b/src/io/dummy_input.ts
@@ -5,6 +5,10 @@ import type { IInput } from './input';
  * Used by IContext when no command is running, should never be read from.
  */
 export class DummyInput implements IInput {
+  get finished(): boolean {
+    return false;
+  }
+
   isTerminal(): boolean {
     return false;
   }

--- a/src/io/input.ts
+++ b/src/io/input.ts
@@ -1,4 +1,6 @@
 export interface IInput {
+  finished: boolean;
+
   isTerminal(): boolean;
 
   poll(timeoutMs: number): boolean;

--- a/src/io/input_all.ts
+++ b/src/io/input_all.ts
@@ -1,13 +1,17 @@
 import type { IInput } from './input';
 
 export abstract class InputAll implements IInput {
+  get finished(): boolean {
+    return this._index >= this.buffer.length;
+  }
+
   isTerminal(): boolean {
     return false;
   }
 
   poll(timeoutMs: number): boolean {
     // Ignore timeout as all content is already available.
-    return this._index < this.buffer.length;
+    return !this.finished;
   }
 
   /**

--- a/src/io/terminal_input.ts
+++ b/src/io/terminal_input.ts
@@ -8,6 +8,10 @@ export class TerminalInput implements IInput {
     readonly stdinAsyncCallback: IStdinAsyncCallback
   ) {}
 
+  get finished(): boolean {
+    return false;
+  }
+
   isTerminal(): boolean {
     return true;
   }

--- a/test/integration-tests/command/less.test.ts
+++ b/test/integration-tests/command/less.test.ts
@@ -46,20 +46,39 @@ test.describe('less command', () => {
     expect(output[1]).toMatch('cat out\r\nSome other file\r\nSecond line\r\n');
   });
 
-  /*
   const stdinOptions = ['sab', 'sw'];
   stdinOptions.forEach(stdinOption => {
-    test(`should run interactively and exit using ${stdinOption}`, async ({ page }) => {
+    test(`should read from named file and quit using ${stdinOption}`, async ({ page }) => {
       await page.evaluate(async stdinOption => {
         const { shellSetupSimple, terminalInput } = globalThis.cockle;
         const { shell } = await shellSetupSimple({ color: true, stdinOption });
-        await Promise.all([
-          shell.inputLine('less file2'),
-          terminalInput(shell, ['q']) // q key to exit.
-        ]);
+        const cmd = shell.inputLine('less file2');
+        terminalInput(shell, ['q']) // q key to exit.
+        await cmd;
+      }, stdinOption);
+      // If less does not close, test will timeout.
+    });
+
+    test(`should read redirected file from stdin and quit using ${stdinOption}`, async ({ page }) => {
+      await page.evaluate(async stdinOption => {
+        const { shellSetupSimple, terminalInput } = globalThis.cockle;
+        const { shell } = await shellSetupSimple({ color: true, stdinOption });
+        const cmd = shell.inputLine('less < file2');
+        terminalInput(shell, ['q']) // q key to exit.
+        await cmd;
+      }, stdinOption);
+      // If less does not close, test will timeout.
+    });
+
+    test(`should read from pipe and quit using ${stdinOption}`, async ({ page }) => {
+      await page.evaluate(async stdinOption => {
+        const { shellSetupSimple, terminalInput } = globalThis.cockle;
+        const { shell } = await shellSetupSimple({ color: true, stdinOption });
+        const cmd = shell.inputLine('cat file2 | less');
+        terminalInput(shell, ['q']) // q key to exit.
+        await cmd;
       }, stdinOption);
       // If less does not close, test will timeout.
     });
   });
-  */
 });

--- a/test/integration-tests/command/less.test.ts
+++ b/test/integration-tests/command/less.test.ts
@@ -53,18 +53,20 @@ test.describe('less command', () => {
         const { shellSetupSimple, terminalInput } = globalThis.cockle;
         const { shell } = await shellSetupSimple({ color: true, stdinOption });
         const cmd = shell.inputLine('less file2');
-        terminalInput(shell, ['q']) // q key to exit.
+        terminalInput(shell, ['q']); // q key to exit.
         await cmd;
       }, stdinOption);
       // If less does not close, test will timeout.
     });
 
-    test(`should read redirected file from stdin and quit using ${stdinOption}`, async ({ page }) => {
+    test(`should read redirected file from stdin and quit using ${stdinOption}`, async ({
+      page
+    }) => {
       await page.evaluate(async stdinOption => {
         const { shellSetupSimple, terminalInput } = globalThis.cockle;
         const { shell } = await shellSetupSimple({ color: true, stdinOption });
         const cmd = shell.inputLine('less < file2');
-        terminalInput(shell, ['q']) // q key to exit.
+        terminalInput(shell, ['q']); // q key to exit.
         await cmd;
       }, stdinOption);
       // If less does not close, test will timeout.
@@ -75,7 +77,7 @@ test.describe('less command', () => {
         const { shellSetupSimple, terminalInput } = globalThis.cockle;
         const { shell } = await shellSetupSimple({ color: true, stdinOption });
         const cmd = shell.inputLine('cat file2 | less');
-        terminalInput(shell, ['q']) // q key to exit.
+        terminalInput(shell, ['q']); // q key to exit.
         await cmd;
       }, stdinOption);
       // If less does not close, test will timeout.

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -192,9 +192,7 @@ test.describe('Shell', () => {
         ret.push(output.textAndClear());
         return ret;
       });
-      expect(output[0]).toMatch(
-        '\r\nLINES=10\r\nCOLUMNS=44\r\n'
-      );
+      expect(output[0]).toMatch('\r\nLINES=10\r\nCOLUMNS=44\r\n');
       expect(output[1]).toMatch('\r\nCOLUMNS=45\r\n');
       expect(output[2]).toMatch('\r\nLINES=14\r\n');
     });

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -193,10 +193,10 @@ test.describe('Shell', () => {
         return ret;
       });
       expect(output[0]).toMatch(
-        '\r\nLINES=10\r\nLESS_LINES=10\r\nCOLUMNS=44\r\nLESS_COLUMNS=44\r\n'
+        '\r\nLINES=10\r\nCOLUMNS=44\r\n'
       );
-      expect(output[1]).toMatch('\r\nCOLUMNS=45\r\nLESS_COLUMNS=45\r\n');
-      expect(output[2]).toMatch('\r\nLINES=14\r\nLESS_LINES=14\r\n');
+      expect(output[1]).toMatch('\r\nCOLUMNS=45\r\n');
+      expect(output[2]).toMatch('\r\nLINES=14\r\n');
     });
   });
 


### PR DESCRIPTION
This fixes the following use cases for `less`:

```bash
less < months.txt
```

and

```bash
cat months.txt | less
```

Summary of changes:

1. `less` uses a file descriptor of `2` to check `termios` settings and terminal size. This is `/dev/tty1` in the emscripten build, which is used for `stderr` output. Here we solve the problem by monkey-patching the `termios` and window size functions onto `default_tty1_ops` and `default_tty_ops`.
2. The environment variables `LESS_COLUMNS` and `LESS_LINES` are no longer needed.
3. The `poll` and `read` calls from a file or pipe now drop back to accepting input from the terminal when the file/pipe are exhausted. Ideally we'd use separate streams/file descriptors for each but the emscripten implementation is restrictive here.
4. Infinite `poll` timeouts from `less` are now converted to timeouts of zero. This is because `less` polls two file descriptors at the same time but these are implemented sequentially and hence do not work as required. The workaround is the immediate return, which is successful for the `poll` and then `less` drops back to blocking reads without any subsequent polls.

Fixes #192 and #193.