### PR TITLE
Add optional callback to add query params to fetches of files at runtime

### DIFF
--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -324,7 +324,8 @@ export abstract class BaseShell implements IShell {
       proxy(this.enableBufferedStdinCallback.bind(this)),
       proxy(options.outputCallback),
       proxy(this._setMainIO.bind(this)),
-      proxy(this.dispose.bind(this)) // terminateCallback
+      proxy(this.dispose.bind(this)), // terminateCallback
+      options.wasmUrlQueryParams !== undefined ? proxy(options.wasmUrlQueryParams) : undefined
     );
 
     // Register sendStdinNow callback only after this._remote has been initialized.

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -19,7 +19,8 @@ export abstract class BaseShellWorker implements IShellWorker {
     enableBufferedStdinCallback: IShellWorker.IProxyEnableBufferedStdinCallback,
     outputCallback: IShellWorker.IProxyOutputCallback,
     setMainIOCallback: IShellWorker.IProxySetMainIOCallback,
-    terminateCallback: IShellWorker.IProxyTerminateCallback
+    terminateCallback: IShellWorker.IProxyTerminateCallback,
+    wasmUrlQueryParamsCallback?: IShellWorker.IProxyQueryParamsCallback
   ) {
     // Create IWorkerIO equivalents of the IMainIO used in the main UI thread (BaseShell class).
     this._stdinContext = new StdinContext(setMainIOCallback, this._setWorkerIO.bind(this));
@@ -78,7 +79,8 @@ export abstract class BaseShellWorker implements IShellWorker {
       terminateCallback: this._terminateCallback.bind(this),
       workerIO: this._workerIO,
       stdinContext: this._stdinContext,
-      termios: this._termios
+      termios: this._termios,
+      wasmUrlQueryParamsCallback
     });
     await this._shellImpl.initialize();
   }

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -19,6 +19,13 @@ export interface IInitDriveFSCallback {
 }
 
 /**
+ * Return dictionary of query params to be used when fetching the specified filename.
+ */
+export interface IQueryParamsCallback {
+  (filename: string): { [key: string]: string };
+}
+
+/**
  * Return window size as [rows, columns] where rows and columns are integers >= 0.
  * If the size is unknown they will be zero.
  */

--- a/src/commands/command_module_loader.ts
+++ b/src/commands/command_module_loader.ts
@@ -12,6 +12,7 @@ import { joinURL } from '../utils';
 export class CommandModuleLoader {
   constructor(
     readonly wasmBaseUrl: string,
+    readonly wasmUrlQueryParamsCallback: (filename: string) => Promise<string>,
     readonly downloadModuleCallback: IShellWorker.IProxyDownloadModuleCallback
   ) {}
 
@@ -20,11 +21,11 @@ export class CommandModuleLoader {
    * If loading fails return undefined, and caller is responsible for reporting this to the user if
    * appropriate.
    */
-  public getJavaScriptModule(
+  public async getJavaScriptModule(
     packageName: string,
     moduleName: string
-  ): IJavaScriptModule | undefined {
-    const module = this._getModule(packageName, moduleName, false);
+  ): Promise<IJavaScriptModule | undefined> {
+    const module = await this._getModule(packageName, moduleName, false);
     return module !== undefined ? (module as IJavaScriptModule) : undefined;
   }
 
@@ -33,17 +34,22 @@ export class CommandModuleLoader {
    * If loading fails return undefined, and caller is responsible for reporting this to the user if
    * appropriate.
    */
-  public getWasmModule(packageName: string, moduleName: string): IWebAssemblyModule | undefined {
-    const module = this._getModule(packageName, moduleName, true);
+  public async getWasmModule(
+    packageName: string,
+    moduleName: string
+  ): Promise<IWebAssemblyModule | undefined> {
+    const module = await this._getModule(packageName, moduleName, true);
     return module !== undefined ? (module as IWebAssemblyModule) : undefined;
   }
 
-  private _getModule(packageName: string, moduleName: string, wasm: boolean): any {
+  private async _getModule(packageName: string, moduleName: string, wasm: boolean): Promise<any> {
     let module = this.cache.get(packageName, moduleName);
     if (module === undefined) {
       // Maybe should use @jupyterlab/coreutils.URLExt to combine URL components.
       const filename = this.cache.key(packageName, moduleName) + '.js';
-      const url = joinURL(this.wasmBaseUrl, filename);
+      const queryParams = await this.wasmUrlQueryParamsCallback(filename);
+      const url = joinURL(this.wasmBaseUrl, filename + queryParams);
+
       console.log(`Cockle loading ${wasm ? 'WebAssembly' : 'JavaScript'} module from ${url}`);
 
       this.downloadModuleCallback(packageName, moduleName, true);

--- a/src/commands/javascript_command_runner.ts
+++ b/src/commands/javascript_command_runner.ts
@@ -17,7 +17,10 @@ export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
 
   async run(context: IRunContext): Promise<number> {
     const { name } = context;
-    const jsModule = this.module.loader.getJavaScriptModule(this.packageName, this.moduleName);
+    const jsModule = await this.module.loader.getJavaScriptModule(
+      this.packageName,
+      this.moduleName
+    );
     if (jsModule === undefined) {
       throw new FindCommandError(name);
     }
@@ -51,7 +54,10 @@ export class JavascriptCommandRunner extends DynamicallyLoadedCommandRunner {
   }
 
   async tabComplete(context: ITabCompleteContext): Promise<ITabCompleteResult> {
-    const jsModule = this.module.loader.getJavaScriptModule(this.packageName, this.moduleName);
+    const jsModule = await this.module.loader.getJavaScriptModule(
+      this.packageName,
+      this.moduleName
+    );
     if (jsModule !== undefined && Object.prototype.hasOwnProperty.call(jsModule, 'tabComplete')) {
       if (jsModule.tabComplete !== undefined) {
         const { name, args, shellId } = context;

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -24,7 +24,7 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
     const avoidInfinitePollTimeout = name === 'less';
 
     const start = performance.now();
-    const wasmModule = this.module.loader.getWasmModule(this.packageName, this.moduleName);
+    const wasmModule = await this.module.loader.getWasmModule(this.packageName, this.moduleName);
     if (wasmModule === undefined) {
       throw new FindCommandError(name);
     }

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -1,6 +1,6 @@
 import type { IObservableDisposable } from '@lumino/disposable';
 import type { IHandleStdin, IStdinReply, IStdinRequest } from './buffered_io';
-import type { IOutputCallback } from './callback';
+import type { IOutputCallback, IQueryParamsCallback } from './callback';
 import type { IExternalCommand } from './external_command';
 
 export interface IShell extends IObservableDisposable {
@@ -28,8 +28,27 @@ export namespace IShell {
     color?: boolean;
     mountpoint?: string;
     cwd?: string;
+
+    /**
+     * Base URL used for stdin and DriveFS requests via ServiceWorker.
+     */
     baseUrl: string;
+
+    /**
+     * Base URL used for fetching WebAssembly and JavaScript command files, and
+     * `cockle-config.json`.
+     */
     wasmBaseUrl: string;
+
+    /**
+     * Optional callback to return the query parameters to append to the URL when cockle fetches a
+     * file at runtime such as a WebAssembly or JavaScript command package, or `cockle-config.json`.
+     * The callback is only called for `.js` and `.json` files. Separate fetches for `.wasm` and
+     * `.data` files that are autoloaded for WebAssembly command packages do not use query
+     * parameters.
+     */
+    wasmUrlQueryParams?: IQueryParamsCallback;
+
     browsingContextId?: string;
     shellManager?: IShellManager; // If specified, register this shell with shellManager
     aliases?: { [key: string]: string };

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -1,6 +1,6 @@
 import type { ProxyMarked, Remote } from 'comlink';
 import type { IWorkerIO } from './buffered_io';
-import type { IInitDriveFSCallback, IOutputCallback } from './callback';
+import type { IInitDriveFSCallback, IOutputCallback, IQueryParamsCallback } from './callback';
 import type {
   ICallExternalCommand,
   ICallExternalTabComplete,
@@ -50,7 +50,8 @@ interface IShellCommon {
     enableBufferedStdinCallback: IShellWorker.IProxyEnableBufferedStdinCallback,
     outputCallback: IShellWorker.IProxyOutputCallback,
     setMainIOCallback: IShellWorker.IProxySetMainIOCallback,
-    terminateCallback: IShellWorker.IProxyTerminateCallback
+    terminateCallback: IShellWorker.IProxyTerminateCallback,
+    wasmUrlQueryParamsCallback?: IShellWorker.IProxyQueryParamsCallback
   ): void;
 
   exitCode: number;
@@ -76,6 +77,7 @@ export namespace IShellWorker {
     extends IEnableBufferedStdinCallback,
       ProxyMarked {}
   export interface IProxyOutputCallback extends IOutputCallback, ProxyMarked {}
+  export interface IProxyQueryParamsCallback extends IQueryParamsCallback, ProxyMarked {}
   export interface IProxySetMainIOCallback extends ISetMainIOCallback, ProxyMarked {}
   export interface IProxyTerminateCallback extends ITerminateCallback, ProxyMarked {}
 
@@ -98,5 +100,6 @@ export namespace IShellImpl {
     workerIO: IWorkerIO;
     stdinContext: IStdinContext;
     termios: Termios.Termios;
+    wasmUrlQueryParamsCallback?: IShellWorker.IProxyQueryParamsCallback;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export * from './arguments';
 export { BaseShell } from './base_shell';
 export { BaseShellWorker } from './base_shell_worker';
 export { IHandleStdin, IStdinReply, IStdinRequest } from './buffered_io';
-export { IOutputCallback } from './callback';
+export * from './callback';
 export {
   IExternalRunContext,
   IExternalTabCompleteContext,

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -32,6 +32,7 @@ export class ShellImpl implements IShellImpl {
     this._options = options;
     this._commandModuleLoader = new CommandModuleLoader(
       options.wasmBaseUrl,
+      this._wasmUrlQueryParams.bind(this),
       options.downloadModuleCallback
     );
 
@@ -467,7 +468,7 @@ export class ShellImpl implements IShellImpl {
 
   private async _initFileSystem(): Promise<void> {
     const { wasmBaseUrl } = this._options;
-    const fsModule = this._commandModuleLoader.getWasmModule('cockle_fs', 'fs');
+    const fsModule = await this._commandModuleLoader.getWasmModule('cockle_fs', 'fs');
     if (fsModule === undefined) {
       // Cannot report this in the terminal as it has not been started yet.
       // TODO: Store this information and report it when the terminal is up and running?
@@ -520,7 +521,9 @@ export class ShellImpl implements IShellImpl {
   }
 
   private async _initWasmPackages(): Promise<void> {
-    const url = joinURL(this._options.wasmBaseUrl, 'cockle-config.json');
+    const filename = 'cockle-config.json';
+    const queryParams = await this._wasmUrlQueryParams(filename);
+    const url = joinURL(this._options.wasmBaseUrl, filename + queryParams);
     const response = await fetch(url);
     if (!response.ok) {
       // Would be nice to report this via the terminal.
@@ -743,6 +746,18 @@ export class ShellImpl implements IShellImpl {
   private _setExitCode(exitCode: number) {
     this._exitCode = exitCode;
     this.environment.set('?', `${exitCode}`);
+  }
+
+  private async _wasmUrlQueryParams(filename: string): Promise<string> {
+    const { wasmUrlQueryParamsCallback } = this._options;
+    if (wasmUrlQueryParamsCallback !== undefined) {
+      const params = await wasmUrlQueryParamsCallback(filename);
+      const asStrings = Object.entries(params).map(([key, value]) => `${key}=${value}`);
+      if (asStrings.length > 0) {
+        return '?' + asStrings.join('&');
+      }
+    }
+    return '';
   }
 
   private _commandLine: ICommandLine = { text: '', cursorIndex: 0 };


### PR DESCRIPTION
This adds a new `wasmUrlQueryParams` to the `IShell.IOptions` passed to a `Shell` constructor to allow query params to be appended to fetches of js/wasm command files at runtime, to allow a web server to tailor behaviour of such requests based on the filename fetched. Only `.js` and `.json` files have the query params appended, `.wasm` and `.data` files that are auto-fetched as part of initialising a wasm command do not have them appended.

The name `wasmUrlQueryParams` follows that of `wasmBaseUrl` which it is used with.