### PR TITLE
Update coincident from 1.2.3 to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@lumino/coreutils": "^2.2.0",
                 "@lumino/disposable": "^2.1.3",
                 "@lumino/signaling": "^2.1.3",
-                "coincident": "^1.2.3",
+                "coincident": "^4.1.1",
                 "comlink": "^4.4.2",
                 "deepmerge-ts": "^7.1.4",
                 "rimraf": "^6.0.1",
@@ -622,13 +622,8 @@
         "node_modules/@ungap/structured-clone": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
-        },
-        "node_modules/@ungap/with-resolvers": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@ungap/with-resolvers/-/with-resolvers-0.1.0.tgz",
-            "integrity": "sha512-g7f0IkJdPW2xhY7H4iE72DAsIyfuwEFc6JWc2tYFwKDMWWAF699vGjrM348cwQuOXgHpe1gWFe+Eiyjx/ewvvw==",
-            "license": "ISC"
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.12.1",
@@ -790,6 +785,12 @@
                 "@webassemblyjs/ast": "1.12.1",
                 "@xtuc/long": "4.2.2"
             }
+        },
+        "node_modules/@webreflection/utils": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@webreflection/utils/-/utils-0.1.2.tgz",
+            "integrity": "sha512-DQKX0hXSZZ9+KK0OgyTLCFtg9qTebn/1aJsuEaMa6Pzqu5b0zOJ5vn9EVmv9n11BfqNYX7yDqCtheVyvF2W+hg==",
+            "license": "MIT"
         },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
@@ -999,18 +1000,17 @@
             }
         },
         "node_modules/coincident": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/coincident/-/coincident-1.2.3.tgz",
-            "integrity": "sha512-Uxz3BMTWIslzeWjuQnizGWVg0j6khbvHUQ8+5BdM7WuJEm4ALXwq3wluYoB+uF68uPBz/oUOeJnYURKyfjexlA==",
-            "license": "ISC",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/coincident/-/coincident-4.1.1.tgz",
+            "integrity": "sha512-Q+BQsDcJWYXNo5nlSjHvherNvFzFkKXBcYPSOIzIPDmlskTkiMEPf5nEqdFrwPc3u2CkEsG7XXiUM42bhhGBUw==",
+            "license": "MIT",
             "dependencies": {
-                "@ungap/structured-clone": "^1.2.0",
-                "@ungap/with-resolvers": "^0.1.0",
-                "gc-hook": "^0.3.1",
-                "proxy-target": "^3.0.2"
+                "@webreflection/utils": "^0.1.1",
+                "next-resolver": "^0.1.4",
+                "reflected-ffi": "^0.7.0"
             },
-            "optionalDependencies": {
-                "ws": "^8.16.0"
+            "bin": {
+                "coincident": "cli.cjs"
             }
         },
         "node_modules/color-convert": {
@@ -1868,12 +1868,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/gc-hook": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/gc-hook/-/gc-hook-0.3.1.tgz",
-            "integrity": "sha512-E5M+O/h2o7eZzGhzRZGex6hbB3k4NWqO0eA+OzLRLXxhdbYPajZnynPwAtphnh+cRHPwsj5Z80dqZlfI4eK55A==",
-            "license": "ISC"
-        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2362,6 +2356,16 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/next-resolver": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/next-resolver/-/next-resolver-0.1.7.tgz",
+            "integrity": "sha512-mQFcdK07/qkP4bB2wxIlzTrPrF0e651UdMPYwCATdiK/CZc7ZXIkSP3S5lmhd03OUO2Ds4T16XOZU1mMBxZVmg==",
+            "license": "MIT",
+            "dependencies": {
+                "@webreflection/utils": "^0.1.2",
+                "weak-id": "^0.2.1"
+            }
+        },
         "node_modules/node-releases": {
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
@@ -2598,12 +2602,6 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
-        "node_modules/proxy-target": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/proxy-target/-/proxy-target-3.0.2.tgz",
-            "integrity": "sha512-FFE1XNwXX/FNC3/P8HiKaJSy/Qk68RitG/QEcLy/bVnTAPlgTAWPZKh0pARLAnpfXQPKyalBhk009NRTgsk8vQ==",
-            "license": "MIT"
-        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2641,6 +2639,15 @@
             "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/reflected-ffi": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/reflected-ffi/-/reflected-ffi-0.7.2.tgz",
+            "integrity": "sha512-g9yPPQIGsMKPMM+vho+75E9bf2VoyLrR1R03ADd3sjwvoxkikty8M75/4Tt+0oX+o8gjK1SuOc4enWzNnUuO3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "weak-id": "^0.2.1"
             }
         },
         "node_modules/require-directory": {
@@ -3261,6 +3268,21 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/weak-id": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/weak-id/-/weak-id-0.2.2.tgz",
+            "integrity": "sha512-x7O+5YKUZ6ti+nX0aNGTteK5xiDz+uDkJjpQW0ggj7kdIJB3qqh5quE9sn/sTjTMJgFNF6UVU+J2AkYOY8jn2A==",
+            "license": "MIT",
+            "dependencies": {
+                "@webreflection/utils": "^0.3.6"
+            }
+        },
+        "node_modules/weak-id/node_modules/@webreflection/utils": {
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/@webreflection/utils/-/utils-0.3.20.tgz",
+            "integrity": "sha512-+Feb4d3jM+XOgFZSFsyOZCL/h6ieZJPvf1oy5/iOa+C6X5uzkA8mNJAVu5b1Kxj/3fVCMKoR3PaPj1f1z3jN4Q==",
+            "license": "MIT"
+        },
         "node_modules/webpack": {
             "version": "5.94.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
@@ -3389,28 +3411,6 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@lumino/coreutils": "^2.2.0",
         "@lumino/disposable": "^2.1.3",
         "@lumino/signaling": "^2.1.3",
-        "coincident": "^1.2.3",
+        "coincident": "^4.1.1",
         "comlink": "^4.4.2",
         "deepmerge-ts": "^7.1.4",
         "rimraf": "^6.0.1",

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -1,7 +1,6 @@
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import type { ISignal } from '@lumino/signaling';
 import { Signal } from '@lumino/signaling';
-import coincident from 'coincident';
 import { proxy, wrap } from 'comlink';
 import { ansi } from './ansi';
 import type { IMainIO, IStdinReply, IStdinRequest } from './buffered_io';
@@ -114,7 +113,7 @@ export abstract class BaseShell implements IShell {
   ): ICoincidentShellWorker | IComlinkShellWorker {
     const { worker } = options;
     if (this.workerType === 'coincident') {
-      const remote = coincident(worker) as ICoincidentShellWorker;
+      const remote = (worker as any).proxy as ICoincidentShellWorker;
 
       remote.callExternalCommand = this.callExternalCommand.bind(this);
       remote.callExternalTabComplete = this.callExternalTabComplete.bind(this);

--- a/src/base_shell.ts
+++ b/src/base_shell.ts
@@ -1,6 +1,7 @@
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import type { ISignal } from '@lumino/signaling';
 import { Signal } from '@lumino/signaling';
+import coincident from 'coincident/main';
 import { proxy, wrap } from 'comlink';
 import { ansi } from './ansi';
 import type { IMainIO, IStdinReply, IStdinRequest } from './buffered_io';
@@ -396,7 +397,16 @@ export abstract class BaseShell implements IShell {
     // Register external commands here, the names are passed through to the WebWorker.
     options.externalCommands?.forEach(cmd => this._externalCommands.set(cmd.name, cmd));
 
-    this._worker = this.initWorker(options);
+    if (this.workerType === 'coincident') {
+      const { Worker: patchedWorker } = coincident();
+      const originalWorker = globalThis.Worker;
+      globalThis.Worker = patchedWorker;
+      this._worker = this.initWorker(options);
+      globalThis.Worker = originalWorker;
+    } else {
+      this._worker = this.initWorker(options);
+    }
+
     this._initRemote(options).then(this._ready.resolve.bind(this._ready));
   }
 

--- a/src/coincident.worker.ts
+++ b/src/coincident.worker.ts
@@ -1,7 +1,7 @@
-import coincident from 'coincident';
+import coincident from 'coincident/worker';
 import type { ICoincidentShellWorker } from './coincident_shell_worker';
 import { CoincidentShellWorker } from './coincident_shell_worker';
 
-export const proxy = coincident(self) as ICoincidentShellWorker;
+export const proxy = (await coincident()).proxy as ICoincidentShellWorker;
 export const worker = new CoincidentShellWorker();
 worker.initProxy(proxy);

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,4 +1,3 @@
-import coincident from 'coincident/main';
 import { BaseShell } from './base_shell';
 import type { IShell } from './defs';
 
@@ -19,18 +18,11 @@ export class Shell extends BaseShell {
    * Load the web worker.
    */
   protected override initWorker(options: IShell.IOptions): Worker {
-    if (this.workerType === 'coincident') {
-      console.log('Cockle Shell.initWorker coincident');
-      const { Worker: patchedWorker } = coincident();
-      const originalWorker = globalThis.Worker;
-      globalThis.Worker = patchedWorker;
-      const worker = new Worker(new URL('./coincident.worker.js', import.meta.url), {
-        type: 'module'
-      });
-      globalThis.Worker = originalWorker;
-      return worker;
+    const { workerType } = this;
+    console.log(`Cockle Shell.initWorker ${workerType}`);
+    if (workerType === 'coincident') {
+      return new Worker(new URL('./coincident.worker.js', import.meta.url), { type: 'module' });
     } else {
-      console.log('Cockle Shell.initWorker comlink');
       return new Worker(new URL('./comlink.worker.js', import.meta.url), { type: 'module' });
     }
   }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,3 +1,4 @@
+import coincident from 'coincident/main';
 import { BaseShell } from './base_shell';
 import type { IShell } from './defs';
 
@@ -20,7 +21,14 @@ export class Shell extends BaseShell {
   protected override initWorker(options: IShell.IOptions): Worker {
     if (this.workerType === 'coincident') {
       console.log('Cockle Shell.initWorker coincident');
-      return new Worker(new URL('./coincident.worker.js', import.meta.url), { type: 'module' });
+      const { Worker: patchedWorker } = coincident();
+      const originalWorker = globalThis.Worker;
+      globalThis.Worker = patchedWorker;
+      const worker = new Worker(new URL('./coincident.worker.js', import.meta.url), {
+        type: 'module'
+      });
+      globalThis.Worker = originalWorker;
+      return worker;
     } else {
       console.log('Cockle Shell.initWorker comlink');
       return new Worker(new URL('./comlink.worker.js', import.meta.url), { type: 'module' });

--- a/src/types/coincident.d.ts
+++ b/src/types/coincident.d.ts
@@ -1,0 +1,33 @@
+// Coincident v4
+interface IMainOptions {
+  transform?: any;
+  encoder?: any;
+  transfer?: boolean;
+}
+
+interface IMainReturn {
+  Worker: typeof Worker & { proxy: typeof Proxy };
+  native: boolean;
+  transfer: any;
+}
+
+declare module 'coincident/main' {
+  export default function coincident(options?: IMainOptions): IMainReturn;
+}
+
+interface IWorkerOptions extends IMainOptions {
+  minByteLength?: number;
+  maxByteLength?: number;
+}
+
+interface IWorkerReturn {
+  proxy: any;
+  native: boolean;
+  transfer: any;
+  ffi_timeout: number;
+  sync: boolean;
+}
+
+declare module 'coincident/worker' {
+  export default function coincident(options?: IWorkerOptions): Promise<IWorkerReturn>;
+}


### PR DESCRIPTION
Follow up to #335 to update the version of `coincident` from `1.2.3` to the latest `4.1.1`.

Key changes:

- The `coincident` call in the worker is now async. This needs to be an explicit `await` rather than using `then()` as we have to ensure that the worker is fully initialised before the script returns. Top-level await is only available in targets of `es2022` or later, but we are already using that here.
- There are no types in the upstream library so here including what is needed in a new `coincident.d.ts` file.
- ~Creation of the `Worker` in the UI main thread is now more complicated as we need to make the `coincident` call before createing the worker as `coincident` patches and returns a modified `Worker` that we have to use. Hence `initWorker` is more complicated, and this complication will have to be repeated in any downstream libraries such as the JupyterLite `terminal` that create their own modified web workers.~