### PR TITLE
Use performance timer

### DIFF
--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -23,7 +23,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
     const { wasmBaseUrl } = this.module.loader;
     const avoidInfinitePollTimeout = name === 'less';
 
-    const start = Date.now();
+    const start = performance.now();
     const wasmModule = this.module.loader.getWasmModule(this.packageName, this.moduleName);
     if (wasmModule === undefined) {
       throw new FindCommandError(name);
@@ -171,8 +171,8 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
       }
     }
 
-    const end = Date.now();
-    console.debug(`Cockle ${name} load and run time ${end - start} ms`);
+    const end = performance.now();
+    console.debug(`Cockle ${name} load and run time ${(end - start).toFixed(1)} ms`);
     return exitCode;
   }
 

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -439,9 +439,9 @@ export class ShellImpl implements IShellImpl {
     this.output('\x1b]11;?\x07');
 
     const timeoutMs = 100;
-    const start = Date.now();
+    const start = performance.now();
     const chars = await workerIO.readAsync(null, timeoutMs);
-    console.debug('Cockle theme change', Date.now() - start, 'ms');
+    console.debug('Cockle theme change', (performance.now() - start).toFixed(1), 'ms');
 
     termios.setDefaultShell();
     await this._options.enableBufferedStdinCallback(false);

--- a/test/integration-tests/command/sleep.test.ts
+++ b/test/integration-tests/command/sleep.test.ts
@@ -20,9 +20,9 @@ test.describe('sleep command', () => {
     test(`should sleep for ${sleep_s} s`, async ({ page }) => {
       const output = await page.evaluate(async sleep_s => {
         const { shell } = await globalThis.cockle.shellSetupSimple();
-        const start = Date.now();
+        const start = performance.now();
         await shell.inputLine(`sleep ${sleep_s}`);
-        const duration_ms = Date.now() - start;
+        const duration_ms = performance.now() - start;
         return [await shell.exitCode(), duration_ms];
       }, sleep_s);
       expect(output[0]).toBe(0);


### PR DESCRIPTION
Use `performance.now` rather than `Date.now` for high resolution timings.