### PR TITLE
Separate calls to start and end external commands passed to/from webworker

### DIFF
--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -51,11 +51,13 @@ export abstract class BaseShell implements IShell {
     stdoutIsTerminal: boolean,
     stderrIsTerminal: boolean,
     termiosFlags: Termios.IFlags
-  ): Promise<{ exitCode: number; environmentChanges?: Record<string, string | undefined> }> {
+  ): Promise<void> {
     const commandOptions = this._externalCommands.get(name);
+
     if (commandOptions === undefined) {
       // This should not happen unless the command has not been registered properly.
-      return { exitCode: ExitCode.CANNOT_FIND_COMMAND };
+      this._remote!.exitExternalCommand({ exitCode: ExitCode.CANNOT_FIND_COMMAND });
+      return;
     }
 
     const { command } = commandOptions;
@@ -86,7 +88,11 @@ export abstract class BaseShell implements IShell {
       termios
     };
     const exitCode = await command(context);
-    return { exitCode, environmentChanges: externalEnvironment.changed };
+
+    // Exit code is returned via a separate message to the web worker rather than a return from this
+    // function.
+    const environmentChanges = externalEnvironment.changed;
+    this._remote!.exitExternalCommand({ exitCode, environmentChanges });
   }
 
   /**

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -6,7 +6,7 @@ import type {
   ICallExternalTabComplete,
   IDownloadModuleCallback,
   IEnableBufferedStdinCallback,
-  IExitExternalCommand,
+  IExternalCommandResult,
   ISetMainIOCallback,
   ITerminateCallback,
   IWorkerCallbacks
@@ -119,8 +119,8 @@ export abstract class BaseShellWorker implements IShellWorker {
     return this._shellImpl?.exitCode ?? 1;
   }
 
-  exitExternalCommand(exitInfo: IExitExternalCommand): void {
-    this._shellImpl?.exitExternalCommand(exitInfo);
+  exitExternalCommand(result: IExternalCommandResult): void {
+    this._shellImpl?.exitExternalCommand(result);
   }
 
   async externalInput(maxChars: number | null): Promise<string> {

--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -2,10 +2,11 @@ import type { IWorkerIO } from './buffered_io';
 import { ServiceWorkerWorkerIO, SharedArrayBufferWorkerIO } from './buffered_io';
 import type { IOutputCallback, IQueryParamsCallback, ISize } from './callback';
 import type {
-  ICallExternalCommand,
+  ICallExternalCommandNoReturn,
   ICallExternalTabComplete,
   IDownloadModuleCallback,
   IEnableBufferedStdinCallback,
+  IExitExternalCommand,
   ISetMainIOCallback,
   ITerminateCallback,
   IWorkerCallbacks
@@ -118,6 +119,10 @@ export abstract class BaseShellWorker implements IShellWorker {
     return this._shellImpl?.exitCode ?? 1;
   }
 
+  exitExternalCommand(exitInfo: IExitExternalCommand): void {
+    this._shellImpl?.exitExternalCommand(exitInfo);
+  }
+
   async externalInput(maxChars: number | null): Promise<string> {
     return this._shellImpl!.externalInput(maxChars);
   }
@@ -142,7 +147,7 @@ export abstract class BaseShellWorker implements IShellWorker {
   }
 
   registerCallbacks(
-    callExternalCommand: ICallExternalCommand,
+    callExternalCommand: ICallExternalCommandNoReturn,
     callExternalTabComplete: ICallExternalTabComplete,
     downloadModuleCallback: IDownloadModuleCallback,
     enableBufferedStdinCallback: IEnableBufferedStdinCallback,

--- a/src/callback_internal.ts
+++ b/src/callback_internal.ts
@@ -8,13 +8,14 @@ import type { Termios } from './termios';
 
 /**
  * Internal caller (from ShellImpl/ShellWorker to Shell) to run external command.
- * An external command is called via ICallExternalCommand and the exit code is awaited. But witin
- * cockle this is implemented as a call to start the command sent from the web worker to the main UI
- * thread, and a call when the command exits in the other direction. This is to avoid awaiting the
- * end of the command whilst potentially passing other information between the two threads such as
- * for stdin, which can be problematic for coincident (SharedArrayBuffer) web worker comms.
+ * An external command is called via ICallExternalCommand and the exit code is awaited. But within
+ * cockle this is implemented as a call from the web worker to the main UI thread to start the
+ * command, and a separate call in the other direction when the command exits. This is to avoid
+ * awaiting the end of the command whilst potentially passing other information between the two
+ * threads such as for stdin, which can be problematic for coincident (SharedArrayBuffer) web worker
+ * comms.
  */
-export interface IExitExternalCommand {
+export interface IExternalCommandResult {
   exitCode: number;
   environmentChanges?: Record<string, string | undefined>;
 }
@@ -28,7 +29,7 @@ export interface ICallExternalCommand {
     stdoutIsTerminal: boolean,
     stderrIsTerminal: boolean,
     termiosFlags: Termios.IFlags
-  ): Promise<IExitExternalCommand>;
+  ): Promise<IExternalCommandResult>;
 }
 
 export interface ICallExternalCommandNoReturn {

--- a/src/callback_internal.ts
+++ b/src/callback_internal.ts
@@ -8,7 +8,17 @@ import type { Termios } from './termios';
 
 /**
  * Internal caller (from ShellImpl/ShellWorker to Shell) to run external command.
+ * An external command is called via ICallExternalCommand and the exit code is awaited. But witin
+ * cockle this is implemented as a call to start the command sent from the web worker to the main UI
+ * thread, and a call when the command exits in the other direction. This is to avoid awaiting the
+ * end of the command whilst potentially passing other information between the two threads such as
+ * for stdin, which can be problematic for coincident (SharedArrayBuffer) web worker comms.
  */
+export interface IExitExternalCommand {
+  exitCode: number;
+  environmentChanges?: Record<string, string | undefined>;
+}
+
 export interface ICallExternalCommand {
   (
     name: string,
@@ -18,7 +28,19 @@ export interface ICallExternalCommand {
     stdoutIsTerminal: boolean,
     stderrIsTerminal: boolean,
     termiosFlags: Termios.IFlags
-  ): Promise<{ exitCode: number; environmentChanges?: Record<string, string | undefined> }>;
+  ): Promise<IExitExternalCommand>;
+}
+
+export interface ICallExternalCommandNoReturn {
+  (
+    name: string,
+    args: string[],
+    environment: Record<string, string>,
+    stdinIsTerminal: boolean,
+    stdoutIsTerminal: boolean,
+    stderrIsTerminal: boolean,
+    termiosFlags: Termios.IFlags
+  ): void;
 }
 
 export interface ICallExternalTabComplete {
@@ -74,7 +96,7 @@ export interface ITerminateCallback {
  * Callbacks in the shell worker, to call functions in the shall.
  */
 export interface IWorkerCallbacks {
-  callExternalCommand: ICallExternalCommand;
+  callExternalCommand: ICallExternalCommandNoReturn;
   callExternalTabComplete: ICallExternalTabComplete;
   downloadModuleCallback: IDownloadModuleCallback;
   enableBufferedStdinCallback: IEnableBufferedStdinCallback;

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -11,7 +11,7 @@ import type {
   ICallExternalTabComplete,
   IDownloadModuleCallback,
   IEnableBufferedStdinCallback,
-  IExitExternalCommand,
+  IExternalCommandResult,
   ISetMainIOCallback,
   ITerminateCallback
 } from './callback_internal';
@@ -48,7 +48,7 @@ interface IOptionsCommon {
 // Common means common to both ShellWorker and ShellImpl.
 interface IShellCommon {
   exitCode: number;
-  exitExternalCommand(exitInfo: IExitExternalCommand): void;
+  exitExternalCommand(result: IExternalCommandResult): void;
   externalInput(maxChars: number | null): Promise<string>;
   externalOutput(text: string, isStderr: boolean): void;
   input(char: string): Promise<void>;

--- a/src/defs_internal.ts
+++ b/src/defs_internal.ts
@@ -7,10 +7,11 @@ import type {
   ISize
 } from './callback';
 import type {
-  ICallExternalCommand,
+  ICallExternalCommandNoReturn,
   ICallExternalTabComplete,
   IDownloadModuleCallback,
   IEnableBufferedStdinCallback,
+  IExitExternalCommand,
   ISetMainIOCallback,
   ITerminateCallback
 } from './callback_internal';
@@ -47,6 +48,7 @@ interface IOptionsCommon {
 // Common means common to both ShellWorker and ShellImpl.
 interface IShellCommon {
   exitCode: number;
+  exitExternalCommand(exitInfo: IExitExternalCommand): void;
   externalInput(maxChars: number | null): Promise<string>;
   externalOutput(text: string, isStderr: boolean): void;
   input(char: string): Promise<void>;
@@ -62,7 +64,7 @@ export interface IShellWorker extends IShellCommon {
   initialize(options: IShellWorker.IOptions): void;
 
   registerCallbacks(
-    callExternalCommand: ICallExternalCommand,
+    callExternalCommand: ICallExternalCommandNoReturn,
     callExternalTabComplete: ICallExternalTabComplete,
     downloadModuleCallback: IDownloadModuleCallback,
     enableBufferedStdinCallback: IEnableBufferedStdinCallback,
@@ -88,7 +90,7 @@ export type IRemoteShell = Remote<IShellWorker>;
 
 export namespace IShellImpl {
   export interface IOptions extends IOptionsCommon {
-    callExternalCommand: ICallExternalCommand;
+    callExternalCommand: ICallExternalCommandNoReturn;
     callExternalTabComplete: ICallExternalTabComplete;
     downloadModuleCallback: IDownloadModuleCallback;
     enableBufferedStdinCallback: IEnableBufferedStdinCallback;

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -3,7 +3,7 @@ import { Aliases } from './aliases';
 import { ansi } from './ansi';
 import type { IWorkerIO } from './buffered_io';
 import type { ISize } from './callback';
-import type { IExitExternalCommand } from './callback_internal';
+import type { IExternalCommandResult } from './callback_internal';
 import type { ICommandLine } from './command_line';
 import { CommandModule, CommandModuleLoader, CommandPackage, CommandRegistry } from './commands';
 import type { IRunContext } from './context';
@@ -119,7 +119,7 @@ export class ShellImpl implements IShellImpl {
       termiosFlags
     );
 
-    const promise = new PromiseDelegate<IExitExternalCommand>();
+    const promise = new PromiseDelegate<IExternalCommandResult>();
     if (this._externalCommandPromise !== undefined) {
       this._externalCommandPromise.reject('Previous external command did not exit properly');
     }
@@ -136,10 +136,10 @@ export class ShellImpl implements IShellImpl {
     return this._exitCode;
   }
 
-  exitExternalCommand(exitInfo: IExitExternalCommand): void {
+  exitExternalCommand(result: IExternalCommandResult): void {
     // Called when an external command finishes.
     if (this._externalCommandPromise !== undefined) {
-      this._externalCommandPromise.resolve(exitInfo);
+      this._externalCommandPromise.resolve(result);
       this._externalCommandPromise = undefined;
     }
   }
@@ -815,7 +815,7 @@ export class ShellImpl implements IShellImpl {
   private _runContext: IRunContext;
   private _dummyInput = new DummyInput();
   private _dummyOutput = new DummyOutput();
-  private _externalCommandPromise?: PromiseDelegate<IExitExternalCommand>;
+  private _externalCommandPromise?: PromiseDelegate<IExternalCommandResult>;
   private _fileSystem: IFileSystem;
   private _options: IShellImpl.IOptions;
   private _stderr: TerminalOutput;

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -1,7 +1,9 @@
+import { PromiseDelegate } from '@lumino/coreutils';
 import { Aliases } from './aliases';
 import { ansi } from './ansi';
 import type { IWorkerIO } from './buffered_io';
 import type { ISize } from './callback';
+import type { IExitExternalCommand } from './callback_internal';
 import type { ICommandLine } from './command_line';
 import { CommandModule, CommandModuleLoader, CommandPackage, CommandRegistry } from './commands';
 import type { IRunContext } from './context';
@@ -23,6 +25,7 @@ import {
 } from './io';
 import { CommandNode, parse, PipeNode } from './parse';
 import { TabCompleter } from './tab_completer';
+import type { Termios } from './termios';
 import { joinURL, stringFromCharCodes } from './utils';
 
 /**
@@ -55,7 +58,7 @@ export class ShellImpl implements IShellImpl {
       fileSystem: this._fileSystem,
       aliases: new Aliases(),
       commandRegistry: new CommandRegistry(
-        options.callExternalCommand,
+        this.callExternalCommand.bind(this),
         options.callExternalTabComplete
       ),
       environment: new Environment(options.color, options.shellId, options.browsingContextId),
@@ -94,12 +97,51 @@ export class ShellImpl implements IShellImpl {
     return this._runContext.aliases;
   }
 
+  async callExternalCommand(
+    name: string,
+    args: string[],
+    environment: { [key: string]: string },
+    stdinIsTerminal: boolean,
+    stdoutIsTerminal: boolean,
+    stderrIsTerminal: boolean,
+    termiosFlags: Termios.IFlags
+  ): Promise<{ exitCode: number; environmentChanges?: { [key: string]: string | undefined } }> {
+    // Separates the start of the external command and its end which is handled by a promise
+    // delegate. This is so that we are not awaiting the end of the command across the web worker to
+    // main UI thread interface whilst we are potentially also awaiting stdin across that interface.
+    this._options.callExternalCommand(
+      name,
+      args,
+      environment,
+      stdinIsTerminal,
+      stdoutIsTerminal,
+      stderrIsTerminal,
+      termiosFlags
+    );
+
+    const promise = new PromiseDelegate<IExitExternalCommand>();
+    if (this._externalCommandPromise !== undefined) {
+      this._externalCommandPromise.reject('Previous external command did not exit properly');
+    }
+    this._externalCommandPromise = promise;
+
+    return await promise.promise;
+  }
+
   get environment(): Environment {
     return this._runContext.environment;
   }
 
   get exitCode(): number {
     return this._exitCode;
+  }
+
+  exitExternalCommand(exitInfo: IExitExternalCommand): void {
+    // Called when an external command finishes.
+    if (this._externalCommandPromise !== undefined) {
+      this._externalCommandPromise.resolve(exitInfo);
+      this._externalCommandPromise = undefined;
+    }
   }
 
   async externalInput(maxChars: number | null): Promise<string> {
@@ -773,6 +815,7 @@ export class ShellImpl implements IShellImpl {
   private _runContext: IRunContext;
   private _dummyInput = new DummyInput();
   private _dummyOutput = new DummyOutput();
+  private _externalCommandPromise?: PromiseDelegate<IExitExternalCommand>;
   private _fileSystem: IFileSystem;
   private _options: IShellImpl.IOptions;
   private _stderr: TerminalOutput;


### PR DESCRIPTION
Up until now we have run external commands, which are typescript commands that run in the main UI thread, with a single function call from the web worker to start the command and await it finishing. This is fine for plain vanilla and comlink web worker to main UI thread comms, but it does not work for coincident (SharedArrayBuffer) comms as whilst we are awaiting the end of the command we cannot process other messages from the main thread such as to accept `stdin`.

So here internally splitting it into 2 separate calls, one from the web worker to the main UI thread to start the external command, and the second in the other direction when the command finishes. A promise delegate couples them together, resolving when the command's exit code is received.

There is no functional change at all. From outside of `cockle`, and from within the `ExternalCommandRunner`, things look the same as they did.