### PR TITLE
Use ISize object internally and in JS/external commands

### DIFF
--- a/demo/serve/external_command.ts
+++ b/demo/serve/external_command.ts
@@ -80,8 +80,8 @@ export async function externalCommand(context: IExternalRunContext): Promise<num
   }
 
   if (args.includes('size')) {
-    const size = context.size();
-    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+    const { rows, columns } = context.size();
+    context.stdout.write(`size: rows ${rows} x columns ${columns}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/demo/serve/external_command_tab.ts
+++ b/demo/serve/external_command_tab.ts
@@ -118,8 +118,8 @@ export async function externalRun(context: IExternalRunContext): Promise<number>
   }
 
   if (args.includes('size')) {
-    const size = context.size();
-    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+    const { rows, columns } = context.size();
+    context.stdout.write(`size: rows ${rows} x columns ${columns}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -1,6 +1,7 @@
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import type { ISignal } from '@lumino/signaling';
 import { Signal } from '@lumino/signaling';
+import { ISize } from './callback';
 import { proxy, wrap } from 'comlink';
 import { ansi } from './ansi';
 import type { IMainIO, IStdinReply, IStdinRequest } from './buffered_io';
@@ -209,22 +210,17 @@ export abstract class BaseShell implements IShell {
       return;
     }
 
-    if (rows < 0) {
-      rows = 0;
-    }
-    if (columns < 0) {
-      columns = 0;
-    }
-    this._size = [rows, columns];
+    this._size.rows = Math.max(0, rows);
+    this._size.columns = Math.max(0, columns);
 
-    await this._remote!.setSize(rows, columns);
+    await this._remote!.setSize(this._size);
   }
 
   get shellId(): string {
     return this._shellId;
   }
 
-  get size(): [number, number] {
+  get size(): ISize {
     return this._size;
   }
 
@@ -365,7 +361,7 @@ export abstract class BaseShell implements IShell {
   private _ready = new PromiseDelegate<void>();
 
   private _shellId: string; // Unique identifier within a single browser tab.
-  private _size: [number, number] = [0, 0]; // [rows, columns]
+  private _size: ISize = { rows: 0, columns: 0 };
   private _worker?: Worker;
   private _remote?: IRemoteShell;
   private _externalCommands = new Map<string, IExternalCommand.IOptions>();

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -1,12 +1,12 @@
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import type { ISignal } from '@lumino/signaling';
 import { Signal } from '@lumino/signaling';
-import { ISize } from './callback';
 import { proxy, wrap } from 'comlink';
 import { ansi } from './ansi';
 import type { IMainIO, IStdinReply, IStdinRequest } from './buffered_io';
 import { ServiceWorkerMainIO, SharedArrayBufferMainIO } from './buffered_io';
 import type { IOutputCallback } from './callback';
+import type { ISize } from './callback';
 import type { IExternalRunContext } from './context';
 import type { IShell } from './defs';
 import type { IRemoteShell } from './defs_internal';

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -1,5 +1,6 @@
 import type { IWorkerIO } from './buffered_io';
 import { ServiceWorkerWorkerIO, SharedArrayBufferWorkerIO } from './buffered_io';
+import { ISize } from './callback';
 import { StdinContext } from './context';
 import type { IShellWorker } from './defs_internal';
 import type { IDriveFSOptions } from './drive_fs';
@@ -129,9 +130,9 @@ export abstract class BaseShellWorker implements IShellWorker {
     }
   }
 
-  setSize(rows: number, columns: number): void {
+  setSize(size: ISize): void {
     if (this._shellImpl) {
-      this._shellImpl.setSize(rows, columns);
+      this._shellImpl.setSize(size);
     }
   }
 

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -1,6 +1,6 @@
 import type { IWorkerIO } from './buffered_io';
 import { ServiceWorkerWorkerIO, SharedArrayBufferWorkerIO } from './buffered_io';
-import { ISize } from './callback';
+import type { ISize } from './callback';
 import { StdinContext } from './context';
 import type { IShellWorker } from './defs_internal';
 import type { IDriveFSOptions } from './drive_fs';

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -25,10 +25,15 @@ export interface IQueryParamsCallback {
   (filename: string): { [key: string]: string };
 }
 
+export interface ISize {
+  rows: number;
+  columns: number;
+}
+
 /**
  * Return window size as [rows, columns] where rows and columns are integers >= 0.
  * If the size is unknown they will be zero.
  */
 export interface ISizeCallback {
-  (): [number, number];
+  (): ISize;
 }

--- a/src/commands/wasm_command_runner.ts
+++ b/src/commands/wasm_command_runner.ts
@@ -40,7 +40,8 @@ export class WasmCommandRunner extends DynamicallyLoadedCommandRunner {
     }
 
     function getSize(tty: any): [number, number] {
-      return size();
+      const { rows, columns } = size();
+      return [rows, columns];
     }
 
     function poll(stream: any, timeoutMs: number): number {

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -1,6 +1,6 @@
 import type { IObservableDisposable } from '@lumino/disposable';
 import type { IHandleStdin, IStdinReply, IStdinRequest } from './buffered_io';
-import type { IOutputCallback, IQueryParamsCallback } from './callback';
+import type { IOutputCallback, IQueryParamsCallback, ISize } from './callback';
 import type { IExternalCommand } from './external_command';
 
 export interface IShell extends IObservableDisposable {
@@ -32,7 +32,7 @@ export interface IShell extends IObservableDisposable {
   /**
    * Return the size (rows, columns) of the shell, as set by previous `setSize` call.
    */
-  size: [number, number];
+  size: ISize;
 
   /**
    * Start the shell, so that it is ready to accept input.

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -1,6 +1,11 @@
 import type { ProxyMarked, Remote } from 'comlink';
 import type { IWorkerIO } from './buffered_io';
-import type { IInitDriveFSCallback, IOutputCallback, IQueryParamsCallback, ISize } from './callback';
+import type {
+  IInitDriveFSCallback,
+  IOutputCallback,
+  IQueryParamsCallback,
+  ISize
+} from './callback';
 import type {
   ICallExternalCommand,
   ICallExternalTabComplete,

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -1,6 +1,6 @@
 import type { ProxyMarked, Remote } from 'comlink';
 import type { IWorkerIO } from './buffered_io';
-import type { IInitDriveFSCallback, IOutputCallback, IQueryParamsCallback } from './callback';
+import type { IInitDriveFSCallback, IOutputCallback, IQueryParamsCallback, ISize } from './callback';
 import type {
   ICallExternalCommand,
   ICallExternalTabComplete,
@@ -58,7 +58,7 @@ interface IShellCommon {
   externalInput(maxChars: number | null): Promise<string>;
   externalOutput(text: string, isStderr: boolean): void;
   input(char: string): Promise<void>;
-  setSize(rows: number, columns: number): void;
+  setSize(size: ISize): void;
   start(): Promise<void>;
   themeChange(isDark?: boolean): Promise<void>;
 }

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,5 +1,5 @@
 import { ansi } from './ansi';
-import { ISize } from './callback';
+import type { ISize } from './callback';
 
 /**
  * Collection of environment variables that are known to a shell and are passed in and out of

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,4 +1,5 @@
 import { ansi } from './ansi';
+import { ISize } from './callback';
 
 /**
  * Collection of environment variables that are known to a shell and are passed in and out of
@@ -53,7 +54,8 @@ export class Environment extends Map<string, string> {
     return Array.from(this.keys()).filter(name => re.test(name));
   }
 
-  setSize(rows: number, columns: number): void {
+  setSize(size: ISize): void {
+    const { rows, columns } = size;
     if (rows >= 1) {
       const rowsString = rows.toString();
       this.set('LINES', rowsString);

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -1,6 +1,7 @@
 import { Aliases } from './aliases';
 import { ansi } from './ansi';
 import type { IWorkerIO } from './buffered_io';
+import { ISize } from './callback';
 import type { ICommandLine } from './command_line';
 import { CommandModule, CommandModuleLoader, CommandPackage, CommandRegistry } from './commands';
 import type { IRunContext } from './context';
@@ -206,16 +207,16 @@ export class ShellImpl implements IShellImpl {
     this._runContext.workerIO.write(text);
   }
 
-  setSize(rows: number, columns: number): void {
-    this._size = [rows, columns];
-    this.environment.setSize(rows, columns);
+  setSize(size: ISize): void {
+    this._size = size;
+    this.environment.setSize(size);
   }
 
   setWorkerIO(workerIO: IWorkerIO) {
     this._runContext.workerIO = workerIO;
   }
 
-  get size(): [number, number] {
+  get size(): ISize {
     return this._size;
   }
 
@@ -765,7 +766,7 @@ export class ShellImpl implements IShellImpl {
   private _exitCode: number = 0;
   private _requestedDarkMode?: boolean;
   private _isRunning = false;
-  private _size: [number, number] = [0, 0]; // [rows, columns]
+  private _size: ISize = { rows: 0, columns: 0 };
   private _themeStatus = ThemeStatus.PendingChange;
 
   private _commandModuleLoader: CommandModuleLoader;

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -1,7 +1,7 @@
 import { Aliases } from './aliases';
 import { ansi } from './ansi';
 import type { IWorkerIO } from './buffered_io';
-import { ISize } from './callback';
+import type { ISize } from './callback';
 import type { ICommandLine } from './command_line';
 import { CommandModule, CommandModuleLoader, CommandPackage, CommandRegistry } from './commands';
 import type { IRunContext } from './context';

--- a/test/serve/external_command.ts
+++ b/test/serve/external_command.ts
@@ -82,8 +82,8 @@ export async function externalCommand(context: IExternalRunContext): Promise<num
   }
 
   if (args.includes('size')) {
-    const size = context.size();
-    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+    const { rows, columns } = context.size();
+    context.stdout.write(`size: rows ${rows} x columns ${columns}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/test/serve/external_command_tab.ts
+++ b/test/serve/external_command_tab.ts
@@ -117,8 +117,8 @@ export async function externalRun(context: IExternalRunContext): Promise<number>
   }
 
   if (args.includes('size')) {
-    const size = context.size();
-    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+    const { rows, columns } = context.size();
+    context.stdout.write(`size: rows ${rows} x columns ${columns}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/test/util-js/lib/js-tab.js
+++ b/test/util-js/lib/js-tab.js
@@ -877,8 +877,8 @@ var Module = (function (exports) {
             context.stdout.write(`shellId: ${context.shellId}\n`);
         }
         if (args.includes('size')) {
-            const size = context.size();
-            context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+            const { rows, columns } = context.size();
+            context.stdout.write(`size: rows ${rows} x columns ${columns}\n`);
         }
         if (args.includes('exitCode')) {
             return ExitCode.GENERAL_ERROR;

--- a/test/util-js/lib/js-test.js
+++ b/test/util-js/lib/js-test.js
@@ -292,8 +292,8 @@ var Module = (function (exports) {
             context.stdout.write(`shellId: ${context.shellId}\n`);
         }
         if (args.includes('size')) {
-            const size = context.size();
-            context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+            const { rows, columns } = context.size();
+            context.stdout.write(`size: rows ${rows} x columns ${columns}\n`);
         }
         if (args.includes('exitCode')) {
             return ExitCode.GENERAL_ERROR;

--- a/test/util-js/package-lock.json
+++ b/test/util-js/package-lock.json
@@ -16,7 +16,7 @@
         },
         "../..": {
             "name": "@jupyterlite/cockle",
-            "version": "1.4.1",
+            "version": "1.5.2-a1",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -29,8 +29,6 @@
                 "zod": "^3.23.8"
             },
             "devDependencies": {
-                "@rspack/cli": "^1.0.3",
-                "@rspack/core": "^1.0.3",
                 "@types/json-schema": "^7.0.15",
                 "@types/node": "^20.14.12",
                 "@types/react": "^18.2.79",
@@ -39,11 +37,11 @@
                 "copyfiles": "^2.4.1",
                 "eslint": "^8.56.0",
                 "eslint-config-prettier": "^9.1.0",
-                "eslint-plugin-prettier": "^5.1.3",
+                "eslint-plugin-prettier": "^5.5.6",
                 "eslint-plugin-sort": "^4.0.0",
-                "prettier": "^3.3.3",
+                "prettier": "^3.8.3",
                 "source-map-loader": "^5.0.0",
-                "ts-loader": "^9.5.1",
+                "ts-loader": "^9.6.0",
                 "typescript": "~5.5.4"
             }
         },

--- a/test/util-js/src/js-tab.ts
+++ b/test/util-js/src/js-tab.ts
@@ -141,8 +141,8 @@ export async function run(context: IJavaScriptRunContext): Promise<number> {
   }
 
   if (args.includes('size')) {
-    const size = context.size();
-    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+    const { rows, columns } = context.size();
+    context.stdout.write(`size: rows ${rows} x columns ${columns}\n`);
   }
 
   if (args.includes('exitCode')) {

--- a/test/util-js/src/js-test.ts
+++ b/test/util-js/src/js-test.ts
@@ -112,8 +112,8 @@ export async function run(context: IJavaScriptRunContext): Promise<number> {
   }
 
   if (args.includes('size')) {
-    const size = context.size();
-    context.stdout.write(`size: rows ${size[0]} x columns ${size[1]}\n`);
+    const { rows, columns } = context.size();
+    context.stdout.write(`size: rows ${rows} x columns ${columns}\n`);
   }
 
   if (args.includes('exitCode')) {


### PR DESCRIPTION
Use `ISize` object internally and in JS/external commands as it avoids confusion about the order or `rows` and `columns`. Leaving the very public `IShell.setSize` as it was though, to avoid downstream problems. It is still technically a backward-breaking change but only for `JavaScript` and `External` commands.