### PR TITLE
Fix handling of errors during `cd`

### DIFF
--- a/src/builtin/cd_command.ts
+++ b/src/builtin/cd_command.ts
@@ -9,7 +9,7 @@ import { PathType } from '../tab_complete';
 
 class CdArguments extends CommandArguments {
   description = `Change the shell working directory.
-  
+
   Change the current directory to DIR. If DIR is "-", it is converted to $OLDPWD.`;
   positional = new PositionalPathArguments({ pathType: PathType.Directory });
   help = new BooleanArgument('h', 'help', 'display this help and exit');
@@ -53,7 +53,21 @@ export class CdCommand extends BuiltinCommand {
 
     const { FS } = context.fileSystem;
     const oldPwd = FS.cwd();
-    FS.chdir(path);
+    try {
+      FS.chdir(path);
+    } catch (err: any) {
+      const { errno } = err;
+      const { ERRNO_CODES } = context.fileSystem;
+      if (errno === ERRNO_CODES.ENOENT) {
+        context.stderr.write(`cd: ${path}: No such file or directory\n`);
+      } else if (errno === ERRNO_CODES.ENOTDIR) {
+        context.stderr.write(`cd: ${path}: Not a directory\n`);
+      } else {
+        context.stderr.write(`cd: ${path}: Unable to cd\n`);
+      }
+      return ExitCode.GENERAL_ERROR;
+    }
+
     context.environment.set('OLDPWD', oldPwd);
     context.environment.set('PWD', FS.cwd());
     return ExitCode.SUCCESS;

--- a/test/integration-tests/command/cd.test.ts
+++ b/test/integration-tests/command/cd.test.ts
@@ -38,4 +38,25 @@ test.describe('cd command', () => {
   test('should error if use cd - and OLDPWD not set', async ({ page }) => {
     expect(await shellLineSimple(page, 'cd -')).toMatch(/cd: OLDPWD not set/);
   });
+
+  test('should error if cd to non-existent directory', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { shell, output } = await globalThis.cockle.shellSetupSimple();
+      await shell.inputLine('cd /x');
+      return [await shell.exitCode(), output.textAndClear()];
+    });
+    expect(output[0]).toBe(1);
+    expect(output[1]).toMatch('\r\ncd: /x: No such file or directory\r\n');
+  });
+
+  test('should error if cd to file', async ({ page }) => {
+    const output = await page.evaluate(async () => {
+      const { shell, output } = await globalThis.cockle.shellSetupSimple();
+      await shell.inputLine('cd file1');
+      return [await shell.exitCode(), output.textAndClear()];
+    });
+    console.log('XXX', output);
+    expect(output[0]).toBe(1);
+    expect(output[1]).toMatch('\r\ncd: file1: Not a directory\r\n');
+  });
 });


### PR DESCRIPTION
Currently if a `cd` command fails, for example to a non-existent directory, then the emscripten `FS` throws an error that we do not catch, and so the output in the terminal is the not very helpful `[object Object]`. This PR catches such errors, prints a reasonable error message to `stderr`, and returns an exit code of 1.