### PR TITLE
Validate command names on registering

### DIFF
--- a/src/commands/command_registry.ts
+++ b/src/commands/command_registry.ts
@@ -82,14 +82,16 @@ export class CommandRegistry {
 
   registerExternalCommand(name: string, hasTabComplete: boolean): void {
     // Overwrite if name already registered.
-    this._map.set(
-      name,
-      new ExternalCommandRunner(
+    if (this._validName(name)) {
+      this._map.set(
         name,
-        this.callExternalCommand,
-        hasTabComplete ? this.callExternalTabComplete : undefined
-      )
-    );
+        new ExternalCommandRunner(
+          name,
+          this.callExternalCommand,
+          hasTabComplete ? this.callExternalTabComplete : undefined
+        )
+      );
+    }
   }
 
   /**
@@ -98,8 +100,24 @@ export class CommandRegistry {
   private _register(commandRunner: ICommandRunner) {
     // Should probably check not overwriting any command names
     for (const name of commandRunner.names()) {
-      this._map.set(name, commandRunner);
+      if (this._validName(name)) {
+        this._map.set(name, commandRunner);
+      }
     }
+  }
+
+  /**
+   * Return true if name is a valid command name.
+   * CommandRegistry will not register a command with an invalid name and will report it via
+   * console.warn. It will not raise an error as usually command registration occurs before a shell
+   * is up and running.
+   */
+  private _validName(name: string): boolean {
+    const valid = name.match(/^[\w-]+$/) !== null;
+    if (!valid) {
+      console.warn(`${name} is not a valid command name`);
+    }
+    return valid;
   }
 
   // Map of command name to runner.

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -632,6 +632,27 @@ test.describe('Shell', () => {
         expect(output).toMatch(expected);
       });
     });
+
+    ['spa ce', '£', 'br(', 's*', '"', '+', '🚀'].forEach(name => {
+      test(`should not register invalid command name '${name}'`, async ({ page }) => {
+        const output = await page.evaluate(async name => {
+          const { externalCommands, shellSetupEmpty } = globalThis.cockle;
+          // Add another entry to externalCommands with the invalid name.
+          externalCommands[name] = externalCommands['external-tab'];
+          const { output, shell } = await shellSetupEmpty({ externalCommands });
+          await shell.inputLine('which external-tab');
+          const ret = [await shell.exitCode(), output.textAndClear()];
+
+          await shell.inputLine(`which '${name}'`);
+          ret.push(await shell.exitCode(), output.text);
+          return ret;
+        }, name);
+        expect(output[0]).toBe(0);
+        expect(output[1]).toMatch('\r\nexternal-tab\r\n');
+        expect(output[2]).toBe(1);
+        expect(output[3]).toMatch(`\r\nwhich: no ${name} command\r\n`);
+      });
+    });
   });
 
   test.describe('themeChange', () => {


### PR DESCRIPTION
Validate command names when attempting to register them, acceptable characters are letters (upper and lowercase), digits, underscores and dashes. Invalid command names are not registered and they are reported via `console.warn`. They cannot be reported via the `shell` as it usually does not exist when commands are registered.

Fixes #177.