### PR TITLE
Fix backspace in wasm commands such as nano and vim

### DIFF
--- a/src/buffered_io/worker_io.ts
+++ b/src/buffered_io/worker_io.ts
@@ -69,8 +69,7 @@ export abstract class WorkerIO implements IWorkerIO {
       const chars = this._getStdin(-1);
       this._postRead(chars);
     }
-    const ret = this._readFromBuffer(maxChars);
-    return ret;
+    return this._readFromBuffer(maxChars);
   }
 
   async readAsync(maxChars: number | null, timeoutMs: number): Promise<number[]> {
@@ -207,7 +206,10 @@ export abstract class WorkerIO implements IWorkerIO {
           break;
         //case 8:
         case 127:
-          if (this._readBuffer.length > 0) {
+          if ((termiosFlags.c_lflag & Termios.LocalFlag.ICANON) === 0) {
+            temp.push(127);
+            this._readBuffer.push(127);
+          } else if (this._readBuffer.length > 0) {
             temp.push(127);
             this._readBuffer.pop();
           }

--- a/test/integration-tests/command/grep.test.ts
+++ b/test/integration-tests/command/grep.test.ts
@@ -28,4 +28,34 @@ test.describe('grep command', () => {
     expect(output[1]).toMatch(/^grep \^hello file3\r\nhello \r\n/);
     expect(output[2]).toMatch(/^grep hello\$ file3\r\n hello\r\n/);
   });
+
+  const stdinOptions = ['sab', 'sw'];
+  stdinOptions.forEach(stdinOption => {
+    test(`should accept stdin via ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { keys, shellSetupEmpty, terminalInput } = globalThis.cockle;
+        const { shell, output } = await shellSetupEmpty({ stdinOption });
+        const { enter, EOT } = keys;
+        const cmd = shell.inputLine('grep o');
+        await terminalInput(shell, [...('xyz' + enter + 'aobc' + enter + EOT)]);
+        await cmd;
+        return output.text;
+      }, stdinOption);
+      expect(output).toMatch(/^grep o\r\nxyz\r\naobc\r\naobc\r\n/);
+    });
+
+    test(`should accept stdin backspace via ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { keys, shellSetupEmpty, terminalInput } = globalThis.cockle;
+        const { shell, output } = await shellSetupEmpty({ stdinOption });
+        const { backspace, enter, EOT } = keys;
+        const cmd = shell.inputLine('grep o');
+        await terminalInput(shell, [...('aoboc' + backspace + enter + EOT)]);
+        await cmd;
+        return output.text;
+      }, stdinOption);
+      const lines = output.split('\r\n');
+      expect(lines[2]).toBe('aobo'); // Check output line but not input line.
+    });
+  });
 });

--- a/test/integration-tests/command/nano.test.ts
+++ b/test/integration-tests/command/nano.test.ts
@@ -88,6 +88,54 @@ test.describe('nano command', () => {
       }, stdinOption);
       expect(output).toMatch(/^cat file2\r\nSecond line\r\n/);
     });
+
+    test(`should support backspace using ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { keys, shellSetupSimple, terminalInput } = globalThis.cockle;
+        const { shell, output } = await shellSetupSimple({ color: true, stdinOption });
+        const { backspace, enter, leftArrow } = keys;
+        const endOfLine = '\x05'; // Ctrl-E
+        const exit = '\x18'; // Ctrl-X
+        const writeFile = '\x0f'; // Ctrl-O
+        const cmd = shell.inputLine('nano file1');
+        await terminalInput(shell, [
+          endOfLine,
+          'Z',
+          leftArrow,
+          leftArrow,
+          backspace,
+          'L',
+          writeFile,
+          enter,
+          exit
+        ]);
+        await cmd;
+        output.clear();
+        await shell.inputLine('cat file1');
+        return output.text;
+      }, stdinOption);
+      expect(output).toMatch(/^cat file1\r\nContents of the fiLeZ\r\n/);
+    });
+
+    test(`should support backspace when saving filename using ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { keys, shellSetupSimple, terminalInput } = globalThis.cockle;
+        const { shell, output } = await shellSetupSimple({ color: true, stdinOption });
+        const { backspace, enter } = keys;
+        const exit = '\x18'; // Ctrl-X
+        const writeFile = '\x0f'; // Ctrl-O
+        const cmd = shell.inputLine('nano');
+        await terminalInput(shell, [
+          ...('AZ' + writeFile + 'a.tZ' + backspace + 'xt' + enter + exit)
+        ]);
+        await cmd;
+        output.clear();
+        await shell.inputLine('cat a.txt');
+        return output.text;
+      }, stdinOption);
+      // If backspace fails, filename will be incorrect.
+      expect(output).toMatch(/^cat a.txt\r\nAZ\r\n/);
+    });
   });
 
   test('should error on redirect stdin from file', async ({ page }) => {

--- a/test/integration-tests/command/vim.test.ts
+++ b/test/integration-tests/command/vim.test.ts
@@ -113,6 +113,44 @@ test.describe('vim command', () => {
       }, stdinOption);
       expect(output).toMatch(/^cat out\r\naXYbc\r\ndef\r\n/);
     });
+
+    test(`should support backspace when editing using ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { shell, output } = await globalThis.cockle.shellSetupSimple({
+          color: true,
+          stdinOption
+        });
+        const { keys, terminalInput } = globalThis.cockle;
+        const { backspace, delete_, escape } = keys;
+        const cmd = shell.inputLine('vim file1');
+        await terminalInput(shell, [
+          ...('$' + backspace + 'iz' + escape + backspace + backspace + delete_ + escape + ':wq\r')
+        ]);
+        await cmd;
+        output.clear();
+        await shell.inputLine('cat file1');
+        return output.text;
+      }, stdinOption);
+      expect(output).toMatch(/^cat file1\r\nContents of the izle\r\n/);
+    });
+
+    test(`should support backspace when saving using ${stdinOption}`, async ({ page }) => {
+      const output = await page.evaluate(async stdinOption => {
+        const { shell, output } = await globalThis.cockle.shellSetupSimple({
+          color: true,
+          stdinOption
+        });
+        const { keys, terminalInput } = globalThis.cockle;
+        const { backspace, escape } = keys;
+        const cmd = shell.inputLine('vim file1');
+        await terminalInput(shell, [...('iz' + escape + ':x' + backspace + 'wq\r')]);
+        await cmd;
+        output.clear();
+        await shell.inputLine('cat file1');
+        return output.text;
+      }, stdinOption);
+      expect(output).toMatch(/^cat file1\r\nzContents of the file\r\n/);
+    });
   });
 
   test('should error on redirect stdin from file', async ({ page }) => {


### PR DESCRIPTION
Version 1.5.0 introduced a regression when using backspace in wasm commands, in particular `nano` and `vim`. This PR fixes the bug.

Fixes #317.