### PR TITLE
Add `ready` and `size` properties to `IShell`

### DIFF
--- a/src/defs.ts
+++ b/src/defs.ts
@@ -9,9 +9,34 @@ export interface IShell extends IObservableDisposable {
    */
   exitCode(): Promise<number>;
 
+  /**
+   * Input characters from a terminal to the shell.
+   */
   input(char: string): Promise<void>;
+
+  /**
+   * Return promise that resolves when the shell is ready to accept input.
+   */
+  ready: Promise<void>;
+
+  /**
+   * Set the size of the shell.
+   */
   setSize(rows: number, columns: number): Promise<void>;
+
+  /**
+   * String identifier for the shell, must be unique within a browser tab.
+   */
   shellId: string;
+
+  /**
+   * Return the size (rows, columns) of the shell, as set by previous `setSize` call.
+   */
+  size: [number, number];
+
+  /**
+   * Start the shell, so that it is ready to accept input.
+   */
   start(): Promise<void>;
 
   /**
@@ -24,9 +49,25 @@ export interface IShell extends IObservableDisposable {
 
 export namespace IShell {
   export interface IOptions {
-    shellId?: string; // Unique ID/name
+    /**
+     * Optional string identifier. If specified must be unique within a browser tab.
+     */
+    shellId?: string;
+
+    /**
+     * Whether to enable color in the shell, along with various interactive terminal features.
+     * If not specified, defaults to `true`.
+     */
     color?: boolean;
+
+    /**
+     * Optional mount point of shared filesystem drive.
+     */
     mountpoint?: string;
+
+    /**
+     * Optional current working directory.
+     */
     cwd?: string;
 
     /**
@@ -49,16 +90,45 @@ export namespace IShell {
      */
     wasmUrlQueryParams?: IQueryParamsCallback;
 
+    /**
+     * Unique string used to identify shell in Service Worker stdin and drive requests.
+     */
     browsingContextId?: string;
-    shellManager?: IShellManager; // If specified, register this shell with shellManager
+
+    /**
+     * Optional shell manager to register this shell with.
+     * Required for stdin to work via Service Worker.
+     */
+    shellManager?: IShellManager;
+
+    /**
+     * Aliases to set in shell at startup.
+     */
     aliases?: { [key: string]: string };
+
+    /**
+     * Environment variables to set in shell at startup.
+     */
     environment?: { [key: string]: string | undefined };
+
+    /**
+     * External commands to register in shell at startup.
+     */
     externalCommands?: IExternalCommand.IOptions[];
 
-    // Initial directories and files to create, for testing purposes.
+    /**
+     * Initial directories to create in file system, used for testing purposes.
+     */
     initialDirectories?: string[];
+
+    /**
+     * Initial files to create in file system, used for testing purposes.
+     */
     initialFiles?: IShell.IFiles;
 
+    /**
+     * Callback to handle output from the shell, for display in a terminal for example.
+     */
     outputCallback: IOutputCallback;
   }
 


### PR DESCRIPTION
Add `ready` and `size` properties to `IShell`. Downstream `terminal` repo uses `ready`. Also added some more explanation of `IShell` and its `IOptions`.