### PR TITLE
Support passing `ISize` object to `IShell.setSize`

### DIFF
--- a/demo/serve/demo.ts
+++ b/demo/serve/demo.ts
@@ -97,7 +97,7 @@ export class Demo {
   }
 
   async onResize(arg: any): Promise<void> {
-    await this._shell.setSize(arg.rows, arg.cols);
+    await this._shell.setSize({ rows: arg.rows, columns: arg.cols });
   }
 
   private outputCallback(text: string): void {

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -205,15 +205,23 @@ export abstract class BaseShell implements IShell {
     return this._ready.promise;
   }
 
-  async setSize(rows: number, columns: number): Promise<void> {
-    if (this.isDisposed) {
-      return;
+  /**
+   * Set shell size.  Overloaded to take an `ISize` object or `rows` and `columns`.
+   * The former is the recommended approach, the latter was the original implementation and should
+   * be considered deprecated for eventual removal.
+   */
+  async setSize(size: ISize): Promise<void>;
+  async setSize(rows: number, columns: number): Promise<void>;
+  async setSize(sizeOrRows: ISize | number, columns?: number): Promise<void> {
+    if (typeof sizeOrRows === 'object') {
+      await this._setSizeImpl(sizeOrRows.rows, sizeOrRows.columns);
+    } else if (columns === undefined) {
+      const errMsg = 'Incorrect arguments passed to IShell.setSize';
+      console.error(errMsg);
+      throw new Error(errMsg);
+    } else {
+      await this._setSizeImpl(sizeOrRows, columns);
     }
-
-    this._size.rows = Math.max(0, rows);
-    this._size.columns = Math.max(0, columns);
-
-    await this._remote!.setSize(this._size);
   }
 
   get shellId(): string {
@@ -354,6 +362,17 @@ export abstract class BaseShell implements IShell {
 
     // Disable old worker IO before switching it. This is a no-op if already disabled.
     oldMainIO?.disable();
+  }
+
+  private async _setSizeImpl(rows: number, columns: number): Promise<void> {
+    if (this.isDisposed) {
+      return;
+    }
+
+    this._size.rows = Math.max(0, rows);
+    this._size.columns = Math.max(0, columns);
+
+    await this._remote!.setSize(this._size);
   }
 
   private _disposed = new Signal<this, void>(this);

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -21,7 +21,10 @@ export interface IShell extends IObservableDisposable {
 
   /**
    * Set the size of the shell.
+   * The `ISize` overload is the recommended approach; the separate `rows` and `columns` overload is
+   * for backward compatibility and should be considered deprecated.
    */
+  setSize(size: ISize): Promise<void>;
   setSize(rows: number, columns: number): Promise<void>;
 
   /**

--- a/test/integration-tests/command/external-command.test.ts
+++ b/test/integration-tests/command/external-command.test.ts
@@ -261,10 +261,10 @@ cmdName.forEach(cmdName => {
         const { shell, output } = await shellSetupEmpty({ externalCommands });
         await shell.inputLine(`${cmdName} size`);
         const ret0 = output.textAndClear();
-        shell.setSize(10, 20);
+        shell.setSize({ rows: 10, columns: 20 });
         await shell.inputLine(`${cmdName} size`);
         const ret1 = output.textAndClear();
-        shell.setSize(-1, -5);
+        shell.setSize({ rows: -1, columns: -5 });
         await shell.inputLine(`${cmdName} size`);
         return [ret0, ret1, output.text];
       }, cmdName);

--- a/test/integration-tests/command/js-commands.test.ts
+++ b/test/integration-tests/command/js-commands.test.ts
@@ -268,10 +268,10 @@ cmdName.forEach(cmdName => {
         const { shell, output } = await shellSetupEmpty();
         await shell.inputLine(`${cmdName} size`);
         const ret0 = output.textAndClear();
-        shell.setSize(12, 43);
+        shell.setSize({ rows: 12, columns: 43 });
         await shell.inputLine(`${cmdName} size`);
         const ret1 = output.textAndClear();
-        shell.setSize(-2, -7);
+        shell.setSize({ rows: -2, columns: -7 });
         await shell.inputLine(`${cmdName} size`);
         return [ret0, ret1, output.text];
       }, cmdName);

--- a/test/integration-tests/command/ls.test.ts
+++ b/test/integration-tests/command/ls.test.ts
@@ -26,15 +26,15 @@ test.describe('ls command', () => {
         }
       };
       const { shell, output } = await globalThis.cockle.shellSetupSimple(options);
-      await shell.setSize(10, 50);
+      await shell.setSize({ rows: 10, columns: 50 });
       await shell.inputLine('ls');
       const ret = [output.textAndClear()];
 
-      await shell.setSize(10, 40);
+      await shell.setSize({ rows: 10, columns: 40 });
       await shell.inputLine('ls');
       ret.push(output.textAndClear());
 
-      await shell.setSize(10, 20);
+      await shell.setSize({ rows: 10, columns: 20 });
       await shell.inputLine('ls');
       ret.push(output.textAndClear());
       return ret;

--- a/test/integration-tests/command/stty.test.ts
+++ b/test/integration-tests/command/stty.test.ts
@@ -8,7 +8,7 @@ test.describe('stty command', () => {
       await shell.inputLine('stty size');
       const output0 = output.textAndClear();
 
-      await shell.setSize(10, 43);
+      await shell.setSize({ rows: 10, columns: 43 });
       await shell.inputLine('stty size');
       return [output0, output.text];
     });

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -179,6 +179,28 @@ test.describe('Shell', () => {
       const output = await page.evaluate(async () => {
         const { output, shell } = await globalThis.cockle.shellSetupEmpty();
         const ret: string[] = [];
+        await shell.setSize({ rows: 10, columns: 44 });
+        await shell.inputLine('env|grep LINES;env|grep COLUMNS');
+        ret.push(output.textAndClear());
+
+        await shell.setSize({ rows: 0, columns: 45 });
+        await shell.inputLine('env|grep LINES;env|grep COLUMNS');
+        ret.push(output.textAndClear());
+
+        await shell.setSize({ rows: 14, columns: -1 });
+        await shell.inputLine('env|grep LINES;env|grep COLUMNS');
+        ret.push(output.textAndClear());
+        return ret;
+      });
+      expect(output[0]).toMatch('\r\nLINES=10\r\nCOLUMNS=44\r\n');
+      expect(output[1]).toMatch('\r\nCOLUMNS=45\r\n');
+      expect(output[2]).toMatch('\r\nLINES=14\r\n');
+    });
+
+    test('should support separate rows and columns for backward compatibility', async ({ page }) => {
+      const output = await page.evaluate(async () => {
+        const { output, shell } = await globalThis.cockle.shellSetupEmpty();
+        const ret: string[] = [];
         await shell.setSize(10, 44);
         await shell.inputLine('env|grep LINES;env|grep COLUMNS');
         ret.push(output.textAndClear());

--- a/test/integration-tests/shell.test.ts
+++ b/test/integration-tests/shell.test.ts
@@ -197,7 +197,9 @@ test.describe('Shell', () => {
       expect(output[2]).toMatch('\r\nLINES=14\r\n');
     });
 
-    test('should support separate rows and columns for backward compatibility', async ({ page }) => {
+    test('should support separate rows and columns for backward compatibility', async ({
+      page
+    }) => {
       const output = await page.evaluate(async () => {
         const { output, shell } = await globalThis.cockle.shellSetupEmpty();
         const ret: string[] = [];

--- a/test/integration-tests/tab_completer.test.ts
+++ b/test/integration-tests/tab_completer.test.ts
@@ -29,12 +29,12 @@ test.describe('TabCompleter', () => {
     test('should arrange in columns', async ({ page }) => {
       const output = await page.evaluate(async () => {
         const { shell, output } = await globalThis.cockle.shellSetupEmpty();
-        await shell.setSize(40, 10);
+        await shell.setSize({ rows: 40, columns: 10 });
         await shell.input('t');
         await shell.input('\t');
         const ret0 = output.textAndClear();
 
-        await shell.setSize(40, 20);
+        await shell.setSize({ rows: 40, columns: 20 });
         await shell.input('\t');
         const ret1 = output.textAndClear();
         return [ret0, ret1];

--- a/test/serve/shell_setup.ts
+++ b/test/serve/shell_setup.ts
@@ -102,7 +102,7 @@ async function _shellSetupCommon(options: IOptions, level: number): Promise<IShe
   (shell as any).inputLine = inputLine;
 
   await shell.start();
-  await shell.setSize(24, 80);
+  await shell.setSize({ rows: 24, columns: 80 });
 
   if (stdinOption) {
     // Set initial synchronous stdin option before enabling recording of output.


### PR DESCRIPTION
Follow-up to #324 to support passing an `ISize` object to `IShell.setSize`. This is now the preferred approach for consistency across the project. The original overload that takes separate `rows` and `columns` arguments is still supported for backward compatibiliity. It should be considered deprecated for eventual removal, but it will not be removed quickly.