### PR TITLE
Allow for asynchronous initDriveFS

### DIFF
--- a/src/base_shell_worker.ts
+++ b/src/base_shell_worker.ts
@@ -135,7 +135,7 @@ export abstract class BaseShellWorker implements IShellWorker {
   /**
    * Initialize the DriveFS to mount an external file system.
    */
-  protected abstract initDriveFS(options: IDriveFSOptions): void;
+  protected abstract initDriveFS(options: IDriveFSOptions): Promise<void> | void;
 
   async input(char: string): Promise<void> {
     if (this._shellImpl) {

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -15,7 +15,7 @@ export interface IOutputCallback {
  * Initialise DriveFS to mount external drive into the shell's filesystem.
  */
 export interface IInitDriveFSCallback {
-  (options: IDriveFSOptions): void;
+  (options: IDriveFSOptions): Promise<void> | void;
 }
 
 /**

--- a/src/coincident_shell_worker.ts
+++ b/src/coincident_shell_worker.ts
@@ -14,7 +14,7 @@ export class CoincidentShellWorker extends BaseShellWorker implements IShellWork
    * Initialize the DriveFS to mount an external file system.
    * Default implementation does nothing.
    */
-  protected initDriveFS(options: IDriveFSOptions): void {}
+  protected initDriveFS(options: IDriveFSOptions): Promise<void> | void {}
 
   initProxy(proxy: ICoincidentShellWorker): void {
     proxy.exitCode = this.exitCode.bind(this);

--- a/src/comlink_shell_worker.ts
+++ b/src/comlink_shell_worker.ts
@@ -14,5 +14,5 @@ export class ComlinkShellWorker extends BaseShellWorker {
    * Initialize the DriveFS to mount an external file system.
    * Default implementation does nothing.
    */
-  protected initDriveFS(options: IDriveFSOptions): void {}
+  protected initDriveFS(options: IDriveFSOptions): Promise<void> | void {}
 }

--- a/src/shell_impl.ts
+++ b/src/shell_impl.ts
@@ -535,7 +535,7 @@ export class ShellImpl implements IShellImpl {
     this._runContext.fileSystem.PROXYFS = PROXYFS;
 
     const { browsingContextId, baseUrl, initialDirectories, initialFiles } = this._options;
-    this._options.initDriveFSCallback({
+    await this._options.initDriveFSCallback({
       browsingContextId,
       baseUrl,
       fileSystem: this._runContext.fileSystem,


### PR DESCRIPTION
This will be needed for Notebook.link. Where the DriveFS creation needs to be awaited asynchronously.